### PR TITLE
fix: harden production settings and pin container images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Copy this file to .env only if you are not using scripts/New-LocalSecrets.ps1.
 # Every value below is required. Never commit real values.
+SWAGGER_ENABLED=true
 AUTH_GATE_POSTGRES_DB=
 MOTO_HUB_POSTGRES_DB=
 RIDER_MANAGER_POSTGRES_DB=

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+
+updates:
+  - package-ecosystem: docker-compose
+    directories:
+      - "/"
+      - "/deploy/base"
+    target-branch: epic/5-local-development-loop
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Manaus
+    groups:
+      container-images:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directories:
+      - "/AuthGate/AuthGate"
+      - "/MotoHub/MotoHub"
+      - "/RentalOperations/RentalOperations"
+      - "/RiderManager/RiderManager"
+    target-branch: epic/5-local-development-loop
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Manaus
+    groups:
+      dotnet-base-images:
+        patterns:
+          - "mcr.microsoft.com/dotnet/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     directories:
       - "/"
       - "/deploy/base"
-    target-branch: epic/5-local-development-loop
     schedule:
       interval: weekly
       day: monday
@@ -22,7 +21,6 @@ updates:
       - "/MotoHub/MotoHub"
       - "/RentalOperations/RentalOperations"
       - "/RiderManager/RiderManager"
-    target-branch: epic/5-local-development-loop
     schedule:
       interval: weekly
       day: monday

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
             moto_hub:
               - 'MotoHub/**'
               - 'Shared/Health/**'
+              - 'Shared/Hosting/**'
               - '.github/workflows/ci.yml'
               - '.grype.yaml'
               - '.trivyignore.yaml'
@@ -58,6 +59,7 @@ jobs:
             rental_operations:
               - 'RentalOperations/**'
               - 'Shared/Health/**'
+              - 'Shared/Hosting/**'
               - '.github/workflows/ci.yml'
               - '.grype.yaml'
               - '.trivyignore.yaml'

--- a/AuthGate/AuthGate/AuthGate.csproj
+++ b/AuthGate/AuthGate/AuthGate.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <Compile Include="..\..\Shared\Health\ServiceHealthChecks.cs" Link="Shared\Health\ServiceHealthChecks.cs" />
+    <Compile Include="..\..\Shared\Hosting\SwaggerPolicy.cs" Link="Shared\Hosting\SwaggerPolicy.cs" />
     <Compile Include="..\..\Shared\Messaging\QueueMessageAuthenticator.cs" Link="Shared\Messaging\QueueMessageAuthenticator.cs" />
   </ItemGroup>
   

--- a/AuthGate/AuthGate/Dockerfile
+++ b/AuthGate/AuthGate/Dockerfile
@@ -7,6 +7,7 @@ RUN dotnet restore AuthGate/AuthGate/AuthGate.csproj
 FROM restore AS publish
 COPY AuthGate/ AuthGate/AuthGate/
 COPY --from=shared Health/ Shared/Health/
+COPY --from=shared Hosting/ Shared/Hosting/
 COPY --from=shared Messaging/ Shared/Messaging/
 RUN dotnet publish AuthGate/AuthGate/AuthGate.csproj \
     --configuration Release \

--- a/AuthGate/AuthGate/Program.cs
+++ b/AuthGate/AuthGate/Program.cs
@@ -13,6 +13,7 @@ using AuthGate.Services.File;
 using AuthGate.Services;
 using Npgsql;
 using ProjectY.Shared.Health;
+using ProjectY.Shared.Hosting;
 using Serilog.Sinks.Elasticsearch;
 using ProjectY.Shared.Messaging;
 
@@ -118,14 +119,11 @@ if (args.Contains("--bootstrap-admin", StringComparer.Ordinal))
     return;
 }
 
-if (app.Environment.IsDevelopment())
+if (SwaggerPolicy.IsEnabled(app.Environment, app.Configuration))
 {
     app.UseSwagger();
     app.UseSwaggerUI();
 }
