### PR TITLE
fix: support standalone service Dockerfile builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,5 @@
 !RiderManager/RiderManager/**
 !Shared/
 !Shared/**
+**/bin/
+**/obj/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+**
+!AuthGate/
+!AuthGate/AuthGate/
+!AuthGate/AuthGate/**
+!MotoHub/
+!MotoHub/MotoHub/
+!MotoHub/MotoHub/**
+!RentalOperations/
+!RentalOperations/RentalOperations/
+!RentalOperations/RentalOperations/**
+!RiderManager/
+!RiderManager/RiderManager/
+!RiderManager/RiderManager/**
+!Shared/
+!Shared/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
             auth_gate:
               - 'AuthGate/**'
               - 'Shared/**'
+              - '.dockerignore'
               - '.github/workflows/ci.yml'
               - '.grype.yaml'
               - '.trivyignore.yaml'
@@ -49,6 +50,7 @@ jobs:
               - 'MotoHub/**'
               - 'Shared/Health/**'
               - 'Shared/Hosting/**'
+              - '.dockerignore'
               - '.github/workflows/ci.yml'
               - '.grype.yaml'
               - '.trivyignore.yaml'
@@ -60,6 +62,7 @@ jobs:
               - 'RentalOperations/**'
               - 'Shared/Health/**'
               - 'Shared/Hosting/**'
+              - '.dockerignore'
               - '.github/workflows/ci.yml'
               - '.grype.yaml'
               - '.trivyignore.yaml'
@@ -70,6 +73,7 @@ jobs:
             rider_manager:
               - 'RiderManager/**'
               - 'Shared/**'
+              - '.dockerignore'
               - '.github/workflows/ci.yml'
               - '.grype.yaml'
               - '.trivyignore.yaml'
@@ -97,7 +101,6 @@ jobs:
             local context="$4"
             local dockerfile="$5"
             local repository="$6"
-            local build_contexts="${7:-}"
             matrix=$(jq --compact-output \
               --arg service "$service" \
               --arg solution "$solution" \
@@ -109,22 +112,21 @@ jobs:
               --arg context "$context" \
               --arg dockerfile "$dockerfile" \
               --arg repository "$repository" \
-              --arg build_contexts "$build_contexts" \
-              '.include += [{service: $service, image: $image, context: $context, dockerfile: $dockerfile, repository: $repository, build_contexts: $build_contexts}]' \
+              '.include += [{service: $service, image: $image, context: $context, dockerfile: $dockerfile, repository: $repository}]' \
               <<< "$image_matrix")
           }
 
           if [[ "$AUTH_GATE_CHANGED" == "true" ]]; then
-            add_service "AuthGate" "AuthGate/AuthGate.sln" "auth-gate" "AuthGate" "AuthGate/AuthGate/Dockerfile" "ghcr.io/ivega123/projecty/auth-gate" "shared=./Shared"
+            add_service "AuthGate" "AuthGate/AuthGate.sln" "auth-gate" "." "AuthGate/AuthGate/Dockerfile" "ghcr.io/ivega123/projecty/auth-gate"
           fi
           if [[ "$MOTO_HUB_CHANGED" == "true" ]]; then
-            add_service "MotoHub" "MotoHub/MotoHub.sln" "moto-hub" "MotoHub" "MotoHub/MotoHub/Dockerfile" "ghcr.io/ivega123/projecty/moto-hub" "shared=./Shared"
+            add_service "MotoHub" "MotoHub/MotoHub.sln" "moto-hub" "." "MotoHub/MotoHub/Dockerfile" "ghcr.io/ivega123/projecty/moto-hub"
           fi
           if [[ "$RENTAL_OPERATIONS_CHANGED" == "true" ]]; then
-            add_service "RentalOperations" "RentalOperations/RentalOperations.sln" "rental-operations" "RentalOperations" "RentalOperations/RentalOperations/Dockerfile" "ghcr.io/ivega123/projecty/rental-operations" "shared=./Shared"
+            add_service "RentalOperations" "RentalOperations/RentalOperations.sln" "rental-operations" "." "RentalOperations/RentalOperations/Dockerfile" "ghcr.io/ivega123/projecty/rental-operations"
           fi
           if [[ "$RIDER_MANAGER_CHANGED" == "true" ]]; then
-            add_service "RiderManager" "RiderManager/RiderManager.sln" "rider-manager" "RiderManager" "RiderManager/RiderManager/Dockerfile" "ghcr.io/ivega123/projecty/rider-manager" "shared=./Shared"
+            add_service "RiderManager" "RiderManager/RiderManager.sln" "rider-manager" "." "RiderManager/RiderManager/Dockerfile" "ghcr.io/ivega123/projecty/rider-manager"
           fi
 
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
@@ -202,7 +204,6 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
-          build-contexts: ${{ matrix.build_contexts }}
           platforms: linux/amd64
           tags: projecty/${{ matrix.image }}:ci-${{ github.sha }}
           outputs: type=oci,dest=artifacts/${{ matrix.image }}-oci,tar=false,oci-mediatypes=true

--- a/AuthGate/AuthGate/AuthGate.csproj
+++ b/AuthGate/AuthGate/AuthGate.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>b58724c6-b297-4724-8e57-1259ab94380a</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AuthGate/AuthGate/Dockerfile
+++ b/AuthGate/AuthGate/Dockerfile
@@ -1,14 +1,12 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS restore
 WORKDIR /src
 
-COPY AuthGate/AuthGate.csproj AuthGate/AuthGate/
+COPY AuthGate/AuthGate/AuthGate.csproj AuthGate/AuthGate/
 RUN dotnet restore AuthGate/AuthGate/AuthGate.csproj
 
 FROM restore AS publish
-COPY AuthGate/ AuthGate/AuthGate/
-COPY --from=shared Health/ Shared/Health/
-COPY --from=shared Hosting/ Shared/Hosting/
-COPY --from=shared Messaging/ Shared/Messaging/
+COPY AuthGate/AuthGate/ AuthGate/AuthGate/
+COPY Shared/ Shared/
 RUN dotnet publish AuthGate/AuthGate/AuthGate.csproj \
     --configuration Release \
     --output /app/publish \

--- a/MotoHub/MotoHub/Dockerfile
+++ b/MotoHub/MotoHub/Dockerfile
@@ -1,13 +1,12 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS restore
 WORKDIR /src
 
-COPY MotoHub/MotoHub.csproj MotoHub/MotoHub/
+COPY MotoHub/MotoHub/MotoHub.csproj MotoHub/MotoHub/
 RUN dotnet restore MotoHub/MotoHub/MotoHub.csproj
 
 FROM restore AS publish
-COPY MotoHub/ MotoHub/MotoHub/
-COPY --from=shared Health/ Shared/Health/
-COPY --from=shared Hosting/ Shared/Hosting/
+COPY MotoHub/MotoHub/ MotoHub/MotoHub/
+COPY Shared/ Shared/
 RUN dotnet publish MotoHub/MotoHub/MotoHub.csproj \
     --configuration Release \
     --output /app/publish \

--- a/MotoHub/MotoHub/MotoHub.csproj
+++ b/MotoHub/MotoHub/MotoHub.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>989b6433-41fd-4f8d-b301-26b9f15b6d49</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RentalOperations/RentalOperations/Dockerfile
+++ b/RentalOperations/RentalOperations/Dockerfile
@@ -1,13 +1,12 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS restore
 WORKDIR /src
 
-COPY RentalOperations/RentalOperations.csproj RentalOperations/RentalOperations/
+COPY RentalOperations/RentalOperations/RentalOperations.csproj RentalOperations/RentalOperations/
 RUN dotnet restore RentalOperations/RentalOperations/RentalOperations.csproj
 
 FROM restore AS publish
-COPY RentalOperations/ RentalOperations/RentalOperations/
-COPY --from=shared Health/ Shared/Health/
-COPY --from=shared Hosting/ Shared/Hosting/
+COPY RentalOperations/RentalOperations/ RentalOperations/RentalOperations/
+COPY Shared/ Shared/
 RUN dotnet publish RentalOperations/RentalOperations/RentalOperations.csproj \
     --configuration Release \
     --output /app/publish \

--- a/RentalOperations/RentalOperations/RentalOperations.csproj
+++ b/RentalOperations/RentalOperations/RentalOperations.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>13eefecb-1b21-4346-8676-bd8620044da4</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RiderManager/RiderManager/Dockerfile
+++ b/RiderManager/RiderManager/Dockerfile
@@ -1,14 +1,12 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS restore
 WORKDIR /src
 
-COPY RiderManager/RiderManager.csproj RiderManager/RiderManager/
+COPY RiderManager/RiderManager/RiderManager.csproj RiderManager/RiderManager/
 RUN dotnet restore RiderManager/RiderManager/RiderManager.csproj
 
 FROM restore AS publish
-COPY RiderManager/ RiderManager/RiderManager/
-COPY --from=shared Health/ Shared/Health/
-COPY --from=shared Hosting/ Shared/Hosting/
-COPY --from=shared Messaging/ Shared/Messaging/
+COPY RiderManager/RiderManager/ RiderManager/RiderManager/
+COPY Shared/ Shared/
 RUN dotnet publish RiderManager/RiderManager/RiderManager.csproj \
     --configuration Release \
     --output /app/publish \

--- a/RiderManager/RiderManager/RiderManager.csproj
+++ b/RiderManager/RiderManager/RiderManager.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>6c506916-5e52-4447-ade1-8bb27ba378f4</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,10 +114,8 @@ services:
 
   auth-gate:
     build:
-      context: ./AuthGate
-      dockerfile: AuthGate/Dockerfile
-      additional_contexts:
-        shared: ./Shared
+      context: .
+      dockerfile: AuthGate/AuthGate/Dockerfile
     container_name: auth-gate
     ports:
       - "8080:8080"
@@ -144,10 +142,8 @@ services:
   
   rider-manager:
     build:
-      context: ./RiderManager
-      dockerfile: RiderManager/Dockerfile
-      additional_contexts:
-        shared: ./Shared
+      context: .
+      dockerfile: RiderManager/RiderManager/Dockerfile
     container_name: rider-manager
     ports:
       - "8000:8000"
@@ -178,10 +174,8 @@ services:
 
   moto-hub:
     build:
-      context: ./MotoHub
-      dockerfile: MotoHub/Dockerfile
-      additional_contexts:
-        shared: ./Shared
+      context: .
+      dockerfile: MotoHub/MotoHub/Dockerfile
     container_name: moto-hub
     ports:
       - "8100:8100"
@@ -207,10 +201,8 @@ services:
   
   rental-operations:
     build:
-      context: ./RentalOperations
-      dockerfile: RentalOperations/Dockerfile
-      additional_contexts:
-        shared: ./Shared
+      context: .
+      dockerfile: RentalOperations/RentalOperations/Dockerfile
     container_name: rental-operations
     ports:
       - "8200:8200"

--- a/docs/security/container-image-scanning.md
+++ b/docs/security/container-image-scanning.md
@@ -6,16 +6,16 @@ builds all four. References in `deploy/overlays/selfhost/compose.yaml` whose
 build contexts do not yet exist are outside this gate until their Dockerfiles
 are added.
 
-Each current image uses its service directory as the primary build context. All four
-receive `Shared/` as a separate, read-only BuildKit named context, so the repository
-root and `.git/` are never sent to any build. The equivalent
-standalone commands are:
+Each current image uses the repository root as its build context, and the root
+`.dockerignore` limits that context to the four application projects and `Shared/`.
+This makes the Dockerfiles self-contained for Visual Studio and command-line builds
+without sending `.git/` or local secrets. The equivalent standalone commands are:
 
 ```bash
-docker build --build-context shared=./Shared -f AuthGate/AuthGate/Dockerfile -t projecty/auth-gate AuthGate
-docker build --build-context shared=./Shared -f MotoHub/MotoHub/Dockerfile -t projecty/moto-hub MotoHub
-docker build --build-context shared=./Shared -f RentalOperations/RentalOperations/Dockerfile -t projecty/rental-operations RentalOperations
-docker build --build-context shared=./Shared -f RiderManager/RiderManager/Dockerfile -t projecty/rider-manager RiderManager
+docker build -f AuthGate/AuthGate/Dockerfile -t projecty/auth-gate .
+docker build -f MotoHub/MotoHub/Dockerfile -t projecty/moto-hub .
+docker build -f RentalOperations/RentalOperations/Dockerfile -t projecty/rental-operations .
+docker build -f RiderManager/RiderManager/Dockerfile -t projecty/rider-manager .
 ```
 
 Local Linux/amd64 measurements after the chiseled-runtime rewrite:


### PR DESCRIPTION
## Summary
- makes all four service Dockerfiles use the repository root as a self-contained build context
- configures the Visual Studio Dockerfile profiles with `DockerfileContext=..\..`
- removes the named `shared` context requirement from Compose and CI
- adds a root `.dockerignore` that excludes repository metadata, secrets, tests, and unrelated files
- updates standalone build documentation

## Validation
- 79 local .NET tests passed
- `dotnet format --verify-no-changes` passed for all four solutions
- all four projects evaluate `DockerfileContext` as `..\..`
- every Dockerfile `COPY` source exists in the repository-root context
- `docker compose config --quiet` passed

Docker Desktop is unavailable locally, so the four actual image builds are delegated to the PR CI.

Progresses #95