### PR TITLE
feat(dev): add distinct service health probes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
               - 'NuGet.config'
             moto_hub:
               - 'MotoHub/**'
+              - 'Shared/Health/**'
               - '.github/workflows/ci.yml'
               - '.grype.yaml'
               - '.trivyignore.yaml'
@@ -56,6 +57,7 @@ jobs:
               - 'NuGet.config'
             rental_operations:
               - 'RentalOperations/**'
+              - 'Shared/Health/**'
               - '.github/workflows/ci.yml'
               - '.grype.yaml'
               - '.trivyignore.yaml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,10 +114,10 @@ jobs:
             add_service "AuthGate" "AuthGate/AuthGate.sln" "auth-gate" "AuthGate" "AuthGate/AuthGate/Dockerfile" "ghcr.io/ivega123/projecty/auth-gate" "shared=./Shared"
           fi
           if [[ "$MOTO_HUB_CHANGED" == "true" ]]; then
-            add_service "MotoHub" "MotoHub/MotoHub.sln" "moto-hub" "MotoHub" "MotoHub/MotoHub/Dockerfile" "ghcr.io/ivega123/projecty/moto-hub"
+            add_service "MotoHub" "MotoHub/MotoHub.sln" "moto-hub" "MotoHub" "MotoHub/MotoHub/Dockerfile" "ghcr.io/ivega123/projecty/moto-hub" "shared=./Shared"
           fi
           if [[ "$RENTAL_OPERATIONS_CHANGED" == "true" ]]; then
-            add_service "RentalOperations" "RentalOperations/RentalOperations.sln" "rental-operations" "RentalOperations" "RentalOperations/RentalOperations/Dockerfile" "ghcr.io/ivega123/projecty/rental-operations"
+            add_service "RentalOperations" "RentalOperations/RentalOperations.sln" "rental-operations" "RentalOperations" "RentalOperations/RentalOperations/Dockerfile" "ghcr.io/ivega123/projecty/rental-operations" "shared=./Shared"
           fi
           if [[ "$RIDER_MANAGER_CHANGED" == "true" ]]; then
             add_service "RiderManager" "RiderManager/RiderManager.sln" "rider-manager" "RiderManager" "RiderManager/RiderManager/Dockerfile" "ghcr.io/ivega123/projecty/rider-manager" "shared=./Shared"

--- a/AuthGate/AuthGate/AuthGate.csproj
+++ b/AuthGate/AuthGate/AuthGate.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\Shared\Health\ServiceHealthChecks.cs" Link="Shared\Health\ServiceHealthChecks.cs" />
     <Compile Include="..\..\Shared\Messaging\QueueMessageAuthenticator.cs" Link="Shared\Messaging\QueueMessageAuthenticator.cs" />
   </ItemGroup>
   

--- a/AuthGate/AuthGate/Dockerfile
+++ b/AuthGate/AuthGate/Dockerfile
@@ -6,6 +6,7 @@ RUN dotnet restore AuthGate/AuthGate/AuthGate.csproj
 
 FROM restore AS publish
 COPY AuthGate/ AuthGate/AuthGate/
+COPY --from=shared Health/ Shared/Health/
 COPY --from=shared Messaging/ Shared/Messaging/
 RUN dotnet publish AuthGate/AuthGate/AuthGate.csproj \
     --configuration Release \

--- a/AuthGate/AuthGate/Program.cs
+++ b/AuthGate/AuthGate/Program.cs
@@ -11,8 +11,15 @@ using RabbitMQ.Client;
 using AuthGate.Services.RabbitMQ;
 using AuthGate.Services.File;
 using AuthGate.Services;
+using Npgsql;
+using ProjectY.Shared.Health;
 using Serilog.Sinks.Elasticsearch;
 using ProjectY.Shared.Messaging;
