### PR TITLE
feat(dev): gate startup on service health

### DIFF
--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -16,15 +16,11 @@
 
 name: projecty
 
-x-observed: &observed
-  environment: &otel-env
-    OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
-    OTEL_EXPORTER_OTLP_PROTOCOL: grpc
-    OTEL_TRACES_SAMPLER: parentbased_traceidratio
-    OTEL_TRACES_SAMPLER_ARG: "1.0"
-  depends_on:
-    otel-collector:
-      condition: service_started
+x-otel-env: &otel-env
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
+  OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+  OTEL_TRACES_SAMPLER: parentbased_traceidratio
+  OTEL_TRACES_SAMPLER_ARG: "1.0"
 
 x-restart: &restart
   restart: unless-stopped
@@ -221,7 +217,7 @@ services:
       - ./chaos/toxiproxy.json:/config/toxiproxy.json:ro
     networks: [projecty]
     healthcheck:
-      test: ["CMD-SHELL", "/toxiproxy-cli list >/dev/null 2>&1"]
+      test: ["CMD", "/toxiproxy-cli", "list"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -231,7 +227,10 @@ services:
   # ─────────────────────────────────────────────────────────────────────────
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.121.0
+    image: projecty/otel-collector
+    build:
+      context: ./observability
+      dockerfile: otel-collector.Dockerfile
     <<: *restart
     command: ["--config=/etc/otel/config.yaml"]
     ports:
@@ -242,8 +241,16 @@ services:
       - ./observability/otel-collector.yaml:/etc/otel/config.yaml:ro
     networks: [projecty]
     depends_on:
-      - tempo
-      - loki
+      tempo:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/busybox", "wget", "--spider", "-q", "http://localhost:13133/"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
 
   prometheus:
     image: prom/prometheus:v3.2.1
@@ -261,6 +268,15 @@ services:
       - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus
     networks: [projecty]
+    depends_on:
+      otel-collector:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/bin/wget", "--spider", "-q", "http://localhost:9090/-/ready"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
 
   tempo:
     image: grafana/tempo:2.7.1
@@ -272,6 +288,12 @@ services:
       - ./observability/tempo.yaml:/etc/tempo/tempo.yaml:ro
       - tempo-data:/var/tempo
     networks: [projecty]
+    healthcheck:
+      test: ["CMD", "/usr/bin/wget", "--spider", "-q", "http://localhost:3200/ready"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
 
   loki:
     image: grafana/loki:3.4.2
@@ -283,6 +305,12 @@ services:
       - ./observability/loki.yaml:/etc/loki/loki.yaml:ro
       - loki-data:/loki
     networks: [projecty]
+    healthcheck:
+      test: ["CMD", "/busybox/wget", "--spider", "-q", "http://localhost:3100/ready"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
 
   grafana:
     image: grafana/grafana:11.6.0
@@ -301,9 +329,18 @@ services:
       - grafana-data:/var/lib/grafana
     networks: [projecty]
     depends_on:
-      - prometheus
-      - tempo
-      - loki
+      prometheus:
+        condition: service_healthy
+      tempo:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/usr/bin/wget", "--spider", "-q", "http://localhost:3000/api/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
 
   # ─────────────────────────────────────────────────────────────────────────
   # Serviços — núcleo
@@ -333,9 +370,9 @@ services:
       redis:
         condition: service_healthy
       toxiproxy:
-        condition: service_started
+        condition: service_healthy
       otel-collector:
-        condition: service_started
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "/app/api-gateway", "--healthcheck"]
       interval: 10s
@@ -374,6 +411,12 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
+      redis:
+        condition: service_healthy
+      toxiproxy:
+        condition: service_healthy
+      otel-collector:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8091/health/ready >/dev/null 2>&1"]
       interval: 10s
@@ -406,6 +449,12 @@ services:
     depends_on:
       rabbitmq:
         condition: service_healthy
+      minio:
+        condition: service_healthy
+      toxiproxy:
+        condition: service_healthy
+      otel-collector:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "/app/media-guard", "--healthcheck"]
       interval: 10s
@@ -431,6 +480,10 @@ services:
     networks: [projecty]
     depends_on:
       kafka:
+        condition: service_healthy
+      toxiproxy:
+        condition: service_healthy
+      otel-collector:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8093/health/ready').status==200 else 1)\""]
@@ -458,6 +511,12 @@ services:
     depends_on:
       cassandra:
         condition: service_healthy
+      kafka:
+        condition: service_healthy
+      toxiproxy:
+        condition: service_healthy
+      otel-collector:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:4000/health/ready >/dev/null 2>&1"]
       interval: 10s
@@ -484,7 +543,12 @@ services:
       - "3000:3000"
     networks: [projecty]
     depends_on:
-      - api-gateway
+      api-gateway:
+        condition: service_healthy
+      telemetry:
+        condition: service_healthy
+      otel-collector:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:3000/api/health >/dev/null 2>&1"]
       interval: 10s
@@ -509,3 +573,8 @@ services:
     volumes:
       - ../load/k6:/scripts:ro
     networks: [projecty]
+    depends_on:
+      api-gateway:
+        condition: service_healthy
+      prometheus:
+        condition: service_healthy

--- a/deploy/observability/.dockerignore
+++ b/deploy/observability/.dockerignore
@@ -1,0 +1,2 @@
+**
+!otel-collector.Dockerfile

--- a/deploy/observability/otel-collector.Dockerfile
+++ b/deploy/observability/otel-collector.Dockerfile
@@ -1,0 +1,5 @@
+FROM busybox:1.37.0-musl AS probe
+
+FROM otel/opentelemetry-collector-contrib:0.121.0
+
+COPY --from=probe /bin/busybox /busybox

--- a/deploy/observability/otel-collector.yaml
+++ b/deploy/observability/otel-collector.yaml
@@ -10,6 +10,10 @@ receivers:
       http:
         endpoint: 0.0.0.0:4318
 
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
 processors:
   # Agrupa spans por trace antes de amostrar, para nunca cortar um trace pela metade.
   batch:
@@ -56,6 +60,7 @@ exporters:
       enabled: true
 
 service:
+  extensions: [health_check]
   telemetry:
     logs:
       level: info

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -170,6 +170,33 @@ from rotation. Inter-service HTTP upstreams are deliberately excluded from
 readiness: a circuit breaker opening for one upstream must not disable unrelated
 routes served by the same process.
 
+## Verify startup gates
+
+The modernization Compose graph waits for real health instead of elapsed time.
+Tempo and Loki become healthy first, followed by the OpenTelemetry Collector,
+Prometheus, and Grafana. Application services wait for a healthy collector and
+for each infrastructure dependency they use through Toxiproxy.
+
+The observability portion can be exercised before the modernization service
+builds land:
+
+```bash
+docker compose --env-file .env -f deploy/compose.yaml up --build -d \
+  tempo loki otel-collector prometheus grafana toxiproxy
+docker compose --env-file .env -f deploy/compose.yaml ps
+
+# Dependents must retain their container IDs and return to all-green.
+docker compose --env-file .env -f deploy/compose.yaml ps -q \
+  otel-collector prometheus grafana
+docker compose --env-file .env -f deploy/compose.yaml restart loki
+docker compose --env-file .env -f deploy/compose.yaml ps -q \
+  otel-collector prometheus grafana
+```
+
+The IDs before and after the Loki restart must match. Compose health conditions
+gate initial startup only; they do not cascade a dependency restart into healthy
+dependents. No fixed delay is used anywhere in `deploy/compose.yaml`.
+
 ## Stop the stack
 
 Press `Ctrl+C` in the attached Compose session, then run:


### PR DESCRIPTION
## Summary

- replace every remaining short-form or `service_started` dependency in `deploy/compose.yaml` with explicit health conditions
- add readiness checks for Tempo, Loki, OpenTelemetry Collector, Prometheus, Grafana, and Toxiproxy
- make application and load services wait for the healthy infrastructure and observability components they use
- add a minimal collector image containing only a static BusyBox probe binary
- document the startup-order and mid-run dependency restart drill

## Validation

- `docker compose config --quiet` passed with the init, full, and load profiles
- collector probe image built successfully
- cold-started Tempo, Loki, Collector, Prometheus, Grafana, and Toxiproxy in an isolated Compose project
- all six containers became healthy in dependency order
- restarted Loki while the stack was running
- Collector, Prometheus, and Grafana retained the same container IDs and startup timestamps and returned to all-green
- verified no `sleep` or `condition: service_started` remains in `deploy/compose.yaml`

Progresses #31