### PR TITLE
feat(rentals): prevent concurrent double-booking

### DIFF
--- a/RentalOperations/RentalOperations/Controllers/RentalController.cs
+++ b/RentalOperations/RentalOperations/Controllers/RentalController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using RentalOperations.DTOs;
 using RentalOperations.Services;
 using RentalOperations.Filters;
+using RentalOperations.Domain;
 using System.Security.Claims;
 
 namespace RentalOperations.Controllers
@@ -32,6 +33,15 @@ namespace RentalOperations.Controllers
                 }
                 await _rentalService.CreateRentalAsync(createDto, userIdClaim.Value);
                 return Ok("Created with Success!");
+            }
+            catch (ActiveRentalConflictException ex)
+            {
+                return Conflict(new ProblemDetails
+                {
+                    Status = StatusCodes.Status409Conflict,
+                    Title = "Active rental conflict",
+                    Detail = ex.Message
+                });
             }
             catch (Exception ex)
             {

--- a/RentalOperations/RentalOperations/DTOs/ResponseRentalDTO.cs
+++ b/RentalOperations/RentalOperations/DTOs/ResponseRentalDTO.cs
@@ -7,7 +7,7 @@
         public string MotocycleLicencePlate { get; set; } = string.Empty;
         public DateTime StartDate { get; set; }
         public DateTime PredictedEndDate { get; set; }
-        public DateTime ActualEndDate { get; set; }
+        public DateTime? ActualEndDate { get; set; }
         public decimal OriginalTotalCost { get; set; }
         public decimal FinalTotalCost { get; set; }
         public decimal AdditionalCostsOrSavings { get; set; }

--- a/RentalOperations/RentalOperations/Data/MongoRentalIndexInitializer.cs
+++ b/RentalOperations/RentalOperations/Data/MongoRentalIndexInitializer.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Hosting;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using RentalOperations.Model;
+
+namespace RentalOperations.Data;
+
+public sealed class MongoRentalIndexInitializer : IHostedService
+{
+    public const string ActiveRentalIndexName = "ux_rentals_one_active_per_motorcycle";
+
+    private readonly MongoDbContext _context;
+
+    public MongoRentalIndexInitializer(MongoDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await ClassifyLegacyRentalsAsync(cancellationToken);
+
+        var rentals = _context.Database.GetCollection<Rental>("Rentals");
+        var index = new CreateIndexModel<Rental>(
+            Builders<Rental>.IndexKeys.Ascending(rental => rental.MotorcycleLicencePlate),
+            new CreateIndexOptions<Rental>
+            {
+                Name = ActiveRentalIndexName,
+                Unique = true,
+                PartialFilterExpression = Builders<Rental>.Filter.Eq(
+                    rental => rental.Status,
+                    RentalStatus.Active)
+            });
+
+        await rentals.Indexes.CreateOneAsync(index, cancellationToken: cancellationToken);
+    }
+
+    private async Task ClassifyLegacyRentalsAsync(CancellationToken cancellationToken)
+    {
+        var rentals = _context.Database.GetCollection<BsonDocument>("Rentals");
+        var missingStatus = Builders<BsonDocument>.Filter.Exists("status", false);
+        var openRental = Builders<BsonDocument>.Filter.Or(
+            Builders<BsonDocument>.Filter.Exists("endDate", false),
+            Builders<BsonDocument>.Filter.Eq("endDate", BsonNull.Value),
+            Builders<BsonDocument>.Filter.Eq("endDate", DateTime.MinValue));
+
+        await rentals.UpdateManyAsync(
+            Builders<BsonDocument>.Filter.And(missingStatus, openRental),
+            Builders<BsonDocument>.Update
+                .Set("status", RentalStatus.Active.ToString())
+                .Unset("endDate"),
+            cancellationToken: cancellationToken);
+
+        await rentals.UpdateManyAsync(
+            Builders<BsonDocument>.Filter.And(
+                missingStatus,
+                Builders<BsonDocument>.Filter.Gt("endDate", DateTime.MinValue)),
+            Builders<BsonDocument>.Update.Set("status", RentalStatus.Completed.ToString()),
+            cancellationToken: cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/RentalOperations/RentalOperations/Data/MongoRentalIndexInitializer.cs
+++ b/RentalOperations/RentalOperations/Data/MongoRentalIndexInitializer.cs
@@ -8,6 +8,8 @@ namespace RentalOperations.Data;
 public sealed class MongoRentalIndexInitializer : IHostedService
 {
     public const string ActiveRentalIndexName = "ux_rentals_one_active_per_motorcycle";
+    public const string LegacyDuplicateQuarantineMessage =
+        "Quarantined during active-rental index migration: duplicate open rental; review required.";
 
     private readonly MongoDbContext _context;
 
@@ -19,6 +21,7 @@ public sealed class MongoRentalIndexInitializer : IHostedService
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         await ClassifyLegacyRentalsAsync(cancellationToken);
+        await QuarantineDuplicateActiveRentalsAsync(cancellationToken);
 
         var rentals = _context.Database.GetCollection<Rental>("Rentals");
         var index = new CreateIndexModel<Rental>(
@@ -57,6 +60,40 @@ public sealed class MongoRentalIndexInitializer : IHostedService
                 Builders<BsonDocument>.Filter.Gt("endDate", DateTime.MinValue)),
             Builders<BsonDocument>.Update.Set("status", RentalStatus.Completed.ToString()),
             cancellationToken: cancellationToken);
+    }
+
+    private async Task QuarantineDuplicateActiveRentalsAsync(CancellationToken cancellationToken)
+    {
+        var rentals = _context.Database.GetCollection<BsonDocument>("Rentals");
+        var duplicateGroups = await rentals.Aggregate()
+            .Match(new BsonDocument("status", RentalStatus.Active.ToString()))
+            .Sort(new BsonDocument
+            {
+                ["MotorcycleLicencePlate"] = 1,
+                ["startDate"] = 1,
+                ["_id"] = 1
+            })
+            .Group(new BsonDocument
+            {
+                ["_id"] = "$MotorcycleLicencePlate",
+                ["rentalIds"] = new BsonDocument("$push", "$_id"),
+                ["count"] = new BsonDocument("$sum", 1)
+            })
+            .Match(new BsonDocument("count", new BsonDocument("$gt", 1)))
+            .ToListAsync(cancellationToken);
+
+        foreach (var group in duplicateGroups)
+        {
+            var duplicateIds = group["rentalIds"].AsBsonArray.Skip(1);
+            var filter = Builders<BsonDocument>.Filter.And(
+                Builders<BsonDocument>.Filter.In("_id", duplicateIds),
+                Builders<BsonDocument>.Filter.Eq("status", RentalStatus.Active.ToString()));
+            var update = Builders<BsonDocument>.Update
+                .Set("status", RentalStatus.Quarantined.ToString())
+                .Set("statusMessage", LegacyDuplicateQuarantineMessage);
+
+            await rentals.UpdateManyAsync(filter, update, cancellationToken: cancellationToken);
+        }
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/RentalOperations/RentalOperations/Domain/ActiveRentalConflictException.cs
+++ b/RentalOperations/RentalOperations/Domain/ActiveRentalConflictException.cs
@@ -1,0 +1,9 @@
+namespace RentalOperations.Domain;
+
+public sealed class ActiveRentalConflictException : Exception
+{
+    public ActiveRentalConflictException(string licencePlate, Exception? innerException = null)
+        : base($"Motorcycle {licencePlate} already has an active rental.", innerException)
+    {
+    }
+}

--- a/RentalOperations/RentalOperations/Domain/RentalDomain.cs
+++ b/RentalOperations/RentalOperations/Domain/RentalDomain.cs
@@ -7,7 +7,7 @@ namespace RentalOperations.Domain
         public string MotocycleLicencePlate { get; private set; } = string.Empty;
         public string UserId { get; private set; } = string.Empty;
         public DateTime StartDate { get; private set; }
-        public DateTime EndDate { get; private set; }
+        public DateTime? EndDate { get; private set; }
         public DateTime PredictedEndDate { get; private set; }
         public decimal TotalCost { get; private set; }
 
@@ -22,7 +22,7 @@ namespace RentalOperations.Domain
                 MotocycleLicencePlate = dto.MotocycleLicencePlate,
                 UserId = userId,
                 StartDate = dto.StartDate,
-                EndDate = DateTime.MinValue,
+                EndDate = null,
                 PredictedEndDate = dto.PredictedEndDate,
                 TotalCost = CalculateTotalCost(dto.StartDate, dto.PredictedEndDate)
             };

--- a/RentalOperations/RentalOperations/Domain/RentalPeriod.cs
+++ b/RentalOperations/RentalOperations/Domain/RentalPeriod.cs
@@ -1,0 +1,20 @@
+using RentalOperations.Model;
+
+namespace RentalOperations.Domain;
+
+public static class RentalPeriod
+{
+    public static bool Overlaps(
+        Rental rental,
+        DateTime requestedStart,
+        DateTime requestedEnd)
+    {
+        if (rental.Status == RentalStatus.Cancelled)
+        {
+            return false;
+        }
+
+        var existingEnd = rental.EndDate ?? rental.PredictedEndDate;
+        return requestedStart < existingEnd && requestedEnd > rental.StartDate;
+    }
+}

--- a/RentalOperations/RentalOperations/Domain/RentalPeriod.cs
+++ b/RentalOperations/RentalOperations/Domain/RentalPeriod.cs
@@ -9,7 +9,7 @@ public static class RentalPeriod
         DateTime requestedStart,
         DateTime requestedEnd)
     {
-        if (rental.Status == RentalStatus.Cancelled)
+        if (rental.Status is RentalStatus.Cancelled or RentalStatus.Quarantined)
         {
             return false;
         }

--- a/RentalOperations/RentalOperations/Mapper/RentalProfile.cs
+++ b/RentalOperations/RentalOperations/Mapper/RentalProfile.cs
@@ -1,5 +1,4 @@
 ﻿using AutoMapper;
-using MongoDB.Bson;
 using RentalOperations.DTOs;
 using RentalOperations.Model;
 
@@ -25,17 +24,6 @@ namespace RentalOperations.Mapper
             .ForMember(dest => dest.StatusMessage, opt => opt.MapFrom(src => src.StatusMessage))
             .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.UserId));
 
-            CreateMap<ResponseRentalDTO, Rental>()
-            .ForMember(dest => dest._id, opt => opt.MapFrom(src => new ObjectId(src.RentalId)))
-            .ForMember(dest => dest.MotorcycleLicencePlate, opt => opt.MapFrom(src => src.MotocycleLicencePlate))
-            .ForMember(dest => dest.StartDate, opt => opt.MapFrom(src => src.StartDate))
-            .ForMember(dest => dest.EndDate, opt => opt.MapFrom(src => src.ActualEndDate))
-            .ForMember(dest => dest.PredictedEndDate, opt => opt.MapFrom(src => src.PredictedEndDate))
-            .ForMember(dest => dest.InitCost, opt => opt.MapFrom(src => src.OriginalTotalCost))
-            .ForMember(dest => dest.FinalCost, opt => opt.MapFrom(src => src.FinalTotalCost))
-            .ForMember(dest => dest.AdditionalCostsOrSavings, opt => opt.MapFrom(src => src.AdditionalCostsOrSavings))
-            .ForMember(dest => dest.StatusMessage, opt => opt.MapFrom(src => src.StatusMessage))
-            .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.UserId));
         }
     }
 }