+
+if (await HealthProbeCommand.TryRunAsync(args))
+{
+    return;
+}
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -41,6 +48,12 @@ builder.Host.UseSerilog();
 
 var rabbitMQConfig = builder.Configuration.GetSection("RabbitMQ").Get<RabbitMQOptions>();
 builder.Services.AddSingleton<RabbitMQOptions>(rabbitMQConfig);
+var postgresConnection = new NpgsqlConnectionStringBuilder(
+    builder.Configuration.GetConnectionString("Postgresql") ?? "Host=postgres;Port=5432");
+builder.Services
+    .AddProjectYHealthChecks()
+    .AddTcpDependency("postgres", postgresConnection.Host ?? "postgres", postgresConnection.Port)
+    .AddTcpDependency("rabbitmq", rabbitMQConfig?.HostName ?? "rabbitmq", 5672);
 builder.Services.AddSingleton(new QueueMessageAuthenticator(
     builder.Configuration["Messaging:SigningKey"]
         ?? throw new InvalidOperationException("Messaging:SigningKey is not configured.")));
@@ -120,6 +133,7 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
+app.MapProjectYHealthChecks();
 
 app.Run();
 

--- a/MotoHub/MotoHub/Dockerfile
+++ b/MotoHub/MotoHub/Dockerfile
@@ -6,6 +6,7 @@ RUN dotnet restore MotoHub/MotoHub/MotoHub.csproj
 
 FROM restore AS publish
 COPY MotoHub/ MotoHub/MotoHub/
+COPY --from=shared Health/ Shared/Health/
 RUN dotnet publish MotoHub/MotoHub/MotoHub.csproj \
     --configuration Release \
     --output /app/publish \

--- a/MotoHub/MotoHub/MotoHub.csproj
+++ b/MotoHub/MotoHub/MotoHub.csproj
@@ -28,4 +28,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\..\Shared\Health\ServiceHealthChecks.cs" Link="Shared\Health\ServiceHealthChecks.cs" />
+  </ItemGroup>
+
 </Project>

--- a/MotoHub/MotoHub/Program.cs
+++ b/MotoHub/MotoHub/Program.cs
@@ -14,6 +14,13 @@ using Serilog.Sinks.Elasticsearch;
 using MotoHub.Configurations;
 using MotoHub.Services.RabbitMQ;
 using MotoHub.CrossCutting;
+using Npgsql;
+using ProjectY.Shared.Health;
+
+if (await HealthProbeCommand.TryRunAsync(args))
+{
+    return;
+}
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -44,6 +51,12 @@ builder.Host.UseSerilog();
 
 var rabbitMQConfig = builder.Configuration.GetSection("RabbitMQ").Get<RabbitMQOptions>();
 builder.Services.AddSingleton<RabbitMQOptions>(rabbitMQConfig);
