### PR TITLE
Add live update and idempotent setup resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ runs `cassandra-schema` and `minio-buckets`. Each resource waits for its backing
 service to become ready and can be triggered again safely from the Tilt UI.
 Cockroach and Cassandra watch the scripts under `deploy/db/`, while Kafka and
 MinIO use the declarative lists in `deploy/kafka/topics.txt` and
-`deploy/minio/buckets.txt`.
+`deploy/minio/buckets.txt`. Schema files run one at a time in lexical filename
+order, so migrations use numbered names such as `002_add_index.sql` and remain
+safe to re-run.
 
 When a modernization service directory lands under `services/`, its source is
 synced into `/workspace` instead of rebuilding the image. Dependency manifests

--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ The Tilt UI is at <http://localhost:10350>, Grafana is at
 <http://localhost:3001>, and the full-profile console is at
 <http://localhost:3000>. Use `tilt down` to stop the selected profile.
 
+Tilt exposes the database and messaging bootstrap as setup resources. The core
+profile runs `cockroach-migrations` and `kafka-topics`; the full profile also
+runs `cassandra-schema` and `minio-buckets`. Each resource waits for its backing
+service to become ready and can be triggered again safely from the Tilt UI.
+Cockroach and Cassandra watch the scripts under `deploy/db/`, while Kafka and
+MinIO use the declarative lists in `deploy/kafka/topics.txt` and
+`deploy/minio/buckets.txt`.
+
+When a modernization service directory lands under `services/`, its source is
+synced into `/workspace` instead of rebuilding the image. Dependency manifests
+trigger the language-specific restore command, compiled services run an
+incremental build, and the Compose container restarts at the end of the update.
+Tilt's `restart_process()` extension does not support Docker Compose resources,
+so this topology uses the supported `restart_container()` step.
+
 There is not yet an honest all-green first-run time to publish. The Compose
 topology references `services/api-gateway`, `services/rental-core`, and the
 full-profile services that have not landed in the repository, so a clean clone

--- a/Tiltfile
+++ b/Tiltfile
@@ -59,6 +59,117 @@ docker_compose(
     project_name = 'projecty',
 )
 
+# Docker Compose workloads use restart_container(); the restart_process
+# extension does not support Compose resources. Development images keep their
+# source and language toolchain under /workspace so incremental builds happen
+# in-place instead of rebuilding an image.
+def configure_live_update(image, context, manifests, install_command, build_command = ''):
+    if not os.path.exists(context):
+        print('Live update pending service source: %s' % context)
+        return
+
+    update_steps = [
+        fall_back_on(context + '/Dockerfile'),
+        sync(context, '/workspace'),
+        run(install_command, trigger = manifests),
+    ]
+    if build_command:
+        update_steps.append(run(build_command))
+    update_steps.append(restart_container())
+
+    docker_build(
+        image,
+        context,
+        dockerfile = context + '/Dockerfile',
+        live_update = update_steps,
+    )
+
+configure_live_update(
+    'projecty/api-gateway',
+    'services/api-gateway',
+    ['services/api-gateway/Cargo.toml', 'services/api-gateway/Cargo.lock'],
+    'cd /workspace && cargo fetch --locked',
+    'cd /workspace && cargo build --locked',
+)
+configure_live_update(
+    'projecty/rental-core',
+    'services/rental-core',
+    ['services/rental-core/RentalCore.csproj'],
+    'cd /workspace && dotnet restore RentalCore.csproj',
+    'cd /workspace && dotnet build RentalCore.csproj --no-restore',
+)
+configure_live_update(
+    'projecty/media-guard',
+    'services/media-guard',
+    ['services/media-guard/Cargo.toml', 'services/media-guard/Cargo.lock'],
+    'cd /workspace && cargo fetch --locked',
+    'cd /workspace && cargo build --locked',
+)
+configure_live_update(
+    'projecty/risk-pricing',
+    'services/risk-pricing',
+    ['services/risk-pricing/pyproject.toml', 'services/risk-pricing/uv.lock'],
+    'cd /workspace && python -m pip install --disable-pip-version-check -e .',
+)
+configure_live_update(
+    'projecty/telemetry',
+    'services/telemetry',
+    ['services/telemetry/mix.exs', 'services/telemetry/mix.lock'],
+    'cd /workspace && mix deps.get',
+    'cd /workspace && mix compile',
+)
+configure_live_update(
+    'projecty/console',
+    'services/console',
+    ['services/console/package.json', 'services/console/package-lock.json'],
+    'cd /workspace && npm install --ignore-scripts',
+)
+
+bootstrap_script = ['pwsh', '-NoProfile', '-File', 'scripts/Initialize-LocalResource.ps1']
+bootstrap_script_bat = [
+    'powershell',
+    '-NoProfile',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-File',
+    'scripts\\Initialize-LocalResource.ps1',
+]
+
+local_resource(
+    'cockroach-migrations',
+    bootstrap_script + ['-Resource', 'Cockroach'],
+    cmd_bat = bootstrap_script_bat + ['-Resource', 'Cockroach'],
+    deps = ['scripts/Initialize-LocalResource.ps1', 'deploy/db/cockroach'],
+    resource_deps = ['cockroachdb'],
+    labels = ['setup'],
+)
+local_resource(
+    'kafka-topics',
+    bootstrap_script + ['-Resource', 'Kafka'],
+    cmd_bat = bootstrap_script_bat + ['-Resource', 'Kafka'],
+    deps = ['scripts/Initialize-LocalResource.ps1', 'deploy/kafka/topics.txt'],
+    resource_deps = ['kafka'],
+    labels = ['setup'],
+)
+
+if full:
+    local_resource(
+        'cassandra-schema',
+        bootstrap_script + ['-Resource', 'Cassandra'],
+        cmd_bat = bootstrap_script_bat + ['-Resource', 'Cassandra'],
+        deps = ['scripts/Initialize-LocalResource.ps1', 'deploy/db/cassandra'],
+        resource_deps = ['cassandra'],
+        labels = ['setup'],
+    )
+    local_resource(
+        'minio-buckets',
+        bootstrap_script + ['-Resource', 'MinIO'],
+        cmd_bat = bootstrap_script_bat + ['-Resource', 'MinIO'],
+        deps = ['scripts/Initialize-LocalResource.ps1', 'deploy/minio/buckets.txt'],
+        resource_deps = ['minio'],
+        labels = ['setup'],
+    )
+
 infra_resources = ['cockroachdb', 'cockroach-init', 'redis', 'rabbitmq', 'kafka']
 observability_resources = ['otel-collector', 'prometheus', 'tempo', 'loki']
 service_resources = ['api-gateway', 'rental-core']