--- a/RentalOperations/RentalOperations/Model/Rental.cs
+++ b/RentalOperations/RentalOperations/Model/Rental.cs
@@ -20,7 +20,8 @@ namespace RentalOperations.Model
         public DateTime StartDate { get; set; }
 
         [BsonElement("endDate")]
-        public DateTime EndDate { get; set; }
+        [BsonIgnoreIfNull]
+        public DateTime? EndDate { get; set; }
 
         [BsonElement("predictedEndDate")]
         public DateTime PredictedEndDate { get; set; }
@@ -36,6 +37,10 @@ namespace RentalOperations.Model
 
         [BsonElement("statusMessage")]
         public string StatusMessage { get; set; } = string.Empty;
+
+        [BsonElement("status")]
+        [BsonRepresentation(BsonType.String)]
+        public RentalStatus Status { get; set; } = RentalStatus.Active;
 
         public Rental()
         {

--- a/RentalOperations/RentalOperations/Model/RentalStatus.cs
+++ b/RentalOperations/RentalOperations/Model/RentalStatus.cs
@@ -4,5 +4,6 @@ public enum RentalStatus
 {
     Active,
     Completed,
-    Cancelled
+    Cancelled,
+    Quarantined
 }

--- a/RentalOperations/RentalOperations/Model/RentalStatus.cs
+++ b/RentalOperations/RentalOperations/Model/RentalStatus.cs
@@ -1,0 +1,8 @@
+namespace RentalOperations.Model;
+
+public enum RentalStatus
+{
+    Active,
+    Completed,
+    Cancelled
+}

--- a/RentalOperations/RentalOperations/Program.cs
+++ b/RentalOperations/RentalOperations/Program.cs
@@ -53,6 +53,7 @@ builder.Services
     .AddTcpDependency("rabbitmq", rabbitMQConfig?.HostName ?? "rabbitmq", 5672);
 builder.Services.AddSingleton<MongoDbContext>(sp =>
     new MongoDbContext(mongoDbSettings["ConnectionString"], mongoDbSettings["DatabaseName"]));
+builder.Services.AddHostedService<MongoRentalIndexInitializer>();
 builder.Services.AddAuthentication(options =>
 {
     options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;

--- a/RentalOperations/RentalOperations/Repository/RentalRepository.cs
+++ b/RentalOperations/RentalOperations/Repository/RentalRepository.cs
@@ -1,6 +1,7 @@
 ﻿using MongoDB.Bson;
 using MongoDB.Driver;
 using RentalOperations.Data;
+using RentalOperations.Domain;
 using RentalOperations.Model;
 
 namespace RentalOperations.Repository
@@ -16,7 +17,16 @@ namespace RentalOperations.Repository
 
         public async Task<Rental> CreateRentalAsync(Rental rental)
         {
-            await _rentals.InsertOneAsync(rental);
+            try
+            {
+                await _rentals.InsertOneAsync(rental);
+            }
+            catch (MongoWriteException exception)
+                when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+            {
+                throw new ActiveRentalConflictException(rental.MotorcycleLicencePlate, exception);
+            }
+
             return rental;
         }
 
@@ -41,7 +51,10 @@ namespace RentalOperations.Repository
             var today = DateTime.UtcNow;
             var rentals = await _rentals.Find(r => r.MotorcycleLicencePlate == licencePlate).ToListAsync();
 
-            return rentals.Any(r => r.StartDate <= today && (r.EndDate > r.StartDate ? r.EndDate : r.PredictedEndDate) >= today);
+            return rentals.Any(r =>
+                r.Status == RentalStatus.Active &&
+                r.StartDate <= today &&
+                r.PredictedEndDate >= today);
         }
 
         public async Task UpdateRentalAsync(Rental rental)

--- a/RentalOperations/RentalOperations/Services/RentalService.cs
+++ b/RentalOperations/RentalOperations/Services/RentalService.cs
@@ -35,12 +35,12 @@ namespace RentalOperations.Services
             }
 
             var existingRentals = await _repository.GetRentalsByMotorcycleIdAsync(createDto.MotocycleLicencePlate);
-            foreach (var rent in existingRentals)
+            if (existingRentals.Any(rent => RentalPeriod.Overlaps(
+                rent,
+                createDto.StartDate,
+                createDto.PredictedEndDate)))
             {
-                if (createDto.StartDate < rent.EndDate || createDto.PredictedEndDate > rent.StartDate)
-                {
-                    throw new InvalidOperationException("This motorcycle is already rented for the requested period.");
-                }
+                throw new ActiveRentalConflictException(createDto.MotocycleLicencePlate);
             }
 
             var rider = await _riderManagerService.GetRiderByIdAsync(userId);
@@ -83,7 +83,7 @@ namespace RentalOperations.Services
             if (!string.Equals(rental.UserId, userId, StringComparison.Ordinal))
                 throw new UnauthorizedAccessException("The rental belongs to another rider.");
 
-            if (rental.FinalCost > 0)
+            if (rental.Status == RentalStatus.Completed)
                 return _mapper.Map<ResponseRentalDTO>(rental);
 
             var response = _mapper.Map<ResponseRentalDTO>(rental);
@@ -112,8 +112,12 @@ namespace RentalOperations.Services
 
             response.FinalTotalCost = response.OriginalTotalCost + response.AdditionalCostsOrSavings;
 
-            var updateRent = _mapper.Map<Rental>(response);
-            await _repository.UpdateRentalAsync(updateRent);
+            rental.EndDate = actualEndDate;
+            rental.FinalCost = response.FinalTotalCost;
+            rental.AdditionalCostsOrSavings = response.AdditionalCostsOrSavings;
+            rental.StatusMessage = response.StatusMessage;
+            rental.Status = RentalStatus.Completed;
+            await _repository.UpdateRentalAsync(rental);
             return response;
         }
 

