### PR TITLE
fix(security): enforce rental ownership on finalization (C4)

### DIFF
--- a/RentalOperations/RentalOperations/Controllers/RentalController.cs
+++ b/RentalOperations/RentalOperations/Controllers/RentalController.cs
@@ -97,6 +97,10 @@ namespace RentalOperations.Controllers
                 var response = await _rentalService.CalculateFinalCostAsync(rentalId, userIdClaim.Value, actualEndDate);
                 return Ok(response);
             }
+            catch (UnauthorizedAccessException)
+            {
+                return Forbid();
+            }
             catch (Exception ex)
             {
                 return BadRequest(ex.Message);

--- a/RentalOperations/RentalOperations/Services/RentalService.cs
+++ b/RentalOperations/RentalOperations/Services/RentalService.cs
@@ -79,7 +79,10 @@ namespace RentalOperations.Services
             
             if (rental == null)
                 throw new KeyNotFoundException($"No rental found with ID {rentalId}");
-            
+
+            if (!string.Equals(rental.UserId, userId, StringComparison.Ordinal))
+                throw new UnauthorizedAccessException("The rental belongs to another rider.");
+
             if (rental.FinalCost > 0)
                 return _mapper.Map<ResponseRentalDTO>(rental);
 
@@ -108,7 +111,6 @@ namespace RentalOperations.Services
             }
 
             response.FinalTotalCost = response.OriginalTotalCost + response.AdditionalCostsOrSavings;
-            response.UserId = userId;
 
             var updateRent = _mapper.Map<Rental>(response);
             await _repository.UpdateRentalAsync(updateRent);

--- a/RentalOperations/RentalOperationsTests/Integration/AdminAuthorizationPipelineTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/AdminAuthorizationPipelineTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.IdentityModel.Tokens;
+using RentalOperations.Model;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Net.Http.Headers;
@@ -37,18 +38,99 @@ public class AdminAuthorizationPipelineTests : IClassFixture<CustomWebApplicatio
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
-    private HttpClient CreateClient(string role)
+    [Fact]
+    public async Task CalculateFinalCost_ForAnotherRidersRental_ReturnsForbiddenAndLeavesRentalUnchanged()
+    {
+        var original = _factory.Repository.SeedRental(new Rental
+        {
+            MotorcycleLicencePlate = "OWNER-001",
+            UserId = "rider-a",
+            StartDate = DateTime.UtcNow.Date,
+            PredictedEndDate = DateTime.UtcNow.Date.AddDays(7),
+            InitCost = 210m
+        });
+        var rentalId = original._id!.Value.ToString();
+        using var client = CreateClient("Rider", "rider-b");
+        var actualEndDate = Uri.EscapeDataString(original.PredictedEndDate.ToString("O"));
+
+        var response = await client.PostAsync(
+            $"/api/Rental/calculate-final-cost?rentalId={rentalId}&actualEndDate={actualEndDate}",
+            content: null);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        var persisted = _factory.Repository.FindRental(rentalId);
+        Assert.NotNull(persisted);
+        Assert.Equal(original.UserId, persisted.UserId);
+        Assert.Equal(original.EndDate, persisted.EndDate);
+        Assert.Equal(original.FinalCost, persisted.FinalCost);
+        Assert.Equal(original.AdditionalCostsOrSavings, persisted.AdditionalCostsOrSavings);
+        Assert.Equal(original.StatusMessage, persisted.StatusMessage);
+    }
+
+    [Fact]
+    public async Task CalculateFinalCost_ForFinalizedRentalOwnedByAnotherRider_ReturnsForbidden()
+    {
+        var original = _factory.Repository.SeedRental(new Rental
+        {
+            MotorcycleLicencePlate = "OWNER-002",
+            UserId = "rider-a",
+            StartDate = DateTime.UtcNow.Date.AddDays(-7),
+            EndDate = DateTime.UtcNow.Date,
+            PredictedEndDate = DateTime.UtcNow.Date,
+            InitCost = 210m,
+            FinalCost = 210m,
+            StatusMessage = "Already finalized."
+        });
+        var rentalId = original._id!.Value.ToString();
+        using var client = CreateClient("Rider", "rider-b");
+        var actualEndDate = Uri.EscapeDataString(original.EndDate.ToString("O"));
+
+        var response = await client.PostAsync(
+            $"/api/Rental/calculate-final-cost?rentalId={rentalId}&actualEndDate={actualEndDate}",
+            content: null);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CalculateFinalCost_ForOwnedRental_PreservesOwner()
+    {
+        var original = _factory.Repository.SeedRental(new Rental
+        {
+            MotorcycleLicencePlate = "OWNER-003",
+            UserId = "rider-a",
+            StartDate = DateTime.UtcNow.Date,
+            PredictedEndDate = DateTime.UtcNow.Date.AddDays(7),
+            InitCost = 210m
+        });
+        var rentalId = original._id!.Value.ToString();
+        using var client = CreateClient("Rider", original.UserId);
+        var actualEndDate = Uri.EscapeDataString(original.PredictedEndDate.ToString("O"));
+
+        var response = await client.PostAsync(
+            $"/api/Rental/calculate-final-cost?rentalId={rentalId}&actualEndDate={actualEndDate}",
+            content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var persisted = _factory.Repository.FindRental(rentalId);
+        Assert.NotNull(persisted);
+        Assert.Equal(original.UserId, persisted.UserId);
+        Assert.Equal(original.PredictedEndDate, persisted.EndDate);
+        Assert.Equal(original.InitCost, persisted.FinalCost);
+    }
+
+    private HttpClient CreateClient(string role, string userId = "requesting-user")
     {
         var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
         {
             AllowAutoRedirect = false,
             BaseAddress = new Uri("https://localhost")
         });
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateToken(role));
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateToken(role, userId));
         return client;
     }
 
