### PR TITLE
docs(adr): add the missing decision records 0000-0005

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ turns the same work into public technical narratives.
 | Decision | What was rejected | Why | Decision trail |
 |---|---|---|---|
 | Put rental correctness in the database and use an outbox/inbox around events | Application-only pre-checks, in-memory locks, and claims of transport-level "exactly once" | Those approaches do not protect concurrent writers or the gap between committing data and publishing an event | [ADR 0001](docs/adr/0001-polyglot-technology-choices.md), [ADR 0003](docs/adr/0003-observability-and-fault-tolerance.md) |
-| Establish one edge trust boundary | Four editable copies of token and role validation inside domain services | The copies had already diverged and produced an authorization bypass | [ADR 0001](docs/adr/0001-polyglot-technology-choices.md) |
+| Establish one edge trust boundary | Four editable copies of token and role validation inside domain services | The copies had already diverged and produced an authorization bypass | [ADR 0008](docs/adr/0008-single-trust-boundary.md) |
 | Optimize the local feedback loop before adding cloud infrastructure | Premature Kubernetes, manual setup steps, and sleep-based startup ordering | A demonstrable system must start predictably and make source changes cheap | [ADR 0002](docs/adr/0002-development-loop-and-containers.md) |
 | Treat failure tolerance as an observable behavior | Generic retry policies and dashboards that cannot be traced back to a request | Failure claims are credible only when they can be injected, observed, and reproduced | [ADR 0003](docs/adr/0003-observability-and-fault-tolerance.md) |
 | Keep deployment variants in overlays and choose dependencies by protocol | Long-lived environment branches and vendor-specific contracts in workloads | Branches drift; protocol boundaries preserve a credible self-hosted path and an ephemeral cloud path | [ADR 0004](docs/adr/0004-cloud-portability-by-protocol.md), [ADR 0005](docs/adr/0005-repository-and-publication-strategy.md) |
@@ -57,6 +57,14 @@ source locations are in the
 The modernization compose file is a design scaffold: it references services
 that have not landed yet. It is deliberately not presented as a working demo.
 The root compose file runs the audited baseline only.
+
+## Branches
+
+`main` carries every deployment variant as an overlay, so a fix lands once.
+Branches named `article/NN-*` are **frozen citations** cut when an article is
+published: they are never maintained and never accept pull requests. Target
+`main` for any change. The reasoning is in
+[ADR 0005](docs/adr/0005-repository-and-publication-strategy.md).
 
 ## Run locally
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ problems**. This repository preserves that real baseline and documents the
 decisions used to redesign it.
 
 **Start with the evidence:** [read the architecture and security audit](docs/AUDITORIA-ARQUITETURA-SEGURANCA.md),
