### PR TITLE
test(rentals): prove active rental uniqueness with PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ See [Running the audited baseline locally](docs/getting-started.md). This code
 contains known security flaws and development credentials; use it only in an
 isolated local environment.
 
+Database-backed tests use the shared
+[PostgreSQL Testcontainers pattern](docs/testing/testcontainers-postgres.md).
+
 ## Verify published images
 
 After a change reaches `main`, CI publishes each changed service to GHCR with the

--- a/RentalOperations/RentalOperationsTests/Integration/PostgreSql/ActiveRentalConstraintTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/PostgreSql/ActiveRentalConstraintTests.cs
@@ -1,0 +1,98 @@
+using Npgsql;
+
+namespace RentalOperationsTests.Integration.PostgreSql;
+
+[Collection(PostgreSqlCollection.Name)]
+public sealed class ActiveRentalConstraintTests
+{
+    private readonly PostgreSqlFixture _database;
+
+    public ActiveRentalConstraintTests(PostgreSqlFixture database)
+    {
+        _database = database;
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ConcurrentClaimsForSameMotorcycle_OneIsRejectedByDatabaseConstraint()
+    {
+        await _database.ResetAsync();
+
+        const string licencePlate = "TEST-0001";
+        using var ready = new CountdownEvent(2);
+        var start = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var attempts = new[]
+        {
+            TryCreateActiveRentalAsync(licencePlate, ready, start.Task),
+            TryCreateActiveRentalAsync(licencePlate, ready, start.Task)
+        };
+
+        Assert.True(ready.Wait(TimeSpan.FromSeconds(10)), "Both writes did not become ready in time.");
+        start.SetResult(true);
+
+        var outcomes = await Task.WhenAll(attempts);
+
+        Assert.Single(outcomes, outcome => outcome.Inserted);
+        var rejected = Assert.Single(outcomes, outcome => !outcome.Inserted);
+        Assert.Equal(PostgresErrorCodes.UniqueViolation, rejected.SqlState);
+        Assert.Equal("ux_rental_claims_one_active_per_motorcycle", rejected.ConstraintName);
+        Assert.Equal(1, await CountActiveRentalsAsync(licencePlate));
+    }
+
+    private async Task<WriteOutcome> TryCreateActiveRentalAsync(
+        string licencePlate,
+        CountdownEvent ready,
+        Task start)
+    {
+        await using var connection = new NpgsqlConnection(_database.ConnectionString);
+        await connection.OpenAsync();
+        await using var transaction = await connection.BeginTransactionAsync();
+
+        ready.Signal();
+        await start;
+
+        try
+        {
+            await using var command = new NpgsqlCommand(
+                """
+                INSERT INTO rental_claims (id, motorcycle_licence_plate, status)
+                VALUES ($1, $2, 'active');
+                """,
+                connection,
+                transaction);
+            command.Parameters.AddWithValue(Guid.NewGuid());
+            command.Parameters.AddWithValue(licencePlate);
+
+            await command.ExecuteNonQueryAsync();
+            await transaction.CommitAsync();
+            return WriteOutcome.Success;
+        }
+        catch (PostgresException exception)
+        {
+            await transaction.RollbackAsync();
+            return new WriteOutcome(false, exception.SqlState, exception.ConstraintName);
+        }
+    }
+
+    private async Task<long> CountActiveRentalsAsync(string licencePlate)
+    {
+        await using var connection = new NpgsqlConnection(_database.ConnectionString);
+        await connection.OpenAsync();
+        await using var command = new NpgsqlCommand(
+            """
+            SELECT count(*)
+            FROM rental_claims
+            WHERE motorcycle_licence_plate = $1 AND status = 'active';
+            """,
+            connection);
+        command.Parameters.AddWithValue(licencePlate);
+
+        return (long)(await command.ExecuteScalarAsync())!;
+    }
+
+    private sealed record WriteOutcome(bool Inserted, string? SqlState, string? ConstraintName)
+    {
+        public static readonly WriteOutcome Success = new(true, null, null);
+    }
+}

--- a/RentalOperations/RentalOperationsTests/Integration/PostgreSql/PostgreSqlCollection.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/PostgreSql/PostgreSqlCollection.cs
@@ -1,0 +1,7 @@
+namespace RentalOperationsTests.Integration.PostgreSql;
+
+[CollectionDefinition(Name)]
+public sealed class PostgreSqlCollection : ICollectionFixture<PostgreSqlFixture>
+{
+    public const string Name = "PostgreSQL integration";
+}

--- a/RentalOperations/RentalOperationsTests/Integration/PostgreSql/PostgreSqlFixture.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/PostgreSql/PostgreSqlFixture.cs
@@ -1,0 +1,45 @@
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace RentalOperationsTests.Integration.PostgreSql;
+
+public sealed class PostgreSqlFixture : IAsyncLifetime
+{
+    private const string Schema = """
+        CREATE TABLE IF NOT EXISTS rental_claims (
+            id uuid PRIMARY KEY,
+            motorcycle_licence_plate text NOT NULL,
+            status text NOT NULL CHECK (status IN ('active', 'completed')),
+            created_at timestamptz NOT NULL DEFAULT now()
+        );
+
+        CREATE UNIQUE INDEX IF NOT EXISTS ux_rental_claims_one_active_per_motorcycle
+            ON rental_claims (motorcycle_licence_plate)
+            WHERE status = 'active';
+        """;
+
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:17.11-alpine3.24")
+        .WithDatabase("projecty_tests")
+        .WithUsername("projecty")
+        .Build();
+
+    public string ConnectionString => _container.GetConnectionString();
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+
+        await using var dataSource = NpgsqlDataSource.Create(ConnectionString);
+        await using var command = dataSource.CreateCommand(Schema);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    public async Task ResetAsync()
+    {
+        await using var dataSource = NpgsqlDataSource.Create(ConnectionString);
+        await using var command = dataSource.CreateCommand("TRUNCATE TABLE rental_claims;");
+        await command.ExecuteNonQueryAsync();
+    }
+
+    public Task DisposeAsync() => _container.DisposeAsync().AsTask();
+}

--- a/RentalOperations/RentalOperationsTests/RentalOperationsTests.csproj
+++ b/RentalOperations/RentalOperationsTests/RentalOperationsTests.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Npgsql" Version="10.0.3" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.14.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>

--- a/docs/testing/testcontainers-postgres.md
+++ b/docs/testing/testcontainers-postgres.md
@@ -1,0 +1,31 @@
+# PostgreSQL integration tests with Testcontainers
+
+The first database concurrency test lives in
+`RentalOperations/RentalOperationsTests/Integration/PostgreSql`. It starts a real
+PostgreSQL container and proves that two concurrent active-rental claims for the
+same motorcycle cannot both commit. The loser is rejected by PostgreSQL with
+`unique_violation` (`23505`), something an in-memory repository cannot reproduce.
+
+`RentalOperations` still uses MongoDB in the audited baseline, and the planned
+`services/rental-core` project has not landed yet. For that reason, this task keeps
+the minimal future rental schema inside the test fixture instead of pretending it
+is a production migration. Epic 5 should move this schema into a real migration and
+reuse the same concurrent-write pattern against the production repository.
+
+## Run locally
+
+Docker must be running. From the repository root:
+
+```bash
+dotnet test RentalOperations/RentalOperations.sln --configuration Release
+```
+
+The xUnit collection fixture starts PostgreSQL once and shares it across every test
+in that collection. Tables are truncated between tests, and Testcontainers removes
+the container when the collection finishes. This gives suite-level reuse without
+leaving a persistent database behind or requiring a fixed host port.
+
+The root CI workflow already runs this solution whenever `RentalOperations/**`
+changes, so the same container-backed test is mandatory in pull requests. New
+database integration tests should join `PostgreSqlCollection`, reset only the data
+they own, avoid sleeps, and coordinate concurrent work with an explicit start gate.


### PR DESCRIPTION
## Summary

- adds a shared PostgreSQL 17.11 Testcontainers fixture to the rental test project
- runs two coordinated transactions against a partial unique index
- proves that exactly one active claim for the same motorcycle commits and the other receives PostgreSQL `23505`
- documents container lifecycle, suite-level reuse, local execution, and the handoff to Epic #6
- keeps the future schema test-only because the planned `services/rental-core` production project has not landed yet

## Validation

- `dotnet restore RentalOperations/RentalOperations.sln`
- `dotnet format RentalOperations/RentalOperations.sln --verify-no-changes --no-restore`
- `dotnet build RentalOperations/RentalOperations.sln --configuration Release --no-restore`
- full suite with Docker Desktop: 9/9 passed in 21s
- Testcontainers started `postgres:17.11-alpine3.24`, exercised the constraint, and removed the container cleanly
- `git diff --check`

Implements #27.