--- a/RentalOperations/RentalOperationsTests/Integration/AdminAuthorizationPipelineTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/AdminAuthorizationPipelineTests.cs
@@ -83,7 +83,7 @@ public class AdminAuthorizationPipelineTests : IClassFixture<CustomWebApplicatio
         });
         var rentalId = original._id!.Value.ToString();
         using var client = CreateClient("Rider", "rider-b");
-        var actualEndDate = Uri.EscapeDataString(original.EndDate.ToString("O"));
+        var actualEndDate = Uri.EscapeDataString(original.EndDate!.Value.ToString("O"));
 
         var response = await client.PostAsync(
             $"/api/Rental/calculate-final-cost?rentalId={rentalId}&actualEndDate={actualEndDate}",

--- a/RentalOperations/RentalOperationsTests/Integration/InMemoryRentalRepository.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/InMemoryRentalRepository.cs
@@ -59,8 +59,9 @@ public sealed class InMemoryRentalRepository : IRentalRepository
         var now = DateTime.UtcNow;
         return Task.FromResult(_rentals.Values.Any(rental =>
             rental.MotorcycleLicencePlate == licencePlate &&
+            rental.Status == RentalStatus.Active &&
             rental.StartDate <= now &&
-            (rental.EndDate > rental.StartDate ? rental.EndDate : rental.PredictedEndDate) >= now));
+            rental.PredictedEndDate >= now));
     }
 
     public Task UpdateRentalAsync(Rental rental)