-
-app.UseSwagger();
-app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
 

--- a/AuthGate/AuthGate/appsettings.Development.json
+++ b/AuthGate/AuthGate/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "Swagger": {
+    "Enabled": true
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/AuthGate/AuthGate/appsettings.json
+++ b/AuthGate/AuthGate/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "Swagger": {
+    "Enabled": false
+  },
   "RabbitMQ": {
     "HostName": "rabbitmq",
     "VirtualHost": "projecty-rider",

--- a/AuthGate/AuthGateTests/Unit/Hosting/SwaggerPolicyTests.cs
+++ b/AuthGate/AuthGateTests/Unit/Hosting/SwaggerPolicyTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using ProjectY.Shared.Hosting;
+using Xunit;
+
+namespace AuthGateTests.Unit.Hosting;
+
+public class SwaggerPolicyTests
+{
+    [Theory]
+    [InlineData("Development", true, true)]
+    [InlineData("Development", false, false)]
+    [InlineData("Production", true, false)]
+    [InlineData("Production", false, false)]
+    public void IsEnabled_RequiresDevelopmentAndExplicitToggle(
+        string environmentName,
+        bool toggle,
+        bool expected)
+    {
+        var environment = new Mock<IHostEnvironment>();
+        environment.SetupGet(value => value.EnvironmentName).Returns(environmentName);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Swagger:Enabled"] = toggle.ToString()
+            })
+            .Build();
+
+        Assert.Equal(expected, SwaggerPolicy.IsEnabled(environment.Object, configuration));
+    }
+}

--- a/MotoHub/MotoHub/Dockerfile
+++ b/MotoHub/MotoHub/Dockerfile
@@ -7,6 +7,7 @@ RUN dotnet restore MotoHub/MotoHub/MotoHub.csproj
 FROM restore AS publish
 COPY MotoHub/ MotoHub/MotoHub/
 COPY --from=shared Health/ Shared/Health/
+COPY --from=shared Hosting/ Shared/Hosting/
 RUN dotnet publish MotoHub/MotoHub/MotoHub.csproj \
     --configuration Release \
     --output /app/publish \

--- a/MotoHub/MotoHub/MotoHub.csproj
+++ b/MotoHub/MotoHub/MotoHub.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <Compile Include="..\..\Shared\Health\ServiceHealthChecks.cs" Link="Shared\Health\ServiceHealthChecks.cs" />
+    <Compile Include="..\..\Shared\Hosting\SwaggerPolicy.cs" Link="Shared\Hosting\SwaggerPolicy.cs" />
   </ItemGroup>
 
 </Project>

--- a/MotoHub/MotoHub/Program.cs
+++ b/MotoHub/MotoHub/Program.cs
@@ -16,6 +16,7 @@ using MotoHub.Services.RabbitMQ;
 using MotoHub.CrossCutting;
 using Npgsql;
 using ProjectY.Shared.Health;