+var postgresConnection = new NpgsqlConnectionStringBuilder(
+    builder.Configuration.GetConnectionString("Postgresql") ?? "Host=postgres;Port=5432");
+builder.Services
+    .AddProjectYHealthChecks()
+    .AddTcpDependency("postgres", postgresConnection.Host ?? "postgres", postgresConnection.Port)
+    .AddTcpDependency("rabbitmq", rabbitMQConfig?.HostName ?? "rabbitmq", 5672);
 
 builder.Services.AddSingleton<IConnection>(sp =>
 {
@@ -132,6 +145,7 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
+app.MapProjectYHealthChecks();
 
 app.Run();
 

--- a/RentalOperations/RentalOperations/Dockerfile
+++ b/RentalOperations/RentalOperations/Dockerfile
@@ -6,6 +6,7 @@ RUN dotnet restore RentalOperations/RentalOperations/RentalOperations.csproj
 
 FROM restore AS publish
 COPY RentalOperations/ RentalOperations/RentalOperations/
+COPY --from=shared Health/ Shared/Health/
 RUN dotnet publish RentalOperations/RentalOperations/RentalOperations.csproj \
     --configuration Release \
     --output /app/publish \

--- a/RentalOperations/RentalOperations/Program.cs
+++ b/RentalOperations/RentalOperations/Program.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
+using MongoDB.Driver;
+using ProjectY.Shared.Health;
 using RentalOperations.Configurations;
 using RentalOperations.CrossCutting.Services;
 using RentalOperations.Data;
@@ -11,6 +13,11 @@ using RentalOperations.Services.RabbitMQService;
 using Serilog;
 using Serilog.Sinks.Elasticsearch;
 using System.Text;
+
+if (await HealthProbeCommand.TryRunAsync(args))
+{
+    return;
+}
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -38,6 +45,11 @@ builder.Services.AddSingleton<RabbitMQOptions>(rabbitMQConfig);
 builder.Services.Configure<RabbitMQOptions>(builder.Configuration.GetSection("RabbitMQ"));
 
 var mongoDbSettings = builder.Configuration.GetSection("MongoDbSettings");
+var mongoUrl = new MongoUrl(mongoDbSettings["ConnectionString"] ?? "mongodb://mongodb:27017");
+builder.Services
+    .AddProjectYHealthChecks()
+    .AddTcpDependency("mongodb", mongoUrl.Server.Host, mongoUrl.Server.Port)
+    .AddTcpDependency("rabbitmq", rabbitMQConfig?.HostName ?? "rabbitmq", 5672);
 builder.Services.AddSingleton<MongoDbContext>(sp =>
     new MongoDbContext(mongoDbSettings["ConnectionString"], mongoDbSettings["DatabaseName"]));
 builder.Services.AddAuthentication(options =>
@@ -119,6 +131,7 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
+app.MapProjectYHealthChecks();
 
 app.Run();
 

--- a/RentalOperations/RentalOperations/RentalOperations.csproj
+++ b/RentalOperations/RentalOperations/RentalOperations.csproj
@@ -25,4 +25,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\..\Shared\Health\ServiceHealthChecks.cs" Link="Shared\Health\ServiceHealthChecks.cs" />
+  </ItemGroup>
+
 </Project>

--- a/RiderManager/RiderManager/Dockerfile
+++ b/RiderManager/RiderManager/Dockerfile
@@ -6,6 +6,7 @@ RUN dotnet restore RiderManager/RiderManager/RiderManager.csproj
 
 FROM restore AS publish
 COPY RiderManager/ RiderManager/RiderManager/
+COPY --from=shared Health/ Shared/Health/
 COPY --from=shared Messaging/ Shared/Messaging/
 RUN dotnet publish RiderManager/RiderManager/RiderManager.csproj \
     --configuration Release \

--- a/RiderManager/RiderManager/Program.cs
+++ b/RiderManager/RiderManager/Program.cs
@@ -17,8 +17,15 @@ using RiderManager.Services.MinioStorageService;
 using RiderManager.Managers;
 using RiderManager.Services.PreSignedService;
 using RiderManager.Services;
+using Npgsql;
+using ProjectY.Shared.Health;
 using Serilog.Sinks.Elasticsearch;
 using ProjectY.Shared.Messaging;
+
+if (await HealthProbeCommand.TryRunAsync(args))
+{
+    return;
+}
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -33,6 +40,13 @@ builder.Services.AddMinio(configureClient => configureClient
 var rabbitMQConfig = builder.Configuration.GetSection("RabbitMQ").Get<RabbitMQOptions>();
 builder.Services.AddSingleton<RabbitMQOptions>(rabbitMQConfig);
 builder.Services.Configure<RabbitMQOptions>(builder.Configuration.GetSection("RabbitMQ"));
+var postgresConnection = new NpgsqlConnectionStringBuilder(
+    builder.Configuration.GetConnectionString("Postgresql") ?? "Host=postgres;Port=5432");
+builder.Services
+    .AddProjectYHealthChecks()
+    .AddTcpDependency("postgres", postgresConnection.Host ?? "postgres", postgresConnection.Port)
+    .AddTcpDependency("rabbitmq", rabbitMQConfig?.HostName ?? "rabbitmq", 5672)
+    .AddTcpDependency("minio", minioConfig?.Endpoint ?? "minio", 9000);
 builder.Services.AddSingleton(new QueueMessageAuthenticator(
     builder.Configuration["Messaging:SigningKey"]
         ?? throw new InvalidOperationException("Messaging:SigningKey is not configured.")));
@@ -135,5 +149,6 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
+app.MapProjectYHealthChecks();
 
 app.Run();

--- a/RiderManager/RiderManager/RiderManager.csproj
+++ b/RiderManager/RiderManager/RiderManager.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\Shared\Health\ServiceHealthChecks.cs" Link="Shared\Health\ServiceHealthChecks.cs" />
     <Compile Include="..\..\Shared\Messaging\QueueMessageAuthenticator.cs" Link="Shared\Messaging\QueueMessageAuthenticator.cs" />
   </ItemGroup>
 

--- a/Shared/Health/ServiceHealthChecks.cs
+++ b/Shared/Health/ServiceHealthChecks.cs
@@ -1,0 +1,124 @@
+using System.Net.Sockets;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+
+namespace ProjectY.Shared.Health;
+
+public static class ServiceHealthChecks
+{
+    private static readonly string[] ReadyTag = ["ready"];
+    private static readonly string[] StartupTag = ["startup"];
+
+    public static IHealthChecksBuilder AddProjectYHealthChecks(this IServiceCollection services)
+    {
+        services.AddSingleton<StartupHealthCheck>();
+
+        return services
+            .AddHealthChecks()
+            .AddCheck<StartupHealthCheck>(
+                "startup",
+                failureStatus: HealthStatus.Unhealthy,
+                tags: StartupTag);
+    }
+
+    public static IHealthChecksBuilder AddTcpDependency(
+        this IHealthChecksBuilder builder,
+        string name,
+        string host,
+        int port)
+    {
+        return builder.AddCheck(
+            name,
+            new TcpDependencyHealthCheck(host, port),
+            failureStatus: HealthStatus.Unhealthy,
+            tags: ReadyTag);
+    }
+
+    public static IEndpointRouteBuilder MapProjectYHealthChecks(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapHealthChecks("/health/live", new HealthCheckOptions
+        {
+            Predicate = _ => false
+        });
+        endpoints.MapHealthChecks("/health/ready", new HealthCheckOptions
+        {
+            Predicate = registration => registration.Tags.Contains("ready")
+        });
+        endpoints.MapHealthChecks("/health/startup", new HealthCheckOptions
+        {
+            Predicate = registration => registration.Tags.Contains("startup")
+        });
+
+        return endpoints;
+    }
+}
+
+public sealed class StartupHealthCheck(IHostApplicationLifetime applicationLifetime) : IHealthCheck
+{
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var result = applicationLifetime.ApplicationStarted.IsCancellationRequested
+            ? HealthCheckResult.Healthy("Application startup completed.")
+            : HealthCheckResult.Unhealthy("Application startup is still in progress.");
+
+        return Task.FromResult(result);
+    }
+}
+
+public sealed class TcpDependencyHealthCheck(string host, int port) : IHealthCheck
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(2);
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(Timeout);
+
+        try
+        {
+            using var client = new TcpClient();
+            await client
+                .ConnectAsync(host, port, timeout.Token)
+                .AsTask()
+                .WaitAsync(Timeout, cancellationToken);
+            return HealthCheckResult.Healthy($"{host}:{port} is reachable.");
+        }
+        catch (Exception exception) when (exception is SocketException or OperationCanceledException or TimeoutException)
+        {
+            return HealthCheckResult.Unhealthy($"{host}:{port} is unreachable.", exception);
+        }
+    }
+}
+
+public static class HealthProbeCommand
+{
+    public static async Task<bool> TryRunAsync(string[] args)
+    {
+        if (args.Length != 2 || !string.Equals(args[0], "--healthcheck", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
+            using var response = await client.GetAsync(args[1]);
+            Environment.ExitCode = response.IsSuccessStatusCode ? 0 : 1;
+        }
+        catch (Exception exception) when (exception is HttpRequestException or TaskCanceledException)
+        {
+            Console.Error.WriteLine(exception.Message);
+            Environment.ExitCode = 1;
+        }
+
+        return true;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,12 @@ services:
       Jwt__SigningKeys__MotoHub: "${MOTO_HUB_JWT_SIGNING_KEY:?Set MOTO_HUB_JWT_SIGNING_KEY in .env}"
       Jwt__SigningKeys__RiderManager: "${RIDER_MANAGER_JWT_SIGNING_KEY:?Set RIDER_MANAGER_JWT_SIGNING_KEY in .env}"
       Jwt__SigningKeys__RentalOperations: "${RENTAL_OPERATIONS_JWT_SIGNING_KEY:?Set RENTAL_OPERATIONS_JWT_SIGNING_KEY in .env}"
+    healthcheck:
+      test: ["CMD", "dotnet", "AuthGate.dll", "--healthcheck", "http://localhost:8080/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 10s
   
   rider-manager:
     build:
@@ -158,6 +164,12 @@ services:
       MinIO__SecretKey: "${MINIO_PASSWORD:?Set MINIO_PASSWORD in .env}"
       Jwt__SigningKey: "${RIDER_MANAGER_JWT_SIGNING_KEY:?Set RIDER_MANAGER_JWT_SIGNING_KEY in .env}"
       RiderManagerApiKey: "${RIDER_MANAGER_API_KEY:?Set RIDER_MANAGER_API_KEY in .env}"
+    healthcheck:
+      test: ["CMD", "dotnet", "RiderManager.dll", "--healthcheck", "http://localhost:8000/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 10s
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -166,6 +178,8 @@ services:
     build:
       context: ./MotoHub
       dockerfile: MotoHub/Dockerfile
+      additional_contexts:
+        shared: ./Shared
     container_name: moto-hub
     ports:
       - "8100:8100"
@@ -181,11 +195,19 @@ services:
       Jwt__SigningKey: "${MOTO_HUB_JWT_SIGNING_KEY:?Set MOTO_HUB_JWT_SIGNING_KEY in .env}"
       MotoHubApiKey: "${MOTO_HUB_API_KEY:?Set MOTO_HUB_API_KEY in .env}"
       RentalOperationsSettings__ApiKey: "${RENTAL_OPERATIONS_API_KEY:?Set RENTAL_OPERATIONS_API_KEY in .env}"
+    healthcheck:
+      test: ["CMD", "dotnet", "MotoHub.dll", "--healthcheck", "http://localhost:8100/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 10s
   
   rental-operations:
     build:
       context: ./RentalOperations
       dockerfile: RentalOperations/Dockerfile
+      additional_contexts:
+        shared: ./Shared
     container_name: rental-operations
     ports:
       - "8200:8200"
@@ -203,6 +225,12 @@ services:
       RentalOperationsApiKey: "${RENTAL_OPERATIONS_API_KEY:?Set RENTAL_OPERATIONS_API_KEY in .env}"
       RiderManagerSettings__ApiKey: "${RIDER_MANAGER_API_KEY:?Set RIDER_MANAGER_API_KEY in .env}"
       MotoHubSettings__ApiKey: "${MOTO_HUB_API_KEY:?Set MOTO_HUB_API_KEY in .env}"
+    healthcheck:
+      test: ["CMD", "dotnet", "RentalOperations.dll", "--healthcheck", "http://localhost:8200/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 10s
     depends_on:
       rabbitmq:
         condition: service_healthy

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,6 +136,40 @@ The command creates the `Admin` role when needed, creates or promotes the
 configured account, and exits. The `finally` block removes both plaintext
 values from the shell even if bootstrap fails.
 
+## Verify health probes
+
+Each application exposes three separate endpoints:
+
+| Endpoint | Question | Dependency failure |
+|---|---|---|
+| `/health/live` | Is the process responding? | Stays healthy |
+| `/health/ready` | Can required infrastructure be reached? | Becomes unhealthy |
+| `/health/startup` | Has application startup completed? | Unchanged after startup |
+
+Compose uses `/health/ready` for container health. The probe command runs through
+the application assembly itself, so the chiseled images do not need a shell,
+`curl`, or `wget`.
+
+Manual readiness drill:
+
+```bash
+docker compose up --build -d
+curl --fail http://localhost:8000/health/live
+curl --fail http://localhost:8000/health/ready
+curl --fail http://localhost:8000/health/startup
+
+docker compose stop rabbitmq
+curl --fail http://localhost:8000/health/live
+curl --fail http://localhost:8000/health/ready # expected to fail with HTTP 503
+
+docker compose start rabbitmq
+```
+
+The process remains live while RabbitMQ is unavailable, but readiness removes it
+from rotation. Inter-service HTTP upstreams are deliberately excluded from
+readiness: a circuit breaker opening for one upstream must not disable unrelated
+routes served by the same process.
+
 ## Stop the stack
 
 Press `Ctrl+C` in the attached Compose session, then run:
@@ -153,7 +187,6 @@ Named volumes are retained so local database contents survive the restart.
   contains no committed secret defaults.
 - Supporting databases, queues, object storage, and observability tools publish
   host ports with development settings.
-- There are no reliable health gates; startup currently depends on fixed waits.
 - The modernization topology in `deploy/compose.yaml` is not runnable until its
   referenced services land.
 

--- a/docs/security/container-image-scanning.md
+++ b/docs/security/container-image-scanning.md
@@ -5,15 +5,15 @@ AuthGate, MotoHub, RentalOperations, and RiderManager. A change to the CI workfl
 builds all four. References in `deploy/compose.yaml` whose build contexts do not yet
 exist are outside this gate until their Dockerfiles are added.
 
-Each current image uses its service directory as the primary build context. AuthGate
-and RiderManager receive `Shared/` as a separate, read-only BuildKit named context,
-so the repository root and `.git/` are never sent to either build. The equivalent
+Each current image uses its service directory as the primary build context. All four
+receive `Shared/` as a separate, read-only BuildKit named context, so the repository
+root and `.git/` are never sent to any build. The equivalent
 standalone commands are:
 
 ```bash
 docker build --build-context shared=./Shared -f AuthGate/AuthGate/Dockerfile -t projecty/auth-gate AuthGate
-docker build -f MotoHub/MotoHub/Dockerfile -t projecty/moto-hub MotoHub
-docker build -f RentalOperations/RentalOperations/Dockerfile -t projecty/rental-operations RentalOperations
+docker build --build-context shared=./Shared -f MotoHub/MotoHub/Dockerfile -t projecty/moto-hub MotoHub
+docker build --build-context shared=./Shared -f RentalOperations/RentalOperations/Dockerfile -t projecty/rental-operations RentalOperations
 docker build --build-context shared=./Shared -f RiderManager/RiderManager/Dockerfile -t projecty/rider-manager RiderManager
 ```
 


### PR DESCRIPTION
## Summary

- expose separate `/health/live`, `/health/ready`, and `/health/startup` endpoints on all four services
- keep readiness scoped to required infrastructure so an inter-service circuit breaker does not remove unrelated routes
- add bounded TCP dependency checks and a shell-free probe command for the chiseled images
- configure Compose healthchecks every 10 seconds and update CI build contexts/documentation

## Validation

- Release builds for all four solutions
- AuthGate: 23 tests passed
- MotoHub: 41 tests passed
- RentalOperations: 9 tests passed
- RiderManager: 3 tests passed
- all four Docker images built successfully
- all 12 probe endpoints returned HTTP 200 on the fresh stack
- with RabbitMQ stopped, every liveness probe stayed HTTP 200 and every readiness probe returned HTTP 503 within about 2 seconds
- after RabbitMQ recovered, all readiness probes returned HTTP 200 again

Progresses #30