@@ -104,6 +105,7 @@ public sealed class InMemoryRentalRepository : IRentalRepository
         InitCost = rental.InitCost,
         FinalCost = rental.FinalCost,
         AdditionalCostsOrSavings = rental.AdditionalCostsOrSavings,
-        StatusMessage = rental.StatusMessage
+        StatusMessage = rental.StatusMessage,
+        Status = rental.Status
     };
 }

--- a/RentalOperations/RentalOperationsTests/Integration/MongoDb/ActiveRentalApiTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/MongoDb/ActiveRentalApiTests.cs
@@ -1,0 +1,292 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.Tokens;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using RentalOperations.CrossCutting.Model;
+using RentalOperations.CrossCutting.Services;
+using RentalOperations.Data;
+using RentalOperations.DTOs;
+using RentalOperations.Model;
+using RentalOperations.Repository;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using Testcontainers.MongoDb;
+
+namespace RentalOperationsTests.Integration.MongoDb;
+
+public sealed class ActiveRentalApiTests : IAsyncLifetime
+{
+    private const string DatabaseName = "rental_concurrency_tests";
+    private readonly MongoDbContainer _database = new MongoDbBuilder("mongo:8.0").Build();
+    private MongoRentalApiFactory? _factory;
+
+    public async Task InitializeAsync()
+    {
+        await _database.StartAsync();
+        var rentals = new MongoClient(_database.GetConnectionString())
+            .GetDatabase(DatabaseName)
+            .GetCollection<BsonDocument>("Rentals");
+        await rentals.InsertOneAsync(new BsonDocument
+        {
+            ["MotorcycleLicencePlate"] = "LEGACY-0001",
+            ["userId"] = "legacy-rider",
+            ["startDate"] = DateTime.UtcNow.Date.AddDays(-7),
+            ["endDate"] = DateTime.MinValue,
+            ["predictedEndDate"] = DateTime.UtcNow.Date.AddDays(7),
+            ["initCost"] = 210m
+        });
+        _factory = new MongoRentalApiFactory(_database.GetConnectionString(), DatabaseName);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+        }
+
+        await _database.DisposeAsync();
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ConcurrentCreateRequestsForSameMotorcycle_OneSucceedsAndOneReturnsConflict()
+    {
+        using var client = CreateAuthenticatedClient();
+        var request = new RentalCreateDto
+        {
+            MotocycleLicencePlate = "RACE-0001",
+            StartDate = DateTime.UtcNow.Date.AddDays(1),
+            PredictedEndDate = DateTime.UtcNow.Date.AddDays(8)
+        };
+
+        var responses = await Task.WhenAll(
+            client.PostAsJsonAsync("/api/Rental/create", request),
+            client.PostAsJsonAsync("/api/Rental/create", request));
+
+        Assert.Single(responses, response => response.StatusCode == HttpStatusCode.OK);
+        Assert.Single(responses, response => response.StatusCode == HttpStatusCode.Conflict);
+
+        var rentals = new MongoClient(_database.GetConnectionString())
+            .GetDatabase(DatabaseName)
+            .GetCollection<Rental>("Rentals");
+        var activeRentals = await rentals.CountDocumentsAsync(
+            rental => rental.MotorcycleLicencePlate == request.MotocycleLicencePlate &&
+                      rental.Status == RentalStatus.Active);
+        var persisted = await rentals.Find(
+                rental => rental.MotorcycleLicencePlate == request.MotocycleLicencePlate)
+            .SingleAsync();
+
+        Assert.Equal(1, activeRentals);
+        Assert.Null(persisted.EndDate);
+
+        var legacyRental = await rentals.Find(rental =>
+                rental.MotorcycleLicencePlate == "LEGACY-0001")
+            .SingleAsync();
+        Assert.Equal(RentalStatus.Active, legacyRental.Status);
+        Assert.Null(legacyRental.EndDate);
+
+        var indexes = await (await rentals.Indexes.ListAsync()).ToListAsync();
+        Assert.Contains(indexes, index =>
+            index["name"] == MongoRentalIndexInitializer.ActiveRentalIndexName &&
+            index["unique"].AsBoolean);
+
+        var actualEndDate = Uri.EscapeDataString(request.PredictedEndDate.ToString("O"));
+        var completion = await client.PostAsync(
+            $"/api/Rental/calculate-final-cost?rentalId={persisted._id!.Value}&actualEndDate={actualEndDate}",
+            content: null);
+        Assert.Equal(HttpStatusCode.OK, completion.StatusCode);
+
+        var nextRental = new RentalCreateDto
+        {
+            MotocycleLicencePlate = request.MotocycleLicencePlate,
+            StartDate = request.PredictedEndDate,
+            PredictedEndDate = request.PredictedEndDate.AddDays(7)
+        };
+        var nextResponse = await client.PostAsJsonAsync("/api/Rental/create", nextRental);
+
+        Assert.Equal(HttpStatusCode.OK, nextResponse.StatusCode);
+        Assert.Equal(2, await rentals.CountDocumentsAsync(
+            rental => rental.MotorcycleLicencePlate == request.MotocycleLicencePlate));
+        Assert.Equal(1, await rentals.CountDocumentsAsync(
+            rental => rental.MotorcycleLicencePlate == request.MotocycleLicencePlate &&
+                      rental.Status == RentalStatus.Active));
+    }
+
+    private HttpClient CreateAuthenticatedClient()
+    {
+        var factory = _factory ?? throw new InvalidOperationException("The test database has not started.");
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("https://localhost")
+        });
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            CreateToken("Rider", "rider-1"));
+        return client;
+    }
+
+    private static string CreateToken(string role, string userId)
+    {
+        var credentials = new SigningCredentials(
+            new SymmetricSecurityKey(Encoding.UTF8.GetBytes(MongoRentalApiFactory.JwtKey)),
+            SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            issuer: "projecty.auth-gate",
+            audience: "projecty.rental-operations",
+            claims:
+            [
+                new Claim(ClaimTypes.NameIdentifier, userId),
+                new Claim(ClaimTypes.Role, role)
+            ],
+            expires: DateTime.UtcNow.AddMinutes(5),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}
+
+internal sealed class MongoRentalApiFactory : WebApplicationFactory<Program>
+{
+    public const string JwtKey = "test-only-key-with-at-least-32-bytes";
+    private readonly string _connectionString;
+    private readonly string _databaseName;
+
+    public MongoRentalApiFactory(string connectionString, string databaseName)
+    {
+        _connectionString = connectionString;
+        _databaseName = databaseName;
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.ConfigureAppConfiguration((_, configuration) =>
+        {
+            configuration.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:SigningKey"] = JwtKey,
+                ["Jwt:Issuer"] = "projecty.auth-gate",
+                ["Jwt:Audience"] = "projecty.rental-operations",
+                ["MongoDbSettings:ConnectionString"] = _connectionString,
+                ["MongoDbSettings:DatabaseName"] = _databaseName
+            });
+        });
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll<IHostedService>();
+            services.RemoveAll<MongoDbContext>();
+            services.RemoveAll<IRentalRepository>();
+            services.RemoveAll<IRiderManagerService>();
+            services.RemoveAll<IMotorcycleService>();
+
+            services.AddSingleton(new MongoDbContext(_connectionString, _databaseName));
+            services.AddScoped<RentalRepository>();
+            services.AddSingleton<ConcurrentCreateGate>();
+            services.AddScoped<IRentalRepository>(provider => new SynchronizingRentalRepository(
+                provider.GetRequiredService<RentalRepository>(),
+                provider.GetRequiredService<ConcurrentCreateGate>()));
+            services.AddSingleton<IRiderManagerService, StubRiderManagerService>();
+            services.AddSingleton<IMotorcycleService, StubMotorcycleService>();
+            services.AddHostedService<MongoRentalIndexInitializer>();
+
+            services.PostConfigure<JwtBearerOptions>(
+                JwtBearerDefaults.AuthenticationScheme,
+                options =>
+                {
+                    options.TokenValidationParameters = new TokenValidationParameters
+                    {
+                        ValidateIssuerSigningKey = true,
+                        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(JwtKey)),
+                        ValidateIssuer = true,
+                        ValidIssuer = "projecty.auth-gate",
+                        ValidateAudience = true,
+                        ValidAudience = "projecty.rental-operations"
+                    };
+                });
+        });
+    }
+}
+
+internal sealed class ConcurrentCreateGate
+{
+    private readonly TaskCompletionSource _bothRequestsReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _remainingRequests = 2;
+
+    public async Task WaitAsync()
+    {
+        if (Interlocked.Decrement(ref _remainingRequests) == 0)
+        {
+            _bothRequestsReady.TrySetResult();
+        }
+
+        await _bothRequestsReady.Task.WaitAsync(TimeSpan.FromSeconds(10));
+    }
+}
+
+internal sealed class SynchronizingRentalRepository : IRentalRepository
+{
+    private readonly RentalRepository _repository;
+    private readonly ConcurrentCreateGate _gate;
+
+    public SynchronizingRentalRepository(RentalRepository repository, ConcurrentCreateGate gate)
+    {
+        _repository = repository;
+        _gate = gate;
+    }
+
+    public async Task<Rental> CreateRentalAsync(Rental rental)
+    {
+        await _gate.WaitAsync();
+        return await _repository.CreateRentalAsync(rental);
+    }
+
+    public Task<Rental> GetRentalByIdAsync(string id) => _repository.GetRentalByIdAsync(id);
+
+    public Task<List<Rental>> GetRentalsByUserId(string userId) =>
+        _repository.GetRentalsByUserId(userId);
+
+    public Task<List<Rental>> GetRentalsByMotorcycleIdAsync(string licencePlate) =>
+        _repository.GetRentalsByMotorcycleIdAsync(licencePlate);
+
+    public Task<bool> IsMotorcycleCurrentlyRentedAsync(string licencePlate) =>
+        _repository.IsMotorcycleCurrentlyRentedAsync(licencePlate);
+
+    public Task UpdateRentalAsync(Rental rental) => _repository.UpdateRentalAsync(rental);
+
+    public Task UpdateLicensePlateForAllRentalsAsync(string oldLicensePlate, string newLicensePlate) =>
+        _repository.UpdateLicensePlateForAllRentalsAsync(oldLicensePlate, newLicensePlate);
+
+    public Task DeleteRentalAsync(string id) => _repository.DeleteRentalAsync(id);
+}
+
+internal sealed class StubRiderManagerService : IRiderManagerService
+{
+    public Task<Rider> GetRiderByIdAsync(string riderId) => Task.FromResult(new Rider
+    {
+        Id = riderId,
+        UserId = riderId,
+        CNHType = "A"
+    });
+}
+
+internal sealed class StubMotorcycleService : IMotorcycleService
+{
+    public Task<Motorcycle> GetMotorcycleByIdAsync(string motorcycleId) => Task.FromResult(new Motorcycle
+    {
+        licensePlate = motorcycleId,
+        model = "Concurrency test",
+        year = 2026
+    });
+}