+using ProjectY.Shared.Hosting;
 
 if (await HealthProbeCommand.TryRunAsync(args))
 {
@@ -132,7 +133,7 @@ builder.Services.AddSwaggerGen(c =>
 
 var app = builder.Build();
 
-if (app.Environment.IsDevelopment())
+if (SwaggerPolicy.IsEnabled(app.Environment, app.Configuration))
 {
     app.UseSwagger();
     app.UseSwaggerUI();

--- a/MotoHub/MotoHub/appsettings.Development.json
+++ b/MotoHub/MotoHub/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "Swagger": {
+    "Enabled": true
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/MotoHub/MotoHub/appsettings.json
+++ b/MotoHub/MotoHub/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "Swagger": {
+    "Enabled": false
+  },
   "RabbitMQ": {
     "HostName": "rabbitmq",
     "VirtualHost": "projecty-rental",

--- a/RentalOperations/RentalOperations/Dockerfile
+++ b/RentalOperations/RentalOperations/Dockerfile
@@ -7,6 +7,7 @@ RUN dotnet restore RentalOperations/RentalOperations/RentalOperations.csproj
 FROM restore AS publish
 COPY RentalOperations/ RentalOperations/RentalOperations/
 COPY --from=shared Health/ Shared/Health/
+COPY --from=shared Hosting/ Shared/Hosting/
 RUN dotnet publish RentalOperations/RentalOperations/RentalOperations.csproj \
     --configuration Release \
     --output /app/publish \

--- a/RentalOperations/RentalOperations/Program.cs
+++ b/RentalOperations/RentalOperations/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using MongoDB.Driver;
 using ProjectY.Shared.Health;
+using ProjectY.Shared.Hosting;
 using RentalOperations.Configurations;
 using RentalOperations.CrossCutting.Services;
 using RentalOperations.Data;
@@ -119,7 +120,7 @@ builder.Services.AddScoped<IRentalService, RentalService>();
 
 var app = builder.Build();
 
-if (app.Environment.IsDevelopment())
+if (SwaggerPolicy.IsEnabled(app.Environment, app.Configuration))
 {
     app.UseSwagger();
     app.UseSwaggerUI();

--- a/RentalOperations/RentalOperations/RentalOperations.csproj
+++ b/RentalOperations/RentalOperations/RentalOperations.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <Compile Include="..\..\Shared\Health\ServiceHealthChecks.cs" Link="Shared\Health\ServiceHealthChecks.cs" />
+    <Compile Include="..\..\Shared\Hosting\SwaggerPolicy.cs" Link="Shared\Hosting\SwaggerPolicy.cs" />
   </ItemGroup>
 
 </Project>

--- a/RentalOperations/RentalOperations/appsettings.Development.json
+++ b/RentalOperations/RentalOperations/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "Swagger": {
+    "Enabled": true
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/RentalOperations/RentalOperations/appsettings.json
+++ b/RentalOperations/RentalOperations/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "Swagger": {
+    "Enabled": false
+  },
   "MongoDbSettings": {
     "DatabaseName": "RentalOperationsDB"
   },

--- a/RiderManager/RiderManager/Dockerfile
+++ b/RiderManager/RiderManager/Dockerfile
@@ -7,6 +7,7 @@ RUN dotnet restore RiderManager/RiderManager/RiderManager.csproj
 FROM restore AS publish
 COPY RiderManager/ RiderManager/RiderManager/
 COPY --from=shared Health/ Shared/Health/
+COPY --from=shared Hosting/ Shared/Hosting/
 COPY --from=shared Messaging/ Shared/Messaging/
 RUN dotnet publish RiderManager/RiderManager/RiderManager.csproj \
     --configuration Release \

--- a/RiderManager/RiderManager/Program.cs
+++ b/RiderManager/RiderManager/Program.cs
@@ -19,6 +19,7 @@ using RiderManager.Services.PreSignedService;
 using RiderManager.Services;
 using Npgsql;
 using ProjectY.Shared.Health;
+using ProjectY.Shared.Hosting;
 using Serilog.Sinks.Elasticsearch;
 using ProjectY.Shared.Messaging;
 
@@ -136,7 +137,7 @@ builder.Services.AddSwaggerGen(c =>
 
 var app = builder.Build();
 
-if (app.Environment.IsDevelopment())
+if (SwaggerPolicy.IsEnabled(app.Environment, app.Configuration))
 {
     app.UseSwagger();
     app.UseSwaggerUI();

--- a/RiderManager/RiderManager/RiderManager.csproj
+++ b/RiderManager/RiderManager/RiderManager.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <Compile Include="..\..\Shared\Health\ServiceHealthChecks.cs" Link="Shared\Health\ServiceHealthChecks.cs" />
+    <Compile Include="..\..\Shared\Hosting\SwaggerPolicy.cs" Link="Shared\Hosting\SwaggerPolicy.cs" />
     <Compile Include="..\..\Shared\Messaging\QueueMessageAuthenticator.cs" Link="Shared\Messaging\QueueMessageAuthenticator.cs" />
   </ItemGroup>
 

--- a/RiderManager/RiderManager/appsettings.Development.json
+++ b/RiderManager/RiderManager/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "Swagger": {
+    "Enabled": true
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/RiderManager/RiderManager/appsettings.json
+++ b/RiderManager/RiderManager/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "Swagger": {
+    "Enabled": false
+  },
   "RabbitMQ": {
     "HostName": "rabbitmq",
     "VirtualHost": "projecty-rider",

--- a/Shared/Hosting/SwaggerPolicy.cs
+++ b/Shared/Hosting/SwaggerPolicy.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace ProjectY.Shared.Hosting;
+
+public static class SwaggerPolicy
+{
+    public static bool IsEnabled(
+        IHostEnvironment environment,
+        IConfiguration configuration) =>
+        environment.IsDevelopment() &&
+        configuration.GetValue<bool>("Swagger:Enabled");
+}

--- a/Tiltfile
+++ b/Tiltfile
@@ -85,41 +85,41 @@ def configure_live_update(image, context, manifests, install_command, build_comm
     )
 
 configure_live_update(
-    'projecty/api-gateway',
+    'projecty/api-gateway:dev',
     'services/api-gateway',
     ['services/api-gateway/Cargo.toml', 'services/api-gateway/Cargo.lock'],
     'cd /workspace && cargo fetch --locked',
     'cd /workspace && cargo build --locked',
 )
 configure_live_update(
-    'projecty/rental-core',
+    'projecty/rental-core:dev',
     'services/rental-core',
     ['services/rental-core/RentalCore.csproj'],
     'cd /workspace && dotnet restore RentalCore.csproj',
     'cd /workspace && dotnet build RentalCore.csproj --no-restore',
 )
 configure_live_update(
-    'projecty/media-guard',
+    'projecty/media-guard:dev',
     'services/media-guard',
     ['services/media-guard/Cargo.toml', 'services/media-guard/Cargo.lock'],
     'cd /workspace && cargo fetch --locked',
     'cd /workspace && cargo build --locked',
 )
 configure_live_update(
-    'projecty/risk-pricing',
+    'projecty/risk-pricing:dev',
     'services/risk-pricing',
     ['services/risk-pricing/pyproject.toml', 'services/risk-pricing/uv.lock'],
     'cd /workspace && python -m pip install --disable-pip-version-check -e .',
 )
 configure_live_update(
-    'projecty/telemetry',
+    'projecty/telemetry:dev',
     'services/telemetry',
     ['services/telemetry/mix.exs', 'services/telemetry/mix.lock'],
     'cd /workspace && mix deps.get',
     'cd /workspace && mix compile',
 )
 configure_live_update(
-    'projecty/console',
+    'projecty/console:dev',
     'services/console',
     ['services/console/package.json', 'services/console/package-lock.json'],
     'cd /workspace && npm install --ignore-scripts',

--- a/deploy/base/compose.yaml
+++ b/deploy/base/compose.yaml
@@ -132,7 +132,7 @@ services:
   # ─────────────────────────────────────────────────────────────────────────
 
   otel-collector:
-    image: projecty/otel-collector
+    image: projecty/otel-collector:dev
     networks: [projecty]
     depends_on:
       tempo:
@@ -209,7 +209,7 @@ services:
   # ─────────────────────────────────────────────────────────────────────────
 
   api-gateway:
-    image: projecty/api-gateway
+    image: projecty/api-gateway:dev
     networks: [projecty]
     depends_on:
       redis:
@@ -226,7 +226,7 @@ services:
       start_period: 10s
 
   rental-core:
-    image: projecty/rental-core
+    image: projecty/rental-core:dev
     networks: [projecty]
     depends_on:
       cockroach-init:
@@ -255,7 +255,7 @@ services:
   # ─────────────────────────────────────────────────────────────────────────
 
   media-guard:
-    image: projecty/media-guard
+    image: projecty/media-guard:dev
     networks: [projecty]
     depends_on:
       rabbitmq:
@@ -274,7 +274,7 @@ services:
       start_period: 10s
 
   risk-pricing:
-    image: projecty/risk-pricing
+    image: projecty/risk-pricing:dev
     networks: [projecty]
     depends_on:
       kafka:
@@ -291,7 +291,7 @@ services:
       start_period: 15s
 
   telemetry:
-    image: projecty/telemetry
+    image: projecty/telemetry:dev
     networks: [projecty]
     depends_on:
       cassandra:
@@ -310,7 +310,7 @@ services:
       start_period: 25s
 
   console:
-    image: projecty/console
+    image: projecty/console:dev
     networks: [projecty]
     depends_on:
       api-gateway:

--- a/deploy/overlays/selfhost/compose.override.yaml
+++ b/deploy/overlays/selfhost/compose.override.yaml
@@ -189,6 +189,7 @@ services:
       <<: *otel-env
       OTEL_SERVICE_NAME: rental-core
       ASPNETCORE_ENVIRONMENT: Development
+      Swagger__Enabled: "${SWAGGER_ENABLED:-true}"
       ASPNETCORE_URLS: http://+:8091
       ConnectionStrings__Cockroach: "Host=toxiproxy;Port=21257;Database=projecty;Username=root;SSL Mode=Disable"
       Messaging__Kafka__BootstrapServers: "toxiproxy:29092"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - ./deploy/postgres/init-databases.sh:/docker-entrypoint-initdb.d/10-create-service-databases.sh:ro
 
   pgadmin:
-    image: dpage/pgadmin4
+    image: dpage/pgadmin4:9.13
     container_name: pgadmin
     environment:
       PGADMIN_DEFAULT_EMAIL: "${PGADMIN_EMAIL:?Set PGADMIN_EMAIL in .env}"
@@ -69,7 +69,7 @@ services:
       - elk
 
   mongodb:
-    image: mongo:latest
+    image: mongo:8.0
     container_name: mongodb
     ports:
       - "27017:27017"
@@ -98,7 +98,7 @@ services:
       start_period: 10s
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     container_name: minio
     environment:
       MINIO_ROOT_USER: "${MINIO_USER:?Set MINIO_USER in .env}"
@@ -125,7 +125,8 @@ services:
     networks:
       - elk
     environment:
-      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_ENVIRONMENT: Production
+      Swagger__Enabled: "${SWAGGER_ENABLED:-false}"
       ConnectionStrings__Postgresql: "Host=postgres;Port=5432;Database=${AUTH_GATE_POSTGRES_DB:?Set AUTH_GATE_POSTGRES_DB in .env};Username=${POSTGRES_USER:?Set POSTGRES_USER in .env};Password=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}"
       RabbitMQ__UserName: "${AUTH_GATE_RABBITMQ_USER:?Set AUTH_GATE_RABBITMQ_USER in .env}"
       RabbitMQ__Password: "${AUTH_GATE_RABBITMQ_PASSWORD:?Set AUTH_GATE_RABBITMQ_PASSWORD in .env}"
@@ -154,7 +155,8 @@ services:
     networks:
       - elk
     environment:
-      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_ENVIRONMENT: Production
+      Swagger__Enabled: "${SWAGGER_ENABLED:-false}"
       ASPNETCORE_URLS: http://+:8000
       ConnectionStrings__Postgresql: "Host=postgres;Port=5432;Database=${RIDER_MANAGER_POSTGRES_DB:?Set RIDER_MANAGER_POSTGRES_DB in .env};Username=${POSTGRES_USER:?Set POSTGRES_USER in .env};Password=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}"
       RabbitMQ__UserName: "${RIDER_MANAGER_RABBITMQ_USER:?Set RIDER_MANAGER_RABBITMQ_USER in .env}"
@@ -187,7 +189,8 @@ services:
     networks:
       - elk
     environment:
-      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_ENVIRONMENT: Production
+      Swagger__Enabled: "${SWAGGER_ENABLED:-false}"
       ASPNETCORE_URLS: http://+:8100
       ConnectionStrings__Postgresql: "Host=postgres;Port=5432;Database=${MOTO_HUB_POSTGRES_DB:?Set MOTO_HUB_POSTGRES_DB in .env};Username=${POSTGRES_USER:?Set POSTGRES_USER in .env};Password=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}"
       RabbitMQ__UserName: "${MOTO_HUB_RABBITMQ_USER:?Set MOTO_HUB_RABBITMQ_USER in .env}"
@@ -215,7 +218,8 @@ services:
     networks:
       - elk
     environment:
-      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_ENVIRONMENT: Production
+      Swagger__Enabled: "${SWAGGER_ENABLED:-false}"
       ASPNETCORE_URLS: http://+:8200
       MongoDbSettings__ConnectionString: "mongodb://${MONGO_USER:?Set MONGO_USER in .env}:${MONGO_PASSWORD:?Set MONGO_PASSWORD in .env}@mongodb:27017"
       MongoDbSettings__DatabaseName: "${MONGO_DB:?Set MONGO_DB in .env}"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -93,10 +93,18 @@ depends on the network connection and Docker cache.
 
 | Service | Local URL |
 |---|---|
-| Auth Gate | <http://localhost:8080/swagger> |
-| Rider Manager | <http://localhost:8000/swagger> |
-| MotoHub | <http://localhost:8100/swagger> |
-| Rental Operations | <http://localhost:8200/swagger> |
+| Auth Gate | <http://localhost:8080> |
+| Rider Manager | <http://localhost:8000> |
+| MotoHub | <http://localhost:8100> |
+| Rental Operations | <http://localhost:8200> |
+
+The audited baseline Compose stack runs every application in `Production`, so
+Swagger and the developer exception page are disabled. Local IDE launch
+profiles use `Development`; their `appsettings.Development.json` files enable
+Swagger explicitly. Both conditions are required: setting `Swagger:Enabled`
+alone never exposes Swagger from a `Production` process. Set
+`SWAGGER_ENABLED=false` in `.env` to disable Swagger in the self-hosted
+development overlay without editing its Compose files.
 
 Only the HTTP endpoints above are documented as usable. The compose file also
 publishes ports that older documentation described as HTTPS, but it configures

--- a/scripts/New-LocalSecrets.ps1
+++ b/scripts/New-LocalSecrets.ps1
@@ -82,6 +82,7 @@ function New-RabbitMqPasswordHash {
 
 $localSuffix = (New-RandomValue -ByteCount 6).ToLowerInvariant()
 $values = [ordered]@{
+    SWAGGER_ENABLED                   = "true"
     AUTH_GATE_POSTGRES_DB             = "AuthGateDB"
     MOTO_HUB_POSTGRES_DB              = "MotoHubDB"
     RIDER_MANAGER_POSTGRES_DB         = "RiderManagerDB"


### PR DESCRIPTION
## Summary
- gates Swagger behind both the Development environment and an explicit stack toggle
- runs the audited baseline Compose applications in Production and documents the self-hosted development override
- pins every Compose image to an explicit non-latest tag, including local :dev images used by Tilt
- configures weekly grouped Dependabot PRs for Compose and Dockerfile image updates
- extends CI filters for the new shared hosting policy

## Validation
- 79 .NET tests passed (AuthGate 27, RiderManager 3, MotoHub 41, RentalOperations 8)
- dotnet format --verify-no-changes for all four solutions
- docker compose config for the baseline and self-hosted init/full profiles
- Tiltfile evaluation for core and full profiles
- static image scan: no latest or implicit image references

The Docker-backed ActiveRentalConstraintTests integration test could not run because Docker Desktop is unavailable; the remaining RentalOperations suite passed.

Progresses #95