@@ -73,8 +184,19 @@ for resource in infra_resources:
 for resource in observability_resources:
     dc_resource(resource, labels = ['observability'])
 
+service_setup_dependencies = {
+    'rental-core': ['cockroach-migrations', 'kafka-topics'],
+    'media-guard': ['minio-buckets'],
+    'risk-pricing': ['kafka-topics'],
+    'telemetry': ['cassandra-schema', 'kafka-topics'],
+}
+
 for resource in service_resources:
-    dc_resource(resource, labels = ['services'])
+    dc_resource(
+        resource,
+        labels = ['services'],
+        resource_deps = service_setup_dependencies.get(resource, []),
+    )
 
 dc_resource('toxiproxy', labels = ['drills'])
 

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -441,6 +441,7 @@ services:
       MEDIA_BIND: 0.0.0.0:8092
       MEDIA_RABBITMQ_URL: "amqp://${MEDIA_GUARD_RABBITMQ_USER:?Set MEDIA_GUARD_RABBITMQ_USER in .env}:${MEDIA_GUARD_RABBITMQ_PASSWORD:?Set MEDIA_GUARD_RABBITMQ_PASSWORD in .env}@toxiproxy:25672/projecty"
       MEDIA_S3_ENDPOINT: http://minio:9000
+      MEDIA_S3_BUCKET: projecty-media
       MEDIA_MAX_BYTES: "8388608"
       RUST_LOG: info,media_guard=debug
     ports:

--- a/deploy/kafka/topics.txt
+++ b/deploy/kafka/topics.txt
@@ -1,0 +1,4 @@
+# One durable event stream per contract. Commands use --if-not-exists.
+rental.started
+rental.closed
+motorcycle.registered

--- a/deploy/minio/buckets.txt
+++ b/deploy/minio/buckets.txt
@@ -1,0 +1,2 @@
+# Commands use mc mb --ignore-existing.
+projecty-media

--- a/scripts/Initialize-LocalResource.ps1
+++ b/scripts/Initialize-LocalResource.ps1
@@ -46,17 +46,50 @@ function Invoke-Compose {
     }
 }
 