--- a/RentalOperations/RentalOperationsTests/Integration/MongoDb/ActiveRentalApiTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/MongoDb/ActiveRentalApiTests.cs
@@ -36,15 +36,11 @@ public sealed class ActiveRentalApiTests : IAsyncLifetime
         var rentals = new MongoClient(_database.GetConnectionString())
             .GetDatabase(DatabaseName)
             .GetCollection<BsonDocument>("Rentals");
-        await rentals.InsertOneAsync(new BsonDocument
-        {
-            ["MotorcycleLicencePlate"] = "LEGACY-0001",
-            ["userId"] = "legacy-rider",
-            ["startDate"] = DateTime.UtcNow.Date.AddDays(-7),
-            ["endDate"] = DateTime.MinValue,
-            ["predictedEndDate"] = DateTime.UtcNow.Date.AddDays(7),
-            ["initCost"] = 210m
-        });
+        await rentals.InsertManyAsync(
+        [
+            CreateLegacyOpenRental("legacy-rider-1", DateTime.UtcNow.Date.AddDays(-14)),
+            CreateLegacyOpenRental("legacy-rider-2", DateTime.UtcNow.Date.AddDays(-7))
+        ]);
         _factory = new MongoRentalApiFactory(_database.GetConnectionString(), DatabaseName);
     }
 