-follow the [ADR consolidation work](https://github.com/iVega123/ProjectY/issues/15),
+then the [architecture decision records](docs/adr/README.md) that answer it,
 or browse the [modernization program](https://github.com/iVega123/ProjectY/issues/2).
 The accompanying [article series](https://github.com/iVega123/ProjectY/issues/13)
 turns the same work into public technical narratives.
@@ -19,16 +19,15 @@ turns the same work into public technical narratives.
 
 | Decision | What was rejected | Why | Decision trail |
 |---|---|---|---|
-| Put rental correctness in the database and use an outbox/inbox around events | Application-only pre-checks, in-memory locks, and claims of transport-level "exactly once" | Those approaches do not protect concurrent writers or the gap between committing data and publishing an event | [Transactional core](https://github.com/iVega123/ProjectY/issues/6) |
-| Establish one edge trust boundary | Four editable copies of token and role validation inside domain services | The copies had already diverged and produced an authorization bypass | [Rust edge gateway](https://github.com/iVega123/ProjectY/issues/7) |
-| Optimize the local feedback loop before adding cloud infrastructure | Premature Kubernetes, manual setup steps, and sleep-based startup ordering | A demonstrable system must start predictably and make source changes cheap | [Local development loop](https://github.com/iVega123/ProjectY/issues/5) |
-| Treat failure tolerance as an observable behavior | Generic retry policies and dashboards that cannot be traced back to a request | Failure claims are credible only when they can be injected, observed, and reproduced | [Observability](https://github.com/iVega123/ProjectY/issues/8) and [fault-tolerance drills](https://github.com/iVega123/ProjectY/issues/9) |
-| Keep deployment variants in overlays and choose dependencies by protocol | Long-lived environment branches and vendor-specific contracts in workloads | Branches drift; protocol boundaries preserve a credible self-hosted path and an ephemeral cloud path | [Local Kubernetes](https://github.com/iVega123/ProjectY/issues/11) and [AWS cost profiles](https://github.com/iVega123/ProjectY/issues/12) |
+| Put rental correctness in the database and use an outbox/inbox around events | Application-only pre-checks, in-memory locks, and claims of transport-level "exactly once" | Those approaches do not protect concurrent writers or the gap between committing data and publishing an event | [ADR 0001](docs/adr/0001-polyglot-technology-choices.md), [ADR 0003](docs/adr/0003-observability-and-fault-tolerance.md) |
+| Establish one edge trust boundary | Four editable copies of token and role validation inside domain services | The copies had already diverged and produced an authorization bypass | [ADR 0001](docs/adr/0001-polyglot-technology-choices.md) |
+| Optimize the local feedback loop before adding cloud infrastructure | Premature Kubernetes, manual setup steps, and sleep-based startup ordering | A demonstrable system must start predictably and make source changes cheap | [ADR 0002](docs/adr/0002-development-loop-and-containers.md) |
+| Treat failure tolerance as an observable behavior | Generic retry policies and dashboards that cannot be traced back to a request | Failure claims are credible only when they can be injected, observed, and reproduced | [ADR 0003](docs/adr/0003-observability-and-fault-tolerance.md) |
+| Keep deployment variants in overlays and choose dependencies by protocol | Long-lived environment branches and vendor-specific contracts in workloads | Branches drift; protocol boundaries preserve a credible self-hosted path and an ephemeral cloud path | [ADR 0004](docs/adr/0004-cloud-portability-by-protocol.md), [ADR 0005](docs/adr/0005-repository-and-publication-strategy.md) |
 
-These links currently point to the implementation work items. Stable,
-numbered decision records are being assembled under
-[`docs/adr/`](https://github.com/iVega123/ProjectY/issues/15), beginning with
-the audit as ADR 0000.
+Each row links to the record that argues it, including what was rejected and
+at what cost. The full set is indexed in [`docs/adr/`](docs/adr/README.md),
+beginning with the audit as ADR 0000.
 
 ## What the audit changed
 
@@ -53,7 +52,7 @@ source locations are in the
 | Data and messaging | PostgreSQL, MongoDB, RabbitMQ, and MinIO in the original local stack |
 | Original observability | Elasticsearch, Logstash, and Kibana |
 | Modernization scaffold | A container topology under `deploy/` for the planned gateway, transactional core, fault injection, and LGTM observability stack |
-| Decision records | Being normalized and numbered in [issue #15](https://github.com/iVega123/ProjectY/issues/15) |
+| Decision records | Eight records under [`docs/adr/`](docs/adr/README.md): 0000-0005 are the design trail, 0006-0007 are remediation decisions |
 
 The modernization compose file is a design scaffold: it references services
 that have not landed yet. It is deliberately not presented as a working demo.
@@ -96,5 +95,5 @@ the scans that run before publication.
 
 - [Epic 1: repository repositioning](https://github.com/iVega123/ProjectY/issues/2)
 - [All modernization epics](https://github.com/iVega123/ProjectY/issues?q=is%3Aissue%20state%3Aopen%20label%3Aepic)
-- [Architecture decision records](https://github.com/iVega123/ProjectY/issues/15)
+- [Architecture decision records](docs/adr/README.md)
 - [Six-part article series](https://github.com/iVega123/ProjectY/issues/13)

--- a/docs/adr/0000-architecture-audit.md
+++ b/docs/adr/0000-architecture-audit.md
@@ -1,0 +1,65 @@
+# ADR 0000 — The audit is the baseline
+
+- **Status:** Accepted
+- **Date:** 2026-08-26
+
+## Context
+
+This repository began as four ASP.NET Core services for motorcycle rentals,
+written as a backend challenge. Rather than redesign from taste, the starting
+point was a full manual review of the source, the container topology, the
+database schema, and the delivery pipeline.
+
+The review found **42 issues**: 5 critical security flaws, 11 high-risk
+findings, 14 architectural gaps, and 12 delivery or code-quality problems. The
+headline is not the count. It is that the service boundaries were reasonable on
+paper while the system had **no effective perimeter**: authorization was
+reimplemented by copy-paste in four services, the copies had already diverged,
+the signing key was shared and committed, and every backing store was published
+on the host with example credentials.
+
+## Decision
+
+The audit is ADR zero. Every subsequent decision record traces back to one or
+more of its findings, and every remediation commit names the finding it closes.
+The audit document is kept as a **living remediation record** — findings are not
+deleted when fixed, they are annotated with status and the commit that closed
+them.
+
+The full evidence, impact and source locations live in
+[`docs/AUDITORIA-ARQUITETURA-SEGURANCA.md`](../AUDITORIA-ARQUITETURA-SEGURANCA.md).
+That document is deliberately not duplicated here: a copy of a maintained
+document diverges from it on the first edit.
+
+## Alternatives considered
+
+- **Rewrite from scratch, skip the audit.** Faster to start, and it discards the
+  most valuable artifact this repository has. A greenfield rewrite demonstrates
+  building; migrating a system with known defects while it stays up demonstrates
+  judgement under constraint.
+- **Fix silently, present only the finished state.** This is what most portfolio
+  repositories do. It removes the only part of the story that is hard to
+  fabricate — a public account of what your own code got wrong.
+- **Audit, but keep it private.** Same loss, less honesty.
+
+## What was explicitly rejected
+
+Presenting the redesign without the baseline. The redesign is only legible as
+competence because the problems it answers are documented, specific, and
+attributable to real files and line numbers.
+
+## Consequences
+
+- The repository preserves a deliberately flawed baseline. It must never be
+  presented as safe to run outside an isolated environment, and the README says
+  so.
+- Every epic and task references the findings it closes, so coverage is
+  auditable: a finding without an owning issue is a gap, not a decision.
+- The correction order is fixed by dependency rather than by severity — closing
+  the open entry points, then externalizing secrets, then establishing one trust
+  boundary, then making messaging durable, then removing the duplicated code.
+
+## Follow-up
+
+- [Epic 2 — Critical audit fixes](https://github.com/iVega123/ProjectY/issues/3)
+- ADRs 0001–0005 carry the redesign decisions.

--- a/docs/adr/0001-polyglot-technology-choices.md
+++ b/docs/adr/0001-polyglot-technology-choices.md
@@ -1,0 +1,74 @@
+# ADR 0001 — Technology enters by workload, not by résumé
+
+- **Status:** Accepted
+- **Date:** 2026-08-27
+
+## Context
+
+The redesign spans six languages and five data stores. A system with that many
+technologies and no written justification does not read as competence — it reads
+as résumé-driven development, and an experienced reviewer identifies it in
+thirty seconds. The breadth is only defensible if each choice answers a workload
+this domain actually has.
+
+## Decision
+
+**A technology enters because a workload in this domain is served better by it
+than by the alternatives, and the repository says which workload, in writing,
+next to the code.**
+
+| Capability | Choice | The workload that justifies it |
+|---|---|---|
+| Edge | Rust (Axum) | 100% of traffic passes through it and it parses hostile input continuously; predictable latency without GC pauses, memory safety where the input is untrusted |
+| Transactional core | .NET 10 | Money, contracts and invariants — the part that must be boring and correct, with strong typing, versioned migrations and the best test tooling in the set |
+| Live tracking | Elixir (Phoenix) | Tens of thousands of long-lived WebSocket connections with per-process fault isolation; `Presence` solves distributed "who is online" for free |
+| Document pipeline | Rust | Hostile input, CPU-bound work, binary formats — the worst possible place for buffer overflows |
+| Risk and pricing | Python (FastAPI) | The only genuinely statistical work in the system: OCR, fraud scoring, demand models |
+| Console and BFF | Node (Next.js) | Pure I/O fan-out and shaping for the screen; shared TypeScript types remove a class of contract bug |
+| Commands | RabbitMQ | A task with one owner needing explicit ack, retry and dead-lettering — smart broker, dumb consumer |
+| Events | Kafka | A fact with many readers needing retention and replay — dumb broker, smart consumer |
+| Transactional store | Postgres-compatible | Serializable isolation, and a partial unique index that makes double-booking impossible in the database |
+| Time series | Cassandra | Write-heavy, partition-scoped reads, data that ages out — the canonical case |
+| Coordination | Redis | Rate limiting, token revocation, idempotency keys, distributed locks — shared low-latency state, not "the cache" |
+
+The command-versus-event split is the decision most likely to be challenged, so
+it is made visible in naming: commands are `cmd.*` queues, events are
+past-tense topics.
+
+## Alternatives considered
+
+- **One language for everything.** Simpler to operate and to hire for. Rejected
+  here because demonstrating the fit between workload and runtime is part of the
+  point — but this is the choice most production teams should make.
+- **One broker instead of two.** Defensible in a real company. Kept as two
+  because the value is showing *why* they differ; that obliges the rule above to
+  hold everywhere, or the argument collapses.
+- **DynamoDB for projections.** Cheaper and more integrated. Rejected under ADR
+  0004: no protocol equivalent elsewhere, and the access-key modelling does not
+  translate.
+
+## What was explicitly rejected
+
+- **MongoDB.** It was in the original design and is the most replaceable piece
+  in the set — the read projections fit in `JSONB` on the primary store. Removing
+  it takes a whole database out of the architecture, and the projections stay
+  disposable and rebuildable from Kafka.
+- **A service mesh.** Circuit breaking, timeouts, mTLS and routing are already
+  covered by the gateway and per-service libraries, with the code visible. The
+  operational weight does not pay for itself here.
+
+## Consequences
+
+- Eleven technologies is a real operational cost. It is contained by profiles:
+  the default stack is the core; everything else is opt-in.
+- Services must degrade rather than fail when an optional one is down — the
+  declared degradation table in ADR 0003 is the contract.
+- Breadth invites a "broad and shallow" reading. The countermeasure is one
+  deliberately deep column: distributed consistency, written up and proven by
+  tests.
+
+## Follow-up
+
+- [Epic 5 — Transactional core and distributed consistency](https://github.com/iVega123/ProjectY/issues/6)
+- [Epic 9 — Remaining polyglot services](https://github.com/iVega123/ProjectY/issues/10)
+- [One ADR per service justifying its language](https://github.com/iVega123/ProjectY/issues/77)

--- a/docs/adr/0002-development-loop-and-containers.md
+++ b/docs/adr/0002-development-loop-and-containers.md
@@ -1,0 +1,69 @@
+# ADR 0002 — One command starts it, and saving a file costs seconds
+
+- **Status:** Accepted
+- **Date:** 2026-08-28
+
+## Context
+
+A repository with eighteen containers that takes fifteen minutes to start stops
+being a demonstration — whoever cloned it closes the tab. The audited baseline
+made this worse in three specific ways: startup ordering was a `sleep 20`, two
+Dockerfiles had their `ENTRYPOINT` commented out and relied on the compose
+`command`, and that command used `sh -c`, which puts a shell at PID 1 so
+`SIGTERM` never reaches the application (finding M14).
+
+## Decision
+
+**Tilt orchestrates a Compose stack, gated on real health checks, with the
+variants living as overlays rather than branches.**
+
+- Two profiles: the default brings up the core; `-- --full` adds the rest.
+- `depends_on` with `condition: service_healthy` replaces every `sleep`.
+- Observability starts **before** the services, so the first traces are not lost.
+- `live_update` syncs source and restarts in place, so a save costs seconds
+  instead of a full image rebuild.
+- `local_resource` owns migrations, schema creation and topic creation — setup
+  steps that live in README prose are steps nobody runs.
+
+Three invariants hold for all six images: multi-stage build leaving the
+toolchain behind, a non-root user in the final image, and an exec-form
+`ENTRYPOINT`.
+
+Each service exposes three distinct probes. Liveness says the process responds;
+readiness says it can serve; startup grants a grace period for slow boots.
+Collapsing them is how a service gets killed while warming up, or kept in
+rotation while it cannot serve. A tripped circuit breaker must **not** make a
+service unready — it still serves everything not depending on the broken
+upstream.
+
+## Alternatives considered
+
+- **Kubernetes from the start.** More faithful to production, and it adds a
+  layer of debugging while more basic things are still broken. Kubernetes
+  arrives later, on kind, once the manifests are worth testing.
+- **Plain `docker compose up`.** No fast inner loop, no dependency graph, no
+  buttons. The `live_update` path is most of the value.
+- **Keeping the `sleep` and moving on.** It appears to work until the machine is
+  slower than the person who wrote it.
+
+## What was explicitly rejected
+
+`sh -c` as the container command. It is what removes graceful shutdown, and it
+is also why two images cannot run outside Compose. The build context is likewise
+scoped per service rather than to the repository root — with the root as
+context, `COPY . .` drags in the whole monorepo including `.git`, and the
+per-service `.dockerignore` files never apply (finding B5).
+
+## Consequences
+
+- The first build is slow; subsequent loops are seconds. The README states the
+  real first-run time rather than an optimistic one.
+- The overlay structure exists from day one even with a single variant. Adding
+  it later, with three consumers of the manifests, costs roughly ten times more.
+- Compose is a development substrate, not production. Databases run insecure and
+  without TLS, on an internal network, and the file says so at the top.
+
+## Follow-up
+
+- [Epic 4 — Local development loop](https://github.com/iVega123/ProjectY/issues/5)
+- [Epic 10 — Local Kubernetes and signed admission](https://github.com/iVega123/ProjectY/issues/11)

--- a/docs/adr/0003-observability-and-fault-tolerance.md
+++ b/docs/adr/0003-observability-and-fault-tolerance.md
@@ -45,10 +45,22 @@ Fault tolerance, per layer:
 - **Process:** three probes, and graceful shutdown that drains in-flight
   requests and flushes telemetry before exiting.
 
-**The declared degradation table is the contract.** For each dependency: what
-stops, what continues. Written before implementing, it is true; written
-afterwards, it is optimistic fiction. Every degraded path increments a distinct
-metric, so degradation is visible rather than silent.
+**The declared degradation table is the contract.** Written before implementing,
+it is true; written afterwards, it is optimistic fiction. Every degraded path
+increments a distinct metric, so degradation is visible rather than silent.
+
+| Dependency down | Stops | Continues |
+|---|---|---|
+| Redis | Rate limiting and the read cache | Everything, with a degradation counter rising |
+| Risk and pricing | Demand-based pricing | Rentals close on the fixed daily rate |
+| Live tracking | The live map | Last known position, served from Redis |
+| Read projections | Pre-built documents | Reads fall back to the primary store, slower |
+| Kafka | Event propagation | Transactional writes continue; the outbox drains on recovery |
+| Cassandra | Trip history | Current position and rental creation |
+| Primary database | Rental creation and closure | Reads from projections; everything else refuses fast with `Retry-After` |
+
+Fallbacks are explicit code paths, not accidents of exception handling. A row
+reading "unknown" is a defect, not an omission.
 
 Two dependencies fail in deliberately opposite directions. Rate limiting **fails
 open** — without Redis the request passes and a degradation counter rises,

--- a/docs/adr/0003-observability-and-fault-tolerance.md
+++ b/docs/adr/0003-observability-and-fault-tolerance.md
@@ -1,0 +1,87 @@
+# ADR 0003 — Failure behaviour is declared before it is implemented
+
+- **Status:** Accepted
+- **Date:** 2026-08-28
+
+## Context
+
+One user action crosses four runtimes and two brokers. Without end-to-end
+tracing that is undebuggable at the first integration bug, and retrofitting
+instrumentation once six runtimes exist is a project of its own.
+
+The audited baseline had the opposite of this: ELK storing only logs, on an
+unauthenticated port, with no traces and no metrics; no health checks anywhere;
+inter-service HTTP clients with no timeout, no retry and no circuit breaker, so
+the 100-second default applied; and a `BasicNack(requeue: true)` that returned
+poison messages to the head of the queue in a hot loop.
+
+## Decision
+
+**Every service speaks OTLP to a collector, and the failure behaviour of every
+dependency is written down before it is built.**
+
+Observability:
+
+- Traces to Tempo, metrics to Prometheus, logs to Loki, all via one collector —
+  services never learn which backend exists, so swapping one is configuration.
+- RED metrics derive from traces via the spanmetrics connector. Nobody has to
+  remember to increment a counter when adding an endpoint, and six runtimes
+  produce numbers with the same definition.
+- Trace context is carried in RabbitMQ and Kafka headers, so the span chain
+  survives the queue — the half most projects quietly break.
+- An SLO with an error budget and multi-window burn rate. A dashboard informs;
+  an error budget decides.
+
+Fault tolerance, per layer:
+
+- **Edge:** per-upstream timeout, circuit breaker, bulkhead that refuses rather
+  than queues, retry with full jitter on idempotent requests only.
+- **Domain:** outbox and inbox in the same transaction as the aggregate change,
+  giving an exactly-once *effect* without any broker promising exactly-once
+  delivery.
+- **Messaging:** durable queues, persistent messages, publisher confirms, and a
+  real dead-letter exchange with backoff via TTL in the broker rather than
+  `sleep` in the consumer.
+- **Process:** three probes, and graceful shutdown that drains in-flight
+  requests and flushes telemetry before exiting.
+
+**The declared degradation table is the contract.** For each dependency: what
+stops, what continues. Written before implementing, it is true; written
+afterwards, it is optimistic fiction. Every degraded path increments a distinct
+metric, so degradation is visible rather than silent.
+
+Two dependencies fail in deliberately opposite directions. Rate limiting **fails
+open** — without Redis the request passes and a degradation counter rises,
+because losing the limiter beats losing availability. Token verification **fails
+closed** — without Redis there is no way to prove a token was not revoked, so it
+is refused. Security does not degrade to "probably fine".
+
+## Alternatives considered
+
+- **Keeping ELK.** Covers one of three signals, and correlating across them is
+  the entire value.
+- **Hand-instrumented metrics per service.** Six runtimes, six definitions of
+  "a request", and drift within a month.
+- **Asserting resilience without drills.** What every portfolio does. Toxiproxy
+  sits between every service and every dependency so a drill is a button, not a
+  rebuild.
+
+## What was explicitly rejected
+
+Claiming exactly-once delivery. No broker provides it. The outbox gives
+at-least-once delivery; the inbox turns that into an exactly-once effect on the
+consumer. Saying it precisely is part of the point.
+
+## Consequences
+
+- Toxiproxy indirection is development-only; production uses AWS FIS.
+- Consumer state (retry counts, upload reassembly) must live outside process
+  memory, or a second replica is impossible — this is a real constraint the
+  baseline violated.
+- Every row of the degradation table is a test. A row that says "unknown" is a
+  defect.
+
+## Follow-up
+
+- [Epic 7 — Observability and error budget](https://github.com/iVega123/ProjectY/issues/8)
+- [Epic 8 — Demonstrable fault tolerance](https://github.com/iVega123/ProjectY/issues/9)

--- a/docs/adr/0004-cloud-portability-by-protocol.md
+++ b/docs/adr/0004-cloud-portability-by-protocol.md
@@ -1,0 +1,81 @@
+# ADR 0004 — Choose the protocol, not the vendor
+
+- **Status:** Accepted
+- **Date:** 2026-08-29
+
+## Context
+
+The architecture has to satisfy three demands at once: run on a laptop for free,
+stand up on AWS with `terraform apply`, and stay portable to another cloud
+later. Treated as three designs, they age at different rates and two of them rot.
+
+## Decision
+
+**The managed AWS services this architecture uses *are* the open engines it
+already ran.** MSK is Kafka. ElastiCache is Valkey. Aurora speaks Postgres.
+Keyspaces speaks CQL. Amazon MQ is RabbitMQ. EKS is Kubernetes.
+
+One choice buys all three properties:
+
+| Capability | Protocol | Local | AWS | Elsewhere |
+|---|---|---|---|---|
+| Transactional core | Postgres | container | Aurora Serverless v2 | Cloud SQL, Azure DB, Neon |
+| Events | Kafka | apache/kafka | MSK | Confluent, Event Hubs |
+| Commands | AMQP 0-9-1 | rabbitmq | Amazon MQ | any RabbitMQ |
+| Coordination | RESP | valkey | ElastiCache | Memorystore, Azure Cache |
+| Time series | CQL | cassandra | Keyspaces | Astra |
+| Object storage | S3 API | LocalStack | S3 | GCS, R2, MinIO |
+| Orchestration | Kubernetes API | kind | EKS | GKE, AKS |
+| Telemetry | OTLP | collector → LGTM | ADOT → AMP | anything accepting OTLP |
+
+The local replica is faithful because the container is not an imitation of the
+managed service — it is the same engine. `terraform apply` works because nothing
+in the code changes between substrates; the connection string does. And a future
+migration is a Terraform module, not a rewrite.
+
+**Cloud specifics are confined to two seams:** Terraform modules that expose
+*capabilities* rather than resources, and the configuration and secret loading
+path. Everything else is ignorant of where it runs.
+
+## Alternatives considered
+
+- **Aurora DSQL** — the closest philosophical relative of a distributed SQL
+  store. Rejected: it has no foreign keys, and the schema uses one. Referential
+  integrity would move into the application, which is exactly where it tends to
+  fail.
+- **DocumentDB** — the obvious path from MongoDB. Rejected: partial and
+  perpetually lagging compatibility. The better answer is removing MongoDB
+  entirely.
+- **A full LocalStack environment.** The services this architecture leans on
+  most — RDS, MSK, ElastiCache, EKS — sit behind the paid tier. A repository
+  that only starts with a paid licence defeats its own purpose, so the local
+  environment is deliberately hybrid: LocalStack for S3, Secrets Manager and KMS;
+  real containers for the data engines; kind for EKS.
+
+## What was explicitly rejected
+
+- **DynamoDB, SQS/SNS, Cognito.** Cheaper and better integrated, and each is a
+  one-way door: no protocol equivalent elsewhere, and the semantics do not
+  translate. Refusing them is the price of the thesis.
+- **A `CloudProvider` abstraction in application code.** The classic trap: a
+  daily tax across six languages in exchange for a migration that may never
+  happen. Portability comes from the choice of protocol and from the two seams,
+  not from an interface.
+
+## Consequences
+
+- **Portable by design, not exercised.** Network, IAM, admission policy and
+  observability remain cloud-specific, and `modules/gcp/` is only real when
+  someone writes and applies it. The honest claim impresses more than false
+  parity.
+- **Managed is not identical.** Keyspaces speaks CQL but does not expose
+  compaction strategy, so the local `TimeWindowCompactionStrategy` has no
+  counterpart. The replica is faithful in protocol and in application behaviour;
+  it is not faithful in operations.
+- The workloads layer must never reference a cloud resource identifier. The day
+  an ARN leaks into it, portability has died silently.
+
+## Follow-up
+
+- [Epic 11 — AWS, Terraform and cost profiles](https://github.com/iVega123/ProjectY/issues/12)
+- [envs/local against LocalStack and kind](https://github.com/iVega123/ProjectY/issues/85)

--- a/docs/adr/0005-repository-and-publication-strategy.md
+++ b/docs/adr/0005-repository-and-publication-strategy.md
@@ -1,0 +1,88 @@
+# ADR 0005 — Variants are overlays; branches are citations
+
+- **Status:** Accepted
+- **Date:** 2026-08-29
+
+## Context
+
+The project needs several deployment variants — self-hosted, AWS, other clouds
+later, and three cost profiles — and it also feeds a public article series where
+readers want to clone and follow along.
+
+The obvious shape is a branch per variant. It is also how a portfolio repository
+dies: every fix travels five times, and within two months three branches no
+longer build. A repository with broken branches communicates the opposite of the
+intent.
+
+## Decision
+
+**Variants live as overlays on `main`. Branches exist only as frozen
+citations.**
+
+```
+main                          # everything, always green
+├── services/                 # exactly one copy of the code
+├── deploy/
+│   ├── base/
+│   └── overlays/{selfhost,aws,gcp}
+├── infra/envs/{local,aws-low,aws-mid,aws-high}
+└── docs/adr/
+
+article/01-audit              # cut at publication, never maintained
+article/02-polyglot
+```
+
+The README states the rule in one sentence, so nobody opens a pull request
+against a frozen branch, and no fix is ever cherry-picked into one.
+
+**Cost profiles are chosen by promise, not by budget.** The organising rule: you
+pick a profile by the recovery time and data loss you are willing to promise,
+and the budget then tells you whether the promise is payable.
+
+| | Low | Mid | High |
+|---|---|---|---|
+| Cost | ~$40/mo | ~$300/mo | ~$2,500+/mo |
+| Kafka | container | Strimzi on cluster | MSK provisioned |
+| RTO / RPO | hours / 24h | minutes / ~5min | seconds / ~0 |
+| Survives | nothing | an availability zone | a region |
+
+The two axes — substrate and cost profile — are independent, and the matrix is
+deliberately not filled: five cells, not nine. `aws-high` exists as reviewable
+Terraform and is never applied.
+
+**AWS is ephemeral by design.** The always-on demonstration is the self-hosted
+stack; the cloud is `apply`, record, `destroy`. This is not a budget excuse — it
+is the evidence: if something does not come back after a destroy, it was created
+by hand and nobody noticed.
+
+## Alternatives considered
+
+- **A branch per variant.** Gives the reader a clean clone target, at the cost
+  of the maintenance tax above. The frozen article branches recover the reader
+  experience without the tax.
+- **A separate repository per cloud.** Same drift, more of it, and the shared
+  application code has to be vendored or published as packages.
+- **Keeping AWS running.** Roughly $850/month with MSK Serverless alone
+  outweighing everything else. Prohibitive, and it would make the portfolio
+  depend on a recurring bill.
+
+## What was explicitly rejected
+
+Filling the whole substrate × cost matrix. Cells that teach nothing are work
+without a reader.
+
+## Consequences
+
+- The repository is in English — README, ADRs, commit messages, code comments —
+  because the target is international roles and technical writing is an evaluated
+  part of the application.
+- Every fix lands once. The overlay structure must exist before there are
+  several consumers of the manifests, or retrofitting it becomes expensive.
+- The article series is the closest available proxy for a multiplier effect that
+  a solo repository cannot demonstrate on its own.
+
+## Follow-up
+
+- [Epic 12 — Article series](https://github.com/iVega123/ProjectY/issues/13)
+- [Freeze one article branch per part](https://github.com/iVega123/ProjectY/issues/94)
+- [Three cost profiles](https://github.com/iVega123/ProjectY/issues/86)

--- a/docs/adr/0008-single-trust-boundary.md
+++ b/docs/adr/0008-single-trust-boundary.md
@@ -1,0 +1,78 @@
+# ADR 0008 — One trust boundary, at the edge
+
+- **Status:** Accepted
+- **Date:** 2026-08-30
+- **Related findings:** C2, M10, A7, A8, B2, B3
+
+## Context
+
+The audited system reimplemented authorization in every service. Four copies of
+`AuthorizationFilter` and `AdminAuthorizationFilter` existed, maintained by
+copy-paste, and they had **already diverged**: the RentalOperations copy fell
+through to a signature-only check, so any valid rider token was accepted on an
+admin path (finding C2).
+
+That is the failure mode of duplicated security code. It is not that someone
+wrote a bad filter — three of the four were correct. It is that a security fix
+has to be applied four times, and forgetting one creates a hole nobody sees.
+
+Two more consequences followed from the same shape. `[Authorize]` and the custom
+filters were stacked on the same endpoints with conflicting semantics, so
+service-to-service calls carrying only an API key were rejected while two
+endpoints ended up with no attribute at all (B2). And identity handling drifted:
+`role.Contains("Admin")` on a possibly-null value returns 500 rather than 403
+(B3).
+
+## Decision
+
+**Identity is verified exactly once, at the edge. Domain services never parse a
+token.**
+
+- The gateway validates the JWT with `iss` and `aud` enforced, checks the
+  revocation list, and forwards a signed identity to the upstream service.
+- Inbound `x-identity-*` headers are stripped before being set, so a client
+  cannot forge identity by sending the header itself.
+- The original `Authorization` header and cookies are **not** forwarded. The
+  upstream trusts the gateway, not the caller.
+- Domain services apply **domain** authorization only — "is this rental mine",
+  not "is this token valid".
+- The three inter-service API keys are removed; service-to-service calls carry
+  gateway-issued identity like any other request.
+
+This is what makes the gateway worth building. Until the copies are gone, the
+duplication keeps regenerating the class of bug that produced C2.
+
+## Alternatives considered
+
+- **A shared authorization library referenced by all four services.** Removes
+  the copy-paste but not the four deployment units that can drift in version,
+  and it leaves every service holding a signing key. It is the right answer when
+  a gateway is not wanted; here the gateway exists for other reasons anyway.
+- **A service mesh handling authentication.** Rejected in ADR 0001: the
+  operational weight does not pay for itself at this size, and having the policy
+  visible as code is a feature for this repository, not a cost.
+- **Leaving the filters and fixing only the divergent one.** Closes C2 and
+  leaves M10 — the mechanism that produced it — fully intact.
+
+## What was explicitly rejected
+
+Trusting an unsigned identity header. Forwarding `x-identity-subject` without
+stripping the inbound value first would replace a duplicated-code vulnerability
+with a header-spoofing one, which is strictly worse: it would look correct.
+
+## Consequences
+
+- The gateway becomes a single point of failure for authentication. It is
+  mitigated by being stateless and horizontally scalable, and by the fail-closed
+  posture on revocation in ADR 0003 — but it is a real trade accepted here.
+- Domain services can no longer be called directly in a trusted way. In the
+  local stack this is enforced by network policy rather than by the network
+  topology alone.
+- Every endpoint's protection has to be re-verified when the filters are
+  deleted; the removal is only safe with tests asserting the previous behaviour.
+
+## Follow-up
+
+- [Epic 6 — Rust edge gateway](https://github.com/iVega123/ProjectY/issues/7)
+- [Verify identity once at the edge](https://github.com/iVega123/ProjectY/issues/58)
+- [Delete the four duplicated authorization filters](https://github.com/iVega123/ProjectY/issues/62)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,12 +18,15 @@ is what separates a decision from a preference.
 | [0005](0005-repository-and-publication-strategy.md) | Variants are overlays; branches are citations | Why there is no branch per cloud, and how cost profiles are chosen |
 | [0006](0006-secret-loading-and-jwt-boundaries.md) | Secret loading and JWT trust boundaries | How finding C3 was closed |
 | [0007](0007-authenticated-queue-boundary.md) | Authenticate domain-writing queue messages | How finding C5 was closed |
+| [0008](0008-single-trust-boundary.md) | One trust boundary, at the edge | Why domain services stop parsing tokens, and what is traded for it |
 
 ## Reading order
 
-Records 0000–0005 are the design trail and read in sequence. Records 0006 and
-onward are remediation decisions taken while closing individual findings, and
-read on their own.
+Records 0000–0005 are the design trail and read in sequence. ADR 0008 belongs
+to that trail but was written later, after review showed the trust-boundary
+decision was implied everywhere and recorded nowhere; read it after 0001.
+Records 0006 and 0007 are remediation decisions taken while closing individual
+findings, and read on their own. Numbers are never reused or reassigned.
 
 The full findings list, with remediation status and the commit that closed each
 one, lives in

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,31 @@
+# Architecture decision records
+
+Numbered, stable records of the decisions behind this repository. ADR 0000 is
+the audit that started everything; every record after it traces back to one or
+more of its findings.
+
+Records are written from [`template.md`](template.md). The section most other
+templates omit — *what was explicitly rejected* — is the one worth the most: it
+is what separates a decision from a preference.
+
+| # | Decision | Answers |
+|---|---|---|
+| [0000](0000-architecture-audit.md) | The audit is the baseline | Why a flawed system is preserved rather than rewritten |
+| [0001](0001-polyglot-technology-choices.md) | Technology enters by workload, not by résumé | Why six languages and five stores, and which one would be cut first |
+| [0002](0002-development-loop-and-containers.md) | One command starts it, and saving a file costs seconds | Why Tilt over Kubernetes-first, and the container invariants |
+| [0003](0003-observability-and-fault-tolerance.md) | Failure behaviour is declared before it is implemented | Why the degradation table exists, and why rate limiting fails open while token verification fails closed |
+| [0004](0004-cloud-portability-by-protocol.md) | Choose the protocol, not the vendor | Why DynamoDB, SQS and Cognito were refused, and why there is no `CloudProvider` interface |
+| [0005](0005-repository-and-publication-strategy.md) | Variants are overlays; branches are citations | Why there is no branch per cloud, and how cost profiles are chosen |
+| [0006](0006-secret-loading-and-jwt-boundaries.md) | Secret loading and JWT trust boundaries | How finding C3 was closed |
+| [0007](0007-authenticated-queue-boundary.md) | Authenticate domain-writing queue messages | How finding C5 was closed |
+
+## Reading order
+
+Records 0000–0005 are the design trail and read in sequence. Records 0006 and
+onward are remediation decisions taken while closing individual findings, and
+read on their own.
+
+The full findings list, with remediation status and the commit that closed each
+one, lives in
+[`../AUDITORIA-ARQUITETURA-SEGURANCA.md`](../AUDITORIA-ARQUITETURA-SEGURANCA.md).
+It is a living document: findings are annotated when fixed, never deleted.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,35 @@
+# ADR NNNN — <short decision title>
+
+- **Status:** Proposed | Accepted | Superseded by ADR-NNNN
+- **Date:** YYYY-MM-DD
+- **Deciders:** <who>
+
+## Context
+
+What forced a decision. State the constraint, not the solution. If the decision
+traces to an audit finding, name the finding here.
+
+## Decision
+
+What was decided, in the present tense and in one or two paragraphs. Be specific
+enough that a reader can tell whether the code follows it.
+
+## Alternatives considered
+
+For each: what it was, and the concrete reason it lost. An alternative with no
+stated cost was not really considered.
+
+## What was explicitly rejected
+
+The part most records skip, and the part worth the most. Naming what you turned
+down — and the price you accepted for turning it down — is what separates a
+decision from a preference.
+
+## Consequences
+
+What this makes easy, what it makes hard, and what has to be true for it to keep
+holding. Include the operational cost, not only the benefit.
+
+## Follow-up
+
+Issues, epics, or later records that carry this decision into code.


### PR DESCRIPTION
Adds the six design-trail decision records, an index and a template, and
relinks the README to them.

This finishes the part of #15 and #17 that was left open: `docs/adr/` held only
0006 and 0007 (remediation decisions taken while closing C3 and C5), while the
records that argue the redesign itself did not exist, and the README pointed at
issue #15 as pending work.

## What is in here

| File | Answers |
|---|---|
| `0000-architecture-audit.md` | Why a deliberately flawed baseline is preserved rather than rewritten |
| `0001-polyglot-technology-choices.md` | Why six languages and five stores, and which piece would be cut first |
| `0002-development-loop-and-containers.md` | Why Tilt over Kubernetes-first, and the three container invariants |
| `0003-observability-and-fault-tolerance.md` | Why the degradation table is written before implementation, and why rate limiting fails open while token verification fails closed |
| `0004-cloud-portability-by-protocol.md` | Why DynamoDB, SQS and Cognito were refused, and why there is no `CloudProvider` interface |
| `0005-repository-and-publication-strategy.md` | Why there is no branch per cloud, and how cost profiles are chosen |
| `README.md` | Index and reading order |
| `template.md` | The shape every future record follows |

Each record carries an explicit **"what was explicitly rejected"** section. That
is the part most templates omit and the part worth the most — it is what
separates a decision from a preference.

## README changes

- The decision table's trail column now points at the record that argues each
  row, instead of at the implementation issue
- The intro links the ADR index rather than issue #15
- The repository-state row reports eight records instead of "being normalized"
- No reference to issue #15 remains

## One deliberate omission

`docs/AUDITORIA-ARQUITETURA-SEGURANCA.md` was left untouched, and ADR 0000
points at it rather than copying it.

That document has become a living remediation record — per-finding status,
commit links, and a mix of Portuguese and English added as findings were closed.
Translating it in bulk risks mangling those annotations, and duplicating it into
an ADR would create two copies that diverge on the first edit.

It is still the first link in the README and still largely in Portuguese, which
conflicts with the English-repository decision in ADR 0005. Two ways to settle
that, both reasonable:

1. A dedicated translation pass that preserves every status annotation
2. Accept that the evidence document is bilingual and say so in the README

Worth deciding before article part 1 ships, since that piece sends readers
straight to it.

## Verification

- All relative links in the new files and in the README resolve to existing paths
- No code changes; documentation only

## Related

- Finishes the open part of #15 and #17
- ADR 0000 → the audit; 0001–0005 → epics #6, #7, #8, #9, #10, #11, #12, #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQRkUCjsVNmzUaV5qp4SvM


---
_Generated by [Claude Code](https://claude.ai/code/session_01PQRkUCjsVNmzUaV5qp4SvM)_