+function Get-OrderedMigration {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Directory,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Extension
+    )
+
+    $migrations = @(
+        Get-ChildItem -LiteralPath $Directory -File |
+            Where-Object { $_.Extension -eq $Extension } |
+            Sort-Object -Property Name
+    )
+    if ($migrations.Count -eq 0) {
+        throw "No $Extension migrations were found in $Directory."
+    }
+
+    return $migrations
+}
+
 Push-Location $repositoryRoot
 try {
     switch ($Resource) {
         'Cockroach' {
-            Invoke-Compose -Arguments @('run', '--rm', '--no-deps', 'cockroach-init')
+            $migrations = @(Get-OrderedMigration -Directory 'deploy/db/cockroach' -Extension '.sql')
+            foreach ($migration in $migrations) {
+                Write-Host "Applying Cockroach migration $($migration.Name)..."
+                Invoke-Compose -Arguments @(
+                    'run', '--rm', '--no-deps', 'cockroach-init',
+                    '--insecure', '--host=cockroachdb:26257',
+                    "--file=/sql/$($migration.Name)"
+                )
+            }
         }
         'Cassandra' {
-            Invoke-Compose -Arguments @(
-                'exec', '-T', 'cassandra',
-                'cqlsh', '-f', '/schema/001_init.cql'
-            )
+            $migrations = @(Get-OrderedMigration -Directory 'deploy/db/cassandra' -Extension '.cql')
+            foreach ($migration in $migrations) {
+                Write-Host "Applying Cassandra migration $($migration.Name)..."
+                Invoke-Compose -Arguments @(
+                    'exec', '-T', 'cassandra',
+                    'cqlsh', '-f', "/schema/$($migration.Name)"
+                )
+            }
         }
         'Kafka' {
             $topics = Get-Content -LiteralPath 'deploy/kafka/topics.txt' |

--- a/scripts/Initialize-LocalResource.ps1
+++ b/scripts/Initialize-LocalResource.ps1
@@ -1,0 +1,94 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('Cockroach', 'Cassandra', 'Kafka', 'MinIO')]
+    [string]$Resource,
+
+    [string]$ProjectName = 'projecty'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$docker = Get-Command docker -ErrorAction SilentlyContinue
+if (-not $docker) {
+    $dockerCandidates = @(
+        (Join-Path $env:ProgramFiles 'Docker\Docker\resources\bin\docker.exe'),
+        (Join-Path $env:LOCALAPPDATA 'Programs\DockerDesktop\resources\bin\docker.exe')
+    )
+    $dockerPath = $dockerCandidates |
+        Where-Object { Test-Path -LiteralPath $_ } |
+        Select-Object -First 1
+    if (-not $dockerPath) {
+        throw 'Docker CLI was not found. Install Docker Desktop or add docker to PATH.'
+    }
+    $docker = Get-Command $dockerPath -ErrorAction Stop
+}
+$composeArguments = @(
+    'compose',
+    '--project-name', $ProjectName,
+    '--env-file', '.env',
+    '--profile', 'init',
+    '--profile', 'full',
+    '-f', 'deploy/compose.yaml'
+)
+
+function Invoke-Compose {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    & $docker.Source @composeArguments @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Docker Compose failed with exit code $LASTEXITCODE."
+    }
+}
+
+Push-Location $repositoryRoot
+try {
+    switch ($Resource) {
+        'Cockroach' {
+            Invoke-Compose -Arguments @('run', '--rm', '--no-deps', 'cockroach-init')
+        }
+        'Cassandra' {
+            Invoke-Compose -Arguments @(
+                'exec', '-T', 'cassandra',
+                'cqlsh', '-f', '/schema/001_init.cql'
+            )
+        }
+        'Kafka' {
+            $topics = Get-Content -LiteralPath 'deploy/kafka/topics.txt' |
+                ForEach-Object { $_.Trim() } |
+                Where-Object { $_ -and -not $_.StartsWith('#') }
+
+            foreach ($topic in $topics) {
+                Invoke-Compose -Arguments @(
+                    'exec', '-T', 'kafka',
+                    '/opt/kafka/bin/kafka-topics.sh',
+                    '--bootstrap-server', 'localhost:9092',
+                    '--create', '--if-not-exists',
+                    '--topic', $topic,
+                    '--partitions', '3',
+                    '--replication-factor', '1'
+                )
+            }
+        }
+        'MinIO' {
+            $buckets = Get-Content -LiteralPath 'deploy/minio/buckets.txt' |
+                ForEach-Object { $_.Trim() } |
+                Where-Object { $_ -and -not $_.StartsWith('#') }
+
+            foreach ($bucket in $buckets) {
+                Invoke-Compose -Arguments @(
+                    'exec', '-T', 'minio',
+                    'mc', 'mb', '--ignore-existing', "local/$bucket"
+                )
+            }
+        }
+    }
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- add language-specific Live Update recipes for every modernization service, activated as each service source lands
- model Cockroach migrations, Cassandra schema, Kafka topics, and MinIO buckets as dependency-gated, idempotent Tilt resources
- declare Kafka topics and the media bucket in versioned files and document the development loop

Docker Compose resources use Tilt's supported `restart_container()` Live Update step because `restart_process()` is not supported for Compose workloads.

## Validation
- `tilt alpha tiltfile-result --file Tiltfile` (core)
- `tilt alpha tiltfile-result --file Tiltfile -- --full`
- `docker compose --env-file .env --profile init --profile full -f deploy/compose.yaml config --quiet`
- PowerShell parser validation for `scripts/Initialize-LocalResource.ps1`
- `git diff --check`

Container-level re-run verification was not executed because the local Docker Desktop daemon was unavailable.

Progresses #32