@@ -90,11 +86,17 @@ public sealed class ActiveRentalApiTests : IAsyncLifetime
         Assert.Equal(1, activeRentals);
         Assert.Null(persisted.EndDate);
 
-        var legacyRental = await rentals.Find(rental =>
+        var legacyRentals = await rentals.Find(rental =>
                 rental.MotorcycleLicencePlate == "LEGACY-0001")
-            .SingleAsync();
-        Assert.Equal(RentalStatus.Active, legacyRental.Status);
-        Assert.Null(legacyRental.EndDate);
+            .SortBy(rental => rental.StartDate)
+            .ToListAsync();
+        Assert.Equal(2, legacyRentals.Count);
+        Assert.Equal(RentalStatus.Active, legacyRentals[0].Status);
+        Assert.Equal(RentalStatus.Quarantined, legacyRentals[1].Status);
+        Assert.Equal(
+            MongoRentalIndexInitializer.LegacyDuplicateQuarantineMessage,
+            legacyRentals[1].StatusMessage);
+        Assert.All(legacyRentals, rental => Assert.Null(rental.EndDate));
 
         var indexes = await (await rentals.Indexes.ListAsync()).ToListAsync();
         Assert.Contains(indexes, index =>
@@ -136,6 +138,16 @@ public sealed class ActiveRentalApiTests : IAsyncLifetime
             CreateToken("Rider", "rider-1"));
         return client;
     }
