### PR TITLE
feat(dev): add Tilt core and full profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ ignored `.env` and `.rabbitmq-definitions.json` files with random local-only
 credentials. Existing files are never overwritten, so later starts preserve
 the same local data credentials.
 
+The two files are one credential set. If exactly one is missing, Tilt stops
+instead of silently rotating the other and desynchronizing persistent volumes.
+To recover intentionally, stop the stack, remove volumes initialized with the
+old credentials, and run
+`powershell -ExecutionPolicy Bypass -File scripts/New-LocalSecrets.ps1 -Force`.
+
 The complete profile adds Cassandra, MongoDB, MinIO, media processing, risk
 pricing, telemetry, and the web console:
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,41 @@ isolated local environment.
 Database-backed tests use the shared
 [PostgreSQL Testcontainers pattern](docs/testing/testcontainers-postgres.md).
 
+### Modernization development loop
+
+The root [`Tiltfile`](Tiltfile) organizes the topology in
+`deploy/compose.yaml` into infrastructure, observability, service, and failure
+drill groups. It requires Docker Compose v2, Tilt, and PowerShell (`powershell`
+on Windows or `pwsh` on macOS/Linux). Start the core profile with one command:
+
+```bash
+tilt up
+```
+
+On the first run, Tilt invokes `scripts/New-LocalSecrets.ps1` to generate the
+ignored `.env` and `.rabbitmq-definitions.json` files with random local-only
+credentials. Existing files are never overwritten, so later starts preserve
+the same local data credentials.
+
+The complete profile adds Cassandra, MongoDB, MinIO, media processing, risk
+pricing, telemetry, and the web console:
+
+```bash
+tilt up -- --full
+```
+
+The Tilt UI is at <http://localhost:10350>, Grafana is at
+<http://localhost:3001>, and the full-profile console is at
+<http://localhost:3000>. Use `tilt down` to stop the selected profile.
+
+There is not yet an honest all-green first-run time to publish. The Compose
+topology references `services/api-gateway`, `services/rental-core`, and the
+full-profile services that have not landed in the repository, so a clean clone
+cannot complete their image builds today. Once those service directories are
+implemented, the first successful cold start must be timed on a clean Docker
+cache and the measured hardware, network conditions, and duration recorded
+here before the modernization loop is presented as runnable.
+
 ## Verify published images
 
 After a change reaches `main`, CI publishes each changed service to GHCR with the

--- a/Tiltfile
+++ b/Tiltfile
@@ -11,6 +11,20 @@ config.define_bool(
 cfg = config.parse()
 full = cfg.get('full', False)
 
+local_env_exists = os.path.exists('.env')
+rabbitmq_definitions_exist = os.path.exists('.rabbitmq-definitions.json')
+
+if local_env_exists != rabbitmq_definitions_exist:
+    existing_local_file = '.env' if local_env_exists else '.rabbitmq-definitions.json'
+    missing_local_file = '.rabbitmq-definitions.json' if local_env_exists else '.env'
+    partial_credentials_message = (
+        'Partial local credential set: %s exists but %s is missing. Tilt will not ' +
+        'rotate credentials automatically because persistent volumes may still use them. ' +
+        'Stop the stack, remove volumes initialized with the old credentials, then run ' +
+        '`powershell -ExecutionPolicy Bypass -File scripts/New-LocalSecrets.ps1 -Force`.'
+    ) % (existing_local_file, missing_local_file)
+    fail(partial_credentials_message)
+
 required_local_files = ['.env', '.rabbitmq-definitions.json']
 missing_local_files = [path for path in required_local_files if not os.path.exists(path)]
 if missing_local_files and config.tilt_subcommand in ['up', 'ci']:
@@ -37,7 +51,7 @@ if missing_local_files:
     ) % ', '.join(missing_local_files)
     fail(missing_files_message)
 