-    private static string CreateToken(string role)
+    private static string CreateToken(string role, string userId)
     {
         var credentials = new SigningCredentials(
             new SymmetricSecurityKey(Encoding.UTF8.GetBytes(CustomWebApplicationFactory.JwtKey)),
@@ -59,7 +141,7 @@ public class AdminAuthorizationPipelineTests : IClassFixture<CustomWebApplicatio
             audience: "projecty.rental-operations",
             claims:
             [
-                new Claim(ClaimTypes.NameIdentifier, "requesting-user"),
+                new Claim(ClaimTypes.NameIdentifier, userId),
                 new Claim(ClaimTypes.Role, role)
             ],
             expires: DateTime.UtcNow.AddMinutes(5),

--- a/RentalOperations/RentalOperationsTests/Integration/CustomWebApplicationFactory.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/CustomWebApplicationFactory.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
-using RentalOperations.DTOs;
+using RentalOperations.Repository;
 using RentalOperations.Services;
 using System.Text;
 
@@ -15,6 +15,9 @@ namespace RentalOperationsTests.Integration;
 public class CustomWebApplicationFactory : WebApplicationFactory<Program>
 {
     public const string JwtKey = "test-only-key-with-at-least-32-bytes";
+
+    public InMemoryRentalRepository Repository =>
+        Services.GetRequiredService<InMemoryRentalRepository>();
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -31,8 +34,10 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
         builder.ConfigureServices(services =>
         {
             services.RemoveAll<IHostedService>();
-            services.RemoveAll<IRentalService>();
-            services.AddScoped<IRentalService, StubRentalService>();
+            services.RemoveAll<IRentalRepository>();
+            services.AddSingleton<InMemoryRentalRepository>();
+            services.AddSingleton<IRentalRepository>(provider =>
+                provider.GetRequiredService<InMemoryRentalRepository>());
 
             services.PostConfigure<JwtBearerOptions>(
                 JwtBearerDefaults.AuthenticationScheme,
@@ -49,26 +54,5 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
                     };
                 });
         });
-    }
-
-    private sealed class StubRentalService : IRentalService
-    {
-        public Task CreateRentalAsync(RentalCreateDto createDto, string userId) => Task.CompletedTask;
-
-        public Task<ResponseRentalDTO> CalculateFinalCostAsync(
-            string rentalId,
-            string userId,
-            DateTime actualEndDate) => Task.FromResult(new ResponseRentalDTO());
-
-        public Task<List<ResponseRentalDTO>> GetRentalsByUserIdAsync(string userId) =>
-            Task.FromResult(new List<ResponseRentalDTO>
-            {
-                new() { RentalId = "rental-1", UserId = userId }
-            });
-
-        public Task UpdateMotorcycleLicensePlateAsync(string oldLicensePlate, string newLicensePlate) =>
-            Task.CompletedTask;
-
-        public Task<bool> IsMotorcycleCurrentlyRentedAsync(string licencePlate) => Task.FromResult(false);
     }
 }