+
+    private static BsonDocument CreateLegacyOpenRental(string userId, DateTime startDate) => new()
+    {
+        ["MotorcycleLicencePlate"] = "LEGACY-0001",
+        ["userId"] = userId,
+        ["startDate"] = startDate,
+        ["endDate"] = DateTime.MinValue,
+        ["predictedEndDate"] = DateTime.UtcNow.Date.AddDays(7),
+        ["initCost"] = 210m
+    };
 
     private static string CreateToken(string role, string userId)
     {

--- a/RentalOperations/RentalOperationsTests/RentalOperationsTests.csproj
+++ b/RentalOperations/RentalOperationsTests/RentalOperationsTests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Npgsql" Version="10.0.3" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.14.0" />
+    <PackageReference Include="Testcontainers.MongoDb" Version="4.14.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>

--- a/RentalOperations/RentalOperationsTests/Unit/Domain/RentalPeriodTests.cs
+++ b/RentalOperations/RentalOperationsTests/Unit/Domain/RentalPeriodTests.cs
@@ -1,0 +1,69 @@
+using RentalOperations.Domain;
+using RentalOperations.Model;
+
+namespace RentalOperationsTests.Unit.Domain;
+
+public sealed class RentalPeriodTests
+{
+    private static readonly DateTime ExistingStart = new(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime ExistingEnd = new(2026, 8, 8, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void Overlaps_WhenRequestedPeriodIntersectsActiveRental_ReturnsTrue()
+    {
+        var rental = CreateRental(RentalStatus.Active);
+
+        var overlaps = RentalPeriod.Overlaps(
+            rental,
+            ExistingStart.AddDays(1),
+            ExistingEnd.AddDays(1));
+
+        Assert.True(overlaps);
+    }
+
+    [Fact]
+    public void Overlaps_WhenRequestedRentalStartsAtPreviousEnd_ReturnsFalse()
+    {
+        var rental = CreateRental(RentalStatus.Completed, ExistingEnd);
+
+        var overlaps = RentalPeriod.Overlaps(
+            rental,
+            ExistingEnd,
+            ExistingEnd.AddDays(7));
+
+        Assert.False(overlaps);
+    }
+
+    [Fact]
+    public void Overlaps_WhenRequestedRentalEndsAtNextStart_ReturnsFalse()
+    {
+        var rental = CreateRental(RentalStatus.Active);
+
+        var overlaps = RentalPeriod.Overlaps(
+            rental,
+            ExistingStart.AddDays(-7),
+            ExistingStart);
+
+        Assert.False(overlaps);
+    }
+
+    [Fact]
+    public void Overlaps_WhenExistingRentalWasCancelled_ReturnsFalse()
+    {
+        var rental = CreateRental(RentalStatus.Cancelled);
+
+        var overlaps = RentalPeriod.Overlaps(rental, ExistingStart, ExistingEnd);
+
+        Assert.False(overlaps);
+    }
+
+    private static Rental CreateRental(RentalStatus status, DateTime? endDate = null) => new()
+    {
+        MotorcycleLicencePlate = "TEST-0001",
+        UserId = "rider-1",
+        StartDate = ExistingStart,
+        PredictedEndDate = ExistingEnd,
+        EndDate = endDate,
+        Status = status
+    };
+}

--- a/RentalOperations/RentalOperationsTests/Unit/Domain/RentalPeriodTests.cs
+++ b/RentalOperations/RentalOperationsTests/Unit/Domain/RentalPeriodTests.cs
@@ -47,10 +47,12 @@ public sealed class RentalPeriodTests
         Assert.False(overlaps);
     }
 
-    [Fact]
-    public void Overlaps_WhenExistingRentalWasCancelled_ReturnsFalse()
+    [Theory]
+    [InlineData(RentalStatus.Cancelled)]
+    [InlineData(RentalStatus.Quarantined)]
+    public void Overlaps_WhenExistingRentalIsUnavailableForScheduling_ReturnsFalse(RentalStatus status)
     {
-        var rental = CreateRental(RentalStatus.Cancelled);
+        var rental = CreateRental(status);
 
         var overlaps = RentalPeriod.Overlaps(rental, ExistingStart, ExistingEnd);
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,12 @@ services:
       - mongo-data:/data/db
     networks:
       - elk
+    healthcheck:
+      test: ["CMD-SHELL", "mongosh --quiet --username \"$${MONGO_INITDB_ROOT_USERNAME}\" --password \"$${MONGO_INITDB_ROOT_PASSWORD}\" --authenticationDatabase admin --eval \"db.adminCommand('ping').ok\""]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
 
   rabbitmq:
     image: rabbitmq:3-management
@@ -294,6 +300,8 @@ services:
       retries: 6
       start_period: 10s
     depends_on:
+      mongodb:
+        condition: service_healthy
       rabbitmq:
         condition: service_healthy
 


### PR DESCRIPTION
## Summary

- replace the `DateTime.MinValue` end-date sentinel with nullable `EndDate` and an explicit rental status
- fix overlap detection to use half-open period intersection, allowing a rental to start when the previous one ends
- classify legacy documents, keep the oldest active rental per motorcycle, and quarantine duplicate open rentals before creating the unique partial MongoDB index
- translate duplicate-key races into a domain conflict and HTTP 409
- make Compose wait for authenticated MongoDB readiness before RentalOperations starts
- add boundary unit tests and a synchronized concurrent API test backed by a real MongoDB Testcontainer

## Validation

- `dotnet restore RentalOperations/RentalOperations.sln`
- `dotnet build RentalOperations/RentalOperations.sln --no-restore`
- `dotnet test RentalOperations/RentalOperations.sln --no-build --no-restore --filter "Category!=Integration"` (13 passed)
- `dotnet format RentalOperations/RentalOperations.sln --verify-no-changes --no-restore`
- `git diff --check`
- MongoDB/PostgreSQL Testcontainers and Compose validation run in CI because Docker is unavailable locally

Closes #52