-profiles = ['full'] if full else []
+profiles = ['init', 'full'] if full else ['init']
 docker_compose(
     'deploy/compose.yaml',
     env_file = '.env',
@@ -45,7 +59,7 @@ docker_compose(
     project_name = 'projecty',
 )
 
-infra_resources = ['cockroachdb', 'redis', 'rabbitmq', 'kafka']
+infra_resources = ['cockroachdb', 'cockroach-init', 'redis', 'rabbitmq', 'kafka']
 observability_resources = ['otel-collector', 'prometheus', 'tempo', 'loki']
 service_resources = ['api-gateway', 'rental-core']
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,83 @@
+# ProjectY local development orchestration.
+#
+# The default profile loads the core topology. Pass `-- --full` to include the
+# remaining data stores and application services declared with Compose's
+# `full` profile.
+
+config.define_bool(
+    'full',
+    usage = 'Start the complete topology, including telemetry, pricing, media, console, Cassandra, MongoDB, and MinIO.',
+)
+cfg = config.parse()
+full = cfg.get('full', False)
+
+required_local_files = ['.env', '.rabbitmq-definitions.json']
+missing_local_files = [path for path in required_local_files if not os.path.exists(path)]
+if missing_local_files and config.tilt_subcommand in ['up', 'ci']:
+    print('Generating ignored local credentials for the first run...')
+    local(
+        ['pwsh', '-NoProfile', '-File', 'scripts/New-LocalSecrets.ps1'],
+        command_bat = [
+            'powershell',
+            '-NoProfile',
+            '-ExecutionPolicy',
+            'Bypass',
+            '-File',
+            'scripts\\New-LocalSecrets.ps1',
+        ],
+        echo_off = True,
+    )
+
+missing_local_files = [path for path in required_local_files if not os.path.exists(path)]
+if missing_local_files:
+    missing_files_message = (
+        'Local credential generation did not create: %s. Run ' +
+        '`powershell -ExecutionPolicy Bypass -File scripts/New-LocalSecrets.ps1` ' +
+        'to inspect the underlying error.'
+    ) % ', '.join(missing_local_files)
+    fail(missing_files_message)
+
+profiles = ['full'] if full else []
+docker_compose(
+    'deploy/compose.yaml',
+    env_file = '.env',
+    profiles = profiles,
+    project_name = 'projecty',
+)
+
+infra_resources = ['cockroachdb', 'redis', 'rabbitmq', 'kafka']
+observability_resources = ['otel-collector', 'prometheus', 'tempo', 'loki']
+service_resources = ['api-gateway', 'rental-core']
+
+if full:
+    infra_resources += ['cassandra', 'mongodb', 'minio']
+    service_resources += ['media-guard', 'risk-pricing', 'telemetry']
+
+for resource in infra_resources:
+    dc_resource(resource, labels = ['infra'])
+
+for resource in observability_resources:
+    dc_resource(resource, labels = ['observability'])
+
+for resource in service_resources:
+    dc_resource(resource, labels = ['services'])
+
+dc_resource('toxiproxy', labels = ['drills'])
+
+dc_resource(
+    'grafana',
+    labels = ['observability'],
+    links = [link('http://localhost:3001', 'Grafana')],
+)
+
+if full:
+    dc_resource(
+        'console',
+        labels = ['services'],
+        links = [link('http://localhost:3000', 'Console')],
+    )
+
+print('ProjectY profile: %s' % ('full' if full else 'core'))
+print('Tilt UI:  http://localhost:10350')
+print('Grafana:  http://localhost:3001')
+print('Console:  http://localhost:3000 (full profile)')

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -55,7 +55,8 @@ services:
   cockroachdb:
     image: cockroachdb/cockroach:v24.3.5
     <<: *restart
-    command: start-single-node --insecure --listen-addr=0.0.0.0:26257 --http-addr=0.0.0.0:8080
+    # O entrypoint rejeita --listen-addr customizado; o padrão já atende a rede do container.
+    command: start-single-node --insecure --http-addr=0.0.0.0:8080
     ports:
       - "26257:26257"   # SQL
       - "26080:8080"    # console do Cockroach

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -11,8 +11,8 @@
 #   full     → soma telemetry (Elixir), risk-pricing (Python), console, Cassandra, Mongo, MinIO
 #   legacy   → soma os quatro serviços .NET originais, para a fase de estrangulamento
 #
-# Subir manualmente (sem Tilt):  docker compose -f deploy/compose.yaml up -d
-# Com os extras:                 docker compose -f deploy/compose.yaml --profile full up -d
+# Subir manualmente (sem Tilt):  docker compose -f deploy/compose.yaml --profile init up -d
+# Com os extras:                 docker compose -f deploy/compose.yaml --profile init --profile full up -d
 
 name: projecty
 
@@ -73,9 +73,8 @@ services:
   cockroach-init:
     image: cockroachdb/cockroach:v24.3.5
     profiles: ["init"]
-    entrypoint: ["/bin/bash", "-c"]
-    command: >
-      "cockroach sql --insecure --host=cockroachdb:26257 --file=/sql/001_init.sql"
+    entrypoint: ["cockroach", "sql"]
+    command: ["--insecure", "--host=cockroachdb:26257", "--file=/sql/001_init.sql"]
     volumes:
       - ./db/cockroach:/sql:ro
     networks: [projecty]
@@ -367,6 +366,8 @@ services:
       - "8091:8091"
     networks: [projecty]
     depends_on:
+      cockroach-init:
+        condition: service_completed_successfully
       cockroachdb:
         condition: service_healthy
       kafka:

--- a/scripts/New-LocalSecrets.ps1
+++ b/scripts/New-LocalSecrets.ps1
@@ -2,13 +2,21 @@
 
 [CmdletBinding()]
 param(
-    [string]$OutputPath = (Join-Path $PSScriptRoot "..\.env"),
-    [string]$RabbitMqDefinitionsPath = (Join-Path $PSScriptRoot "..\.rabbitmq-definitions.json"),
+    [string]$OutputPath,
+    [string]$RabbitMqDefinitionsPath,
     [switch]$Force
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+    $OutputPath = Join-Path $PSScriptRoot "..\.env"
+}
+
+if ([string]::IsNullOrWhiteSpace($RabbitMqDefinitionsPath)) {
+    $RabbitMqDefinitionsPath = Join-Path $PSScriptRoot "..\.rabbitmq-definitions.json"
+}
 
 $resolvedOutputPath = [System.IO.Path]::GetFullPath($OutputPath)
 $resolvedDefinitionsPath = [System.IO.Path]::GetFullPath($RabbitMqDefinitionsPath)


### PR DESCRIPTION
## Summary

- adds a root `Tiltfile` backed by `deploy/compose.yaml`
- keeps the core topology as the default and enables the complete topology with `tilt up -- --full`
- loads the Compose `init` profile in both Tilt selections and gates `rental-core` on the successful Cockroach initializer
- groups the Tilt UI into infrastructure, observability, services, and failure drills
- surfaces Grafana and console links and prints all entry points at startup
- generates ignored local credentials automatically on the first `tilt up` without overwriting existing files
- detects partial `.env` / `.rabbitmq-definitions.json` sets and stops with an explicit, volume-safe recovery path
- fixes the PowerShell secret generator defaults so invocation from Tilt works reliably
- removes the CockroachDB `--listen-addr` override rejected by the image entrypoint while preserving container-network access
- documents the commands and records why an all-green cold-start duration cannot yet be claimed

## Validation

- GitHub Actions CI run 29: success
- Docker Desktop 4.88.1 / Engine 29.7.2, `desktop-linux`
- `docker compose config --quiet`: core (`init`) and full (`init` + `full`) profiles pass
- Tilt v0.37.7 `alpha tiltfile-result`: core profile, 13/13 manifests enabled
- Tilt v0.37.7 `alpha tiltfile-result -- --full`: full profile, 20/20 manifests enabled
- fresh Cockroach volume: initializer exits 0 and creates `projecty` with `rentals`, `motorcycles`, `outbox`, and `inbox`
- initializer rerun exits 0 and preserves the schema (idempotency)
- real `tilt ci` runs `cockroach-init` to exit 0 before attempting the `rental-core` build
- partial credential states validated in both directions with clear recovery errors
- clean local credential generation verified with the default script arguments
- `git diff --check`

## Known constraint

A real `tilt up` cannot reach all-green yet because the Compose topology references `services/rental-core`, `services/api-gateway`, and the full-profile service directories that have not landed in the repository. The real boot now initializes CockroachDB successfully and advances until Docker tries to build `services/rental-core`, then fails because that directory does not exist. The README states this explicitly and does not invent a first-run duration.

Progresses #28.