--- a/RentalOperations/RentalOperationsTests/Integration/InMemoryRentalRepository.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/InMemoryRentalRepository.cs
@@ -1,0 +1,109 @@
+using MongoDB.Bson;
+using RentalOperations.Model;
+using RentalOperations.Repository;
+using System.Collections.Concurrent;
+
+namespace RentalOperationsTests.Integration;
+
+public sealed class InMemoryRentalRepository : IRentalRepository
+{
+    private readonly ConcurrentDictionary<ObjectId, Rental> _rentals = new();
+
+    public InMemoryRentalRepository()
+    {
+        SeedRental(new Rental
+        {
+            MotorcycleLicencePlate = "DEFAULT-PLATE",
+            UserId = "another-user",
+            StartDate = DateTime.UtcNow.Date,
+            PredictedEndDate = DateTime.UtcNow.Date.AddDays(7),
+            InitCost = 210m
+        });
+    }
+
+    public Rental SeedRental(Rental rental)
+    {
+        var stored = Clone(rental);
+        var id = stored._id ?? ObjectId.GenerateNewId();
+        stored._id = id;
+        _rentals[id] = stored;
+        return Clone(stored);
+    }
+
+    public Rental? FindRental(string id)
+    {
+        var objectId = ObjectId.Parse(id);
+        return _rentals.TryGetValue(objectId, out var rental) ? Clone(rental) : null;
+    }
+
+    public Task<Rental> CreateRentalAsync(Rental rental) =>
+        Task.FromResult(SeedRental(rental));
+
+    public Task<Rental> GetRentalByIdAsync(string id) =>
+        Task.FromResult(FindRental(id)!);
+
+    public Task<List<Rental>> GetRentalsByUserId(string userId) =>
+        Task.FromResult(_rentals.Values
+            .Where(rental => rental.UserId == userId)
+            .Select(Clone)
+            .ToList());
+
+    public Task<List<Rental>> GetRentalsByMotorcycleIdAsync(string licencePlate) =>
+        Task.FromResult(_rentals.Values
+            .Where(rental => rental.MotorcycleLicencePlate == licencePlate)
+            .Select(Clone)
+            .ToList());
+
+    public Task<bool> IsMotorcycleCurrentlyRentedAsync(string licencePlate)
+    {
+        var now = DateTime.UtcNow;
+        return Task.FromResult(_rentals.Values.Any(rental =>
+            rental.MotorcycleLicencePlate == licencePlate &&
+            rental.StartDate <= now &&
+            (rental.EndDate > rental.StartDate ? rental.EndDate : rental.PredictedEndDate) >= now));
+    }
+
+    public Task UpdateRentalAsync(Rental rental)
+    {
+        var id = rental._id ?? throw new InvalidOperationException("Rental ID is required.");
+        _rentals[id] = Clone(rental);
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateLicensePlateForAllRentalsAsync(string oldLicensePlate, string newLicensePlate)
+    {
+        foreach (var entry in _rentals.ToArray())
+        {
+            if (entry.Value.MotorcycleLicencePlate != oldLicensePlate)
+            {
+                continue;
+            }
+
+            var updated = Clone(entry.Value);
+            updated.MotorcycleLicencePlate = newLicensePlate;
+            _rentals[entry.Key] = updated;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteRentalAsync(string id)
+    {
+        _rentals.TryRemove(ObjectId.Parse(id), out _);
+        return Task.CompletedTask;
+    }
+
+    private static Rental Clone(Rental rental) => new()
+    {
+        _id = rental._id,
+        MotorcycleLicencePlate = rental.MotorcycleLicencePlate,
+        UserId = rental.UserId,
+        StartDate = rental.StartDate,
+        EndDate = rental.EndDate,
+        PredictedEndDate = rental.PredictedEndDate,
+        InitCost = rental.InitCost,
+        FinalCost = rental.FinalCost,
+        AdditionalCostsOrSavings = rental.AdditionalCostsOrSavings,
+        StatusMessage = rental.StatusMessage
+    };
+}

--- a/docs/AUDITORIA-ARQUITETURA-SEGURANCA.md
+++ b/docs/AUDITORIA-ARQUITETURA-SEGURANCA.md
@@ -85,6 +85,14 @@ autenticado; na linha 111 faz `response.UserId = userId` antes de gravar.
 **Impacto:** falha de controle de acesso somada a adulteração de dado financeiro.
 `RentalOperations/RentalOperations/Services/RentalService.cs:76-116`
 
+**Status: closed.** `CalculateFinalCostAsync` agora compara o proprietário persistido com o
+`NameIdentifier` autenticado antes de qualquer retorno ou cálculo, e não sobrescreve mais o
+`UserId`. O controller converte a violação em `403`. Testes pelo pipeline HTTP comprovam que um
+rider não consegue finalizar nem ler o resultado já finalizado de outro, que o documento permanece
+inalterado na tentativa e que o proprietário legítimo continua conseguindo finalizar o aluguel.
+Fechado pelo commit
+[`e0873be`](https://github.com/iVega123/ProjectY/commit/e0873be) (C4, task #21).
+
 ### C5 — A fila é uma fronteira de confiança implícita, e está aberta
 O `userId` que decide de quem é o cadastro e a foto de CNH vem do corpo da mensagem, sem
 assinatura nem verificação. A porta 5672 é publicada no host com `user`/`password`.


### PR DESCRIPTION
## Contexto

Implementa o C4 da Epic #3, preservando o fluxo `main -> epic -> task`.

Related to #21.

## Alterações

- valida o `UserId` persistido contra o `NameIdentifier` autenticado antes de qualquer cálculo ou retorno antecipado;
- devolve `403 Forbidden` quando o aluguel pertence a outro rider;
- remove a atribuição que transferia `response.UserId` para o chamador;
- mantém o proprietário original durante uma finalização legítima;
- troca o stub de integração por `RentalService` real com repositório em memória observável;
- atualiza a auditoria com a evidência do C4.

## Regressões cobertas

- Rider B tenta finalizar aluguel aberto do Rider A: `403` e documento integralmente inalterado;
- Rider B tenta obter/finalizar aluguel já fechado do Rider A: `403`;
- Rider A finaliza o próprio aluguel: `200`, custo persistido e proprietário preservado.

## Validação

- AuthGate: 23/23
- MotoHub: 41/41
- RentalOperations: 8/8
- RiderManager: 1/1
- total: 73/73 testes
- `git diff --check`: sem erros

## GitFlow

Este PR aponta somente de `task/21-protect-rental-ownership` para `epic/3-critical-audit-fixes`. Nada deve ser mesclado em `main` até o encerramento da epic.