### PR TITLE
feat: add transactional outbox for reliable events

### DIFF
--- a/AuthGate/AuthGate/AuthGate.csproj
+++ b/AuthGate/AuthGate/AuthGate.csproj
@@ -39,6 +39,14 @@
     <Compile Include="..\..\Shared\Hosting\SwaggerPolicy.cs" Link="Shared\Hosting\SwaggerPolicy.cs" />
     <Compile Include="..\..\Shared\Hosting\DatabaseMigrationCommand.cs" Link="Shared\Hosting\DatabaseMigrationCommand.cs" />
     <Compile Include="..\..\Shared\Messaging\QueueMessageAuthenticator.cs" Link="Shared\Messaging\QueueMessageAuthenticator.cs" />
+    <Compile Include="..\..\Shared\Messaging\IOutboxTransport.cs" Link="Shared\Messaging\IOutboxTransport.cs" />
+    <Compile Include="..\..\Shared\Messaging\IRabbitMqConnectionProvider.cs" Link="Shared\Messaging\IRabbitMqConnectionProvider.cs" />
+    <Compile Include="..\..\Shared\Messaging\OutboxMessage.cs" Link="Shared\Messaging\OutboxMessage.cs" />
+    <Compile Include="..\..\Shared\Messaging\OutboxMetricsEndpoint.cs" Link="Shared\Messaging\OutboxMetricsEndpoint.cs" />
+    <Compile Include="..\..\Shared\Messaging\OutboxModelBuilderExtensions.cs" Link="Shared\Messaging\OutboxModelBuilderExtensions.cs" />
+    <Compile Include="..\..\Shared\Messaging\OutboxRelay.cs" Link="Shared\Messaging\OutboxRelay.cs" />
+    <Compile Include="..\..\Shared\Messaging\OutboxRelayOptions.cs" Link="Shared\Messaging\OutboxRelayOptions.cs" />
+    <Compile Include="..\..\Shared\Messaging\RabbitMqOutboxTransport.cs" Link="Shared\Messaging\RabbitMqOutboxTransport.cs" />
   </ItemGroup>
   
 </Project>

--- a/AuthGate/AuthGate/Controllers/AuthController.cs
+++ b/AuthGate/AuthGate/Controllers/AuthController.cs
@@ -8,6 +8,8 @@ using AuthGate.Services.File;
 using AuthGate.Services.RabbitMQ;
 using AuthGate.Services;
 using AuthGate.Entities;
+using AuthGate.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace AuthGate.Controllers
 {
@@ -22,6 +24,7 @@ namespace AuthGate.Controllers
         private readonly ILogger<AuthController> _logger;
         private readonly IFileValidationService _fileValidationService;
         private readonly IMessagingPublisherService _messagingPublisherService;
+        private readonly ApplicationDbContext? _dbContext;
 
         public AuthController(
             UserManager<ApplicationUser> userManager,
@@ -30,7 +33,8 @@ namespace AuthGate.Controllers
             IConfiguration configuration,
             ILogger<AuthController> logger,
             IFileValidationService fileValidationService,
-            IMessagingPublisherService messagingPublisherService
+            IMessagingPublisherService messagingPublisherService,
+            ApplicationDbContext? dbContext = null
             )
         {
             _userManager = userManager;
@@ -40,6 +44,7 @@ namespace AuthGate.Controllers
             _logger = logger;
             _fileValidationService = fileValidationService;
             _messagingPublisherService = messagingPublisherService;
+            _dbContext = dbContext;
         }
 
         [HttpPost("register/rider")]
@@ -75,6 +80,16 @@ namespace AuthGate.Controllers
                 CNHType = parsedCNHType
             };
 
+            (Stream File, string Extension)? validatedImage = null;
+            if (model.CNHImage != null)
+            {
+                validatedImage = await _fileValidationService.ValidateAndConvertFileAsync(model.CNHImage);
+            }
+
+            await using var transaction = _dbContext is not null && _dbContext.Database.IsRelational()
+                ? await _dbContext.Database.BeginTransactionAsync()
+                : null;
+
             var result = await _userManager.CreateAsync(riderUser, model.Password);
             if (!result.Succeeded)
             {
@@ -94,12 +109,24 @@ namespace AuthGate.Controllers
 
             _logger.LogInformation("Rider user {UserId} successfully registered.", riderUser.Id);
 
-            if (model.CNHImage != null)
-            {
-                var (file, ext) = await _fileValidationService.ValidateAndConvertFileAsync(model.CNHImage);
-                _messagingPublisherService.PublishImageStream(file, ext, riderUser.Id);
-            }
             _messagingPublisherService.PublishRiderInfo(convertRider(model, riderUser.Id));
+            if (validatedImage is not null)
+            {
+                _messagingPublisherService.PublishImageStream(
+                    validatedImage.Value.File,
+                    validatedImage.Value.Extension,
+                    riderUser.Id);
+            }
+
+            if (_dbContext is not null)
+            {
+                await _dbContext.SaveChangesAsync();
+            }
+
+            if (transaction is not null)
+            {
+                await transaction.CommitAsync();
+            }
 
             return Ok("Rider user successfully registered.");
         }

--- a/AuthGate/AuthGate/Data/ApplicationDbContext.cs
+++ b/AuthGate/AuthGate/Data/ApplicationDbContext.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using AuthGate.Model;
+using ProjectY.Shared.Messaging;
 
 namespace AuthGate.Data
 {
@@ -10,6 +11,9 @@ namespace AuthGate.Data
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
         {
         }
+
+        public DbSet<OutboxMessage> OutboxMessages => Set<OutboxMessage>();
+
         protected override void OnModelCreating(ModelBuilder builder)
         {
             base.OnModelCreating(builder);
@@ -27,6 +31,7 @@ namespace AuthGate.Data
                 .IsUnique();
 
             SeedRoles(builder);
+            builder.ConfigureOutbox();
         }
         private static void SeedRoles(ModelBuilder builder)
         {

--- a/AuthGate/AuthGate/Migrations/20260831172837_AddTransactionalOutbox.Designer.cs
+++ b/AuthGate/AuthGate/Migrations/20260831172837_AddTransactionalOutbox.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AuthGate.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace AuthGate.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260831172837_AddTransactionalOutbox")]
+    partial class AddTransactionalOutbox
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AuthGate/AuthGate/Migrations/20260831172837_AddTransactionalOutbox.cs
+++ b/AuthGate/AuthGate/Migrations/20260831172837_AddTransactionalOutbox.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AuthGate.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTransactionalOutbox : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OutboxMessages",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AggregateType = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    AggregateId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    AggregateSequence = table.Column<long>(type: "bigint", nullable: false),
+                    EventType = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Destination = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Payload = table.Column<string>(type: "text", nullable: false),
+                    OccurredAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    PublishedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    PublishAttempts = table.Column<int>(type: "integer", nullable: false),
+                    NextAttemptAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastError = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OutboxMessages", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessages_AggregateType_AggregateId_AggregateSequence",
+                table: "OutboxMessages",
+                columns: new[] { "AggregateType", "AggregateId", "AggregateSequence" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessages_PublishedAtUtc_NextAttemptAtUtc_OccurredAtUtc",
+                table: "OutboxMessages",
+                columns: new[] { "PublishedAtUtc", "NextAttemptAtUtc", "OccurredAtUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OutboxMessages");
+        }
+    }
+}

--- a/AuthGate/AuthGate/Migrations/20260831181244_ClaimOutboxMessages.Designer.cs
+++ b/AuthGate/AuthGate/Migrations/20260831181244_ClaimOutboxMessages.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AuthGate.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace AuthGate.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260831181244_ClaimOutboxMessages")]
+    partial class ClaimOutboxMessages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AuthGate/AuthGate/Migrations/20260831181244_ClaimOutboxMessages.cs
+++ b/AuthGate/AuthGate/Migrations/20260831181244_ClaimOutboxMessages.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AuthGate.Migrations
+{
+    /// <inheritdoc />
+    public partial class ClaimOutboxMessages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_OutboxMessages_PublishedAtUtc_NextAttemptAtUtc_OccurredAtUtc",
+                table: "OutboxMessages");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ClaimToken",
+                table: "OutboxMessages",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ClaimedUntilUtc",
+                table: "OutboxMessages",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessages_PendingClaim",
+                table: "OutboxMessages",
+                columns: new[] { "PublishedAtUtc", "ClaimedUntilUtc", "NextAttemptAtUtc", "OccurredAtUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_OutboxMessages_PendingClaim",
+                table: "OutboxMessages");
+
+            migrationBuilder.DropColumn(
+                name: "ClaimToken",
+                table: "OutboxMessages");
+
+            migrationBuilder.DropColumn(
+                name: "ClaimedUntilUtc",
+                table: "OutboxMessages");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessages_PublishedAtUtc_NextAttemptAtUtc_OccurredAtUtc",
+                table: "OutboxMessages",
+                columns: new[] { "PublishedAtUtc", "NextAttemptAtUtc", "OccurredAtUtc" });
+        }
+    }
+}

--- a/AuthGate/AuthGate/Program.cs
+++ b/AuthGate/AuthGate/Program.cs
@@ -7,7 +7,6 @@ using Microsoft.IdentityModel.Tokens;
 using Serilog;
 using System.Text;
 using AuthGate.Configurations;
-using RabbitMQ.Client;
 using AuthGate.Services.RabbitMQ;
 using AuthGate.Services.File;
 using AuthGate.Services;
@@ -47,30 +46,18 @@ if (!isTesting)
 Log.Logger = loggerConfig.CreateLogger();
 builder.Host.UseSerilog();
 
-var rabbitMQConfig = builder.Configuration.GetSection("RabbitMQ").Get<RabbitMQOptions>();
+var rabbitMQConfig = builder.Configuration.GetSection("RabbitMQ").Get<RabbitMQOptions>()
+    ?? throw new InvalidOperationException("RabbitMQ configuration is missing.");
 builder.Services.AddSingleton<RabbitMQOptions>(rabbitMQConfig);
 var postgresConnection = new NpgsqlConnectionStringBuilder(
     builder.Configuration.GetConnectionString("Postgresql") ?? "Host=postgres;Port=5432");
 builder.Services
     .AddProjectYHealthChecks()
     .AddTcpDependency("postgres", postgresConnection.Host ?? "postgres", postgresConnection.Port)
-    .AddTcpDependency("rabbitmq", rabbitMQConfig?.HostName ?? "rabbitmq", 5672);
+    .AddTcpDependency("rabbitmq", rabbitMQConfig.HostName, 5672);
 builder.Services.AddSingleton(new QueueMessageAuthenticator(
     builder.Configuration["Messaging:SigningKey"]
         ?? throw new InvalidOperationException("Messaging:SigningKey is not configured.")));
-
-builder.Services.AddSingleton<IConnection>(sp =>
-{
-    var rabbitMQOptions = sp.GetRequiredService<RabbitMQOptions>();
-    var factory = new ConnectionFactory()
-    {
-        HostName = rabbitMQOptions.HostName,
-        VirtualHost = rabbitMQOptions.VirtualHost,
-        UserName = rabbitMQOptions.UserName,
-        Password = rabbitMQOptions.Password
-    };
-    return factory.CreateConnection();
-});
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
@@ -79,6 +66,17 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("Postgresql")));
 builder.Services.AddScoped<IMessagingPublisherService, MessagingPublisherService>();
+builder.Services.AddSingleton(new OutboxRelayOptions
+{
+    ServiceName = "auth-gate",
+    HostName = rabbitMQConfig.HostName,
+    VirtualHost = rabbitMQConfig.VirtualHost,
+    UserName = rabbitMQConfig.UserName,
+    Password = rabbitMQConfig.Password
+});
+builder.Services.AddSingleton<IOutboxTransport, RabbitMqOutboxTransport>();
+builder.Services.AddSingleton<IRabbitMqConnectionProvider, RabbitMqConnectionProvider>();
+builder.Services.AddHostedService<OutboxRelay<ApplicationDbContext>>();
 builder.Services.AddScoped<IFileValidationService, FileValidationService>();
 
 builder.Services.AddIdentity<ApplicationUser, IdentityRole>(options =>
@@ -137,6 +135,7 @@ app.UseAuthorization();
 
 app.MapControllers();
 app.MapProjectYHealthChecks();
+app.MapOutboxMetrics<ApplicationDbContext>("auth-gate");
 
 app.Run();
 

--- a/AuthGate/AuthGate/Services/RabbitMQ/MessagingPublisherService.cs
+++ b/AuthGate/AuthGate/Services/RabbitMQ/MessagingPublisherService.cs
@@ -1,77 +1,76 @@
-﻿using AuthGate.Configurations;
+using AuthGate.Configurations;
+using AuthGate.Data;
 using AuthGate.Entities;
-using RabbitMQ.Client;
 using ProjectY.Shared.Messaging;
-using System.Text;
 
-namespace AuthGate.Services.RabbitMQ
+namespace AuthGate.Services.RabbitMQ;
+
+public sealed class MessagingPublisherService : IMessagingPublisherService
 {
-    public class MessagingPublisherService : IMessagingPublisherService
+    private readonly ApplicationDbContext _context;
+    private readonly RabbitMQOptions _rabbitmqOptions;
+    private readonly QueueMessageAuthenticator _messageAuthenticator;
+
+    public MessagingPublisherService(
+        ApplicationDbContext context,
+        RabbitMQOptions rabbitMQOptions,
+        QueueMessageAuthenticator messageAuthenticator)
     {
-        private readonly IConnection _connection;
-        private readonly IModel _channel;
-        private readonly RabbitMQOptions _rabbitmqOptions;
-        private readonly QueueMessageAuthenticator _messageAuthenticator;
+        _context = context;
+        _rabbitmqOptions = rabbitMQOptions;
+        _messageAuthenticator = messageAuthenticator;
+    }
 
-        public MessagingPublisherService(IConnection connection, RabbitMQOptions rabbitMQOptions,
-            QueueMessageAuthenticator messageAuthenticator)
+    public void PublishImageStream(Stream imageStream, string extension, string userId)
+    {
+        const int bufferSize = 4096;
+        var buffer = new byte[bufferSize];
+        var sequenceNumber = 1L;
+        var fileName = $"{userId}_{DateTime.UtcNow:yyyyMMddHHmmss}{extension}";
+        int byteCount;
+
+        while ((byteCount = imageStream.Read(buffer, 0, bufferSize)) > 0)
         {
-            _connection = connection;
-            _channel = _connection.CreateModel();
-            _rabbitmqOptions = rabbitMQOptions;
-            _messageAuthenticator = messageAuthenticator;
-        }
-
-        public void PublishImageStream(Stream imageStream, string extension, string userId)
-        {
-            const int bufferSize = 4096;
-            byte[] buffer = new byte[bufferSize];
-            int byteCount;
-            int sequenceNumber = 0;
-
-            _channel.QueueDeclare(_rabbitmqOptions.ImageStreamQueueName, false, false);
-
-            string fileName = $"{userId}_{DateTime.UtcNow:yyyyMMddHHmmss}{extension}";
-
-            while ((byteCount = imageStream.Read(buffer, 0, bufferSize)) > 0)
+            var message = new
             {
-                var message = new
-                {
-                    UserId = userId,
-                    SequenceNumber = sequenceNumber++,
-                    FileName = fileName,
-                    Content = Convert.ToBase64String(buffer, 0, byteCount),
-                    EndOfFile = imageStream.Position == imageStream.Length
-                };
-
-                var envelope = _messageAuthenticator.CreateEnvelope(
-                    "rider.cnh-image-part.v1",
-                    userId,
-                    message);
-                var body = Encoding.UTF8.GetBytes(envelope);
-
-                _channel.BasicPublish(exchange: "",
-                                      routingKey: _rabbitmqOptions.ImageStreamQueueName,
-                                      basicProperties: null,
-                                      body: body);
-            }
-        }
-
-        public void PublishRiderInfo(RiderMQEntity rider)
-        {
-            _channel.QueueDeclare(_rabbitmqOptions.RiderInfoQueueName, false, false);
-
+                UserId = userId,
+                SequenceNumber = sequenceNumber - 1,
+                FileName = fileName,
+                Content = Convert.ToBase64String(buffer, 0, byteCount),
+                EndOfFile = imageStream.Position == imageStream.Length
+            };
             var envelope = _messageAuthenticator.CreateEnvelope(
-                "rider.registration.v1",
-                rider.UserId,
-                rider);
-            var body = Encoding.UTF8.GetBytes(envelope);
+                "rider.cnh-image-part.v1",
+                userId,
+                message);
 
-            _channel.BasicPublish(exchange: "",
-                                  routingKey: _rabbitmqOptions.RiderInfoQueueName,
-                                  basicProperties: null,
-                                  body: body);
+            _context.OutboxMessages.Add(new OutboxMessage
+            {
+                AggregateType = "rider",
+                AggregateId = userId,
+                AggregateSequence = sequenceNumber++,
+                EventType = "rider.cnh-image-part.v1",
+                Destination = _rabbitmqOptions.ImageStreamQueueName,
+                Payload = envelope
+            });
         }
+    }
 
+    public void PublishRiderInfo(RiderMQEntity rider)
+    {
+        var envelope = _messageAuthenticator.CreateEnvelope(
+            "rider.registration.v1",
+            rider.UserId,
+            rider);
+
+        _context.OutboxMessages.Add(new OutboxMessage
+        {
+            AggregateType = "rider",
+            AggregateId = rider.UserId,
+            AggregateSequence = 0,
+            EventType = "rider.registration.v1",
+            Destination = _rabbitmqOptions.RiderInfoQueueName,
+            Payload = envelope
+        });
     }
 }

--- a/AuthGate/AuthGateTests/Integration/CustomWebApplicationFactory.cs
+++ b/AuthGate/AuthGateTests/Integration/CustomWebApplicationFactory.cs
@@ -9,6 +9,7 @@ using AuthGate.Data;
 using AuthGate.Model;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Hosting;
 using Moq;
 using RabbitMQ.Client;
 using Xunit;
@@ -43,6 +44,7 @@ namespace AuthGateTests.Integration
 
             builder.ConfigureServices(services =>
             {
+                services.RemoveAll<IHostedService>();
                 services.AddDataProtection().UseEphemeralDataProtectionProvider();
 
                 var modelMock = new Mock<IModel>();
@@ -84,7 +86,13 @@ namespace AuthGateTests.Integration
                     {"Jwt:SigningKeys:AuthGate", "test-only-auth-gate-key-with-32-bytes"},
                     {"Jwt:Audiences:MotoHub", "projecty.moto-hub"},
                     {"Jwt:SigningKeys:MotoHub", "test-only-moto-hub-signing-key-0001"},
-                    {"Messaging:SigningKey", "test-only-queue-signing-key-with-32-bytes"}
+                    {"Messaging:SigningKey", "test-only-queue-signing-key-with-32-bytes"},
+                    {"RabbitMQ:HostName", "unused"},
+                    {"RabbitMQ:VirtualHost", "unused"},
+                    {"RabbitMQ:UserName", "unused"},
+                    {"RabbitMQ:Password", "unused"},
+                    {"RabbitMQ:RiderInfoQueueName", "rider-info-test"},
+                    {"RabbitMQ:ImageStreamQueueName", "image-stream-test"}
                 };
 
                 configBuilder.Sources.Clear();

--- a/AuthGate/AuthGateTests/Integration/PostgreSql/MigrationTests.cs
+++ b/AuthGate/AuthGateTests/Integration/PostgreSql/MigrationTests.cs
@@ -28,7 +28,7 @@ public sealed class MigrationTests : IAsyncLifetime
         await context.Database.MigrateAsync();
 
         Assert.Empty(await context.Database.GetPendingMigrationsAsync());
-        Assert.Equal(2, (await context.Database.GetAppliedMigrationsAsync()).Count());
+        Assert.Equal(3, (await context.Database.GetAppliedMigrationsAsync()).Count());
         Assert.Equal(2, await context.Roles.CountAsync());
     }
 }

--- a/AuthGate/AuthGateTests/Integration/PostgreSql/MigrationTests.cs
+++ b/AuthGate/AuthGateTests/Integration/PostgreSql/MigrationTests.cs
@@ -28,7 +28,7 @@ public sealed class MigrationTests : IAsyncLifetime
         await context.Database.MigrateAsync();
 
         Assert.Empty(await context.Database.GetPendingMigrationsAsync());
-        Assert.Single(await context.Database.GetAppliedMigrationsAsync());
+        Assert.Equal(2, (await context.Database.GetAppliedMigrationsAsync()).Count());
         Assert.Equal(2, await context.Roles.CountAsync());
     }
 }

--- a/MotoHub/MotoHub/Data/ApplicationDbContext.cs
+++ b/MotoHub/MotoHub/Data/ApplicationDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using MotoHub.Models;
+using ProjectY.Shared.Messaging;
 
 namespace MotoHub.Data
 {
@@ -10,12 +11,14 @@ namespace MotoHub.Data
         }
 
         public DbSet<Motorcycle> Motorcycles { get; set; }
+        public DbSet<OutboxMessage> OutboxMessages => Set<OutboxMessage>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Motorcycle>()
                 .HasIndex(m => m.LicensePlate)
                 .IsUnique();
+            modelBuilder.ConfigureOutbox();
         }
     }
 }

--- a/MotoHub/MotoHub/Entities/LicencePlateRabbitMQEntity.cs
+++ b/MotoHub/MotoHub/Entities/LicencePlateRabbitMQEntity.cs
@@ -1,7 +1,12 @@
-﻿namespace MotoHub.Entities
+using System.Text.Json.Serialization;
+
+namespace MotoHub.Entities
 {
     public class LicencePlateRabbitMQEntity
     {
+        [JsonIgnore]
+        public string AggregateId { get; set; } = string.Empty;
+
         public string oldLicencePlate { get; set; } = string.Empty;
 
         public string newLicencePlate { get; set; } = string.Empty;

--- a/MotoHub/MotoHub/Migrations/20260831172841_AddTransactionalOutbox.Designer.cs
+++ b/MotoHub/MotoHub/Migrations/20260831172841_AddTransactionalOutbox.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MotoHub.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MotoHub.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260831172841_AddTransactionalOutbox")]
+    partial class AddTransactionalOutbox
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MotoHub/MotoHub/Migrations/20260831172841_AddTransactionalOutbox.cs
+++ b/MotoHub/MotoHub/Migrations/20260831172841_AddTransactionalOutbox.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MotoHub.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTransactionalOutbox : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OutboxMessages",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AggregateType = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    AggregateId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    AggregateSequence = table.Column<long>(type: "bigint", nullable: false),
+                    EventType = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Destination = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Payload = table.Column<string>(type: "text", nullable: false),
+                    OccurredAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    PublishedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    PublishAttempts = table.Column<int>(type: "integer", nullable: false),
+                    NextAttemptAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastError = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OutboxMessages", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessages_AggregateType_AggregateId_AggregateSequence",
+                table: "OutboxMessages",
+                columns: new[] { "AggregateType", "AggregateId", "AggregateSequence" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessages_PublishedAtUtc_NextAttemptAtUtc_OccurredAtUtc",
+                table: "OutboxMessages",
+                columns: new[] { "PublishedAtUtc", "NextAttemptAtUtc", "OccurredAtUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OutboxMessages");
+        }
+    }
+}

--- a/MotoHub/MotoHub/Migrations/20260831181246_ClaimOutboxMessages.Designer.cs
+++ b/MotoHub/MotoHub/Migrations/20260831181246_ClaimOutboxMessages.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MotoHub.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MotoHub.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260831181246_ClaimOutboxMessages")]
+    partial class ClaimOutboxMessages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MotoHub/MotoHub/Migrations/20260831181246_ClaimOutboxMessages.cs
+++ b/MotoHub/MotoHub/Migrations/20260831181246_ClaimOutboxMessages.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MotoHub.Migrations
+{
+    /// <inheritdoc />
+    public partial class ClaimOutboxMessages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_OutboxMessages_PublishedAtUtc_NextAttemptAtUtc_OccurredAtUtc",
+                table: "OutboxMessages");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ClaimToken",
+                table: "OutboxMessages",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ClaimedUntilUtc",
+                table: "OutboxMessages",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessages_PendingClaim",
+                table: "OutboxMessages",
+                columns: new[] { "PublishedAtUtc", "ClaimedUntilUtc", "NextAttemptAtUtc", "OccurredAtUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_OutboxMessages_PendingClaim",
+                table: "OutboxMessages");
+
+            migrationBuilder.DropColumn(
+                name: "ClaimToken",
+                table: "OutboxMessages");
+
+            migrationBuilder.DropColumn(
+                name: "ClaimedUntilUtc",
+                table: "OutboxMessages");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessages_PublishedAtUtc_NextAttemptAtUtc_OccurredAtUtc",
+                table: "OutboxMessages",
+                columns: new[] { "PublishedAtUtc", "NextAttemptAtUtc", "OccurredAtUtc" });
+        }
+    }
+}

--- a/MotoHub/MotoHub/MotoHub.csproj
+++ b/MotoHub/MotoHub/MotoHub.csproj
@@ -37,6 +37,14 @@
     <Compile Include="..\..\Shared\Health\ServiceHealthChecks.cs" Link="Shared\Health\ServiceHealthChecks.cs" />
     <Compile Include="..\..\Shared\Hosting\SwaggerPolicy.cs" Link="Shared\Hosting\SwaggerPolicy.cs" />
     <Compile Include="..\..\Shared\Hosting\DatabaseMigrationCommand.cs" Link="Shared\Hosting\DatabaseMigrationCommand.cs" />
+    <Compile Include="..\..\Shared\Messaging\IOutboxTransport.cs" Link="Shared\Messaging\IOutboxTransport.cs" />
+    <Compile Include="..\..\Shared\Messaging\IRabbitMqConnectionProvider.cs" Link="Shared\Messaging\IRabbitMqConnectionProvider.cs" />
+    <Compile Include="..\..\Shared\Messaging\OutboxMessage.cs" Link="Shared\Messaging\OutboxMessage.cs" />
+    <Compile Include="..\..\Shared\Messaging\OutboxMetricsEndpoint.cs" Link="Shared\Messaging\OutboxMetricsEndpoint.cs" />
+    <Compile Include="..\..\Shared\Messaging\OutboxModelBuilderExtensions.cs" Link="Shared\Messaging\OutboxModelBuilderExtensions.cs" />
+    <Compile Include="..\..\Shared\Messaging\OutboxRelay.cs" Link="Shared\Messaging\OutboxRelay.cs" />
+    <Compile Include="..\..\Shared\Messaging\OutboxRelayOptions.cs" Link="Shared\Messaging\OutboxRelayOptions.cs" />
+    <Compile Include="..\..\Shared\Messaging\RabbitMqOutboxTransport.cs" Link="Shared\Messaging\RabbitMqOutboxTransport.cs" />
   </ItemGroup>
 
 </Project>

--- a/MotoHub/MotoHub/Program.cs
+++ b/MotoHub/MotoHub/Program.cs
@@ -9,7 +9,6 @@ using MotoHub.Services;
 using MotoHub.Repositories;
 using Microsoft.OpenApi.Models;
 using MotoHub.Filters;
-using RabbitMQ.Client;
 using Serilog.Sinks.Elasticsearch;
 using MotoHub.Configurations;
 using MotoHub.Services.RabbitMQ;
@@ -17,6 +16,7 @@ using MotoHub.CrossCutting;
 using Npgsql;
 using ProjectY.Shared.Health;
 using ProjectY.Shared.Hosting;
+using ProjectY.Shared.Messaging;
 
 if (await HealthProbeCommand.TryRunAsync(args))
 {
@@ -50,27 +50,15 @@ if (!isTesting)
 Log.Logger = loggerConfig.CreateLogger();
 builder.Host.UseSerilog();
 
-var rabbitMQConfig = builder.Configuration.GetSection("RabbitMQ").Get<RabbitMQOptions>();
+var rabbitMQConfig = builder.Configuration.GetSection("RabbitMQ").Get<RabbitMQOptions>()
+    ?? throw new InvalidOperationException("RabbitMQ configuration is missing.");
 builder.Services.AddSingleton<RabbitMQOptions>(rabbitMQConfig);
 var postgresConnection = new NpgsqlConnectionStringBuilder(
     builder.Configuration.GetConnectionString("Postgresql") ?? "Host=postgres;Port=5432");
 builder.Services
     .AddProjectYHealthChecks()
     .AddTcpDependency("postgres", postgresConnection.Host ?? "postgres", postgresConnection.Port)
-    .AddTcpDependency("rabbitmq", rabbitMQConfig?.HostName ?? "rabbitmq", 5672);
-
-builder.Services.AddSingleton<IConnection>(sp =>
-{
-    var rabbitMQOptions = sp.GetRequiredService<RabbitMQOptions>();
-    var factory = new ConnectionFactory()
-    {
-        HostName = rabbitMQOptions.HostName,
-        VirtualHost = rabbitMQOptions.VirtualHost,
-        UserName = rabbitMQOptions.UserName,
-        Password = rabbitMQOptions.Password
-    };
-    return factory.CreateConnection();
-});
+    .AddTcpDependency("rabbitmq", rabbitMQConfig.HostName, 5672);
 
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("Postgresql")));
@@ -98,11 +86,23 @@ builder.Services.AddAuthentication(options =>
 builder.Services.AddControllers();
 builder.Services.AddAutoMapper(_ => { }, typeof(Program));
 builder.Services.AddHttpClient();
-builder.Services.AddScoped<IApplicationDbContext, ApplicationDbContext>();
+builder.Services.AddScoped<IApplicationDbContext>(services =>
+    services.GetRequiredService<ApplicationDbContext>());
 builder.Services.AddScoped<IMotorcycleRepository, MotorcycleRepository>();
 builder.Services.AddScoped<AdminAuthorizationFilter>();
 builder.Services.AddScoped<IMotorcycleService, MotorcycleService>();
 builder.Services.AddScoped<IMessagingPublisherService, MessagingPublisherService>();
+builder.Services.AddSingleton(new OutboxRelayOptions
+{
+    ServiceName = "moto-hub",
+    HostName = rabbitMQConfig.HostName,
+    VirtualHost = rabbitMQConfig.VirtualHost,
+    UserName = rabbitMQConfig.UserName,
+    Password = rabbitMQConfig.Password
+});
+builder.Services.AddSingleton<IOutboxTransport, RabbitMqOutboxTransport>();
+builder.Services.AddSingleton<IRabbitMqConnectionProvider, RabbitMqConnectionProvider>();
+builder.Services.AddHostedService<OutboxRelay<ApplicationDbContext>>();
 builder.Services.AddScoped<IRentalOperationService, RentalOperationService>();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
@@ -152,6 +152,7 @@ app.UseAuthorization();
 
 app.MapControllers();
 app.MapProjectYHealthChecks();
+app.MapOutboxMetrics<ApplicationDbContext>("moto-hub");
 
 app.Run();
 

--- a/MotoHub/MotoHub/Services/MotorcycleService.cs
+++ b/MotoHub/MotoHub/Services/MotorcycleService.cs
@@ -55,15 +55,15 @@ namespace MotoHub.Services
 
             existingMotorcycle.LicensePlate = newLicencePlate;
 
-            _repository.Update(existingMotorcycle);
-
             LicencePlateRabbitMQEntity licencePlateRabbitMQEntity = new LicencePlateRabbitMQEntity()
             {
+                AggregateId = existingMotorcycle.Id,
                 newLicencePlate = newLicencePlate,
                 oldLicencePlate = licensePlate,
             };
 
             _messagingPublisherService.PublishLicenceUpdate(licencePlateRabbitMQEntity);
+            _repository.Update(existingMotorcycle);
         }
 
         public async Task<OperationResult> DeleteMotorcycle(string licensePlate)

--- a/MotoHub/MotoHub/Services/RabbitMQ/MessagingPublisherService.cs
+++ b/MotoHub/MotoHub/Services/RabbitMQ/MessagingPublisherService.cs
@@ -1,36 +1,32 @@
-﻿using MotoHub.Configurations;
+using MotoHub.Configurations;
+using MotoHub.Data;
 using MotoHub.Entities;
-using RabbitMQ.Client;
-using System.Text;
+using ProjectY.Shared.Messaging;
 using System.Text.Json;
 
-namespace MotoHub.Services.RabbitMQ
+namespace MotoHub.Services.RabbitMQ;
+
+public sealed class MessagingPublisherService : IMessagingPublisherService
 {
-    public class MessagingPublisherService : IMessagingPublisherService
+    private readonly ApplicationDbContext _context;
+    private readonly RabbitMQOptions _rabbitmqOptions;
+
+    public MessagingPublisherService(ApplicationDbContext context, RabbitMQOptions rabbitMQOptions)
     {
-        private readonly IConnection _connection;
-        private readonly IModel _channel;
-        private readonly RabbitMQOptions _rabbitmqOptions;
+        _context = context;
+        _rabbitmqOptions = rabbitMQOptions;
+    }
 
-        public MessagingPublisherService(IConnection connection, RabbitMQOptions rabbitMQOptions)
+    public void PublishLicenceUpdate(LicencePlateRabbitMQEntity licenceUpdate)
+    {
+        _context.OutboxMessages.Add(new OutboxMessage
         {
-            _connection = connection;
-            _channel = _connection.CreateModel();
-            _rabbitmqOptions = rabbitMQOptions;
-        }
-
-        public void PublishLicenceUpdate(LicencePlateRabbitMQEntity licenceUpdate)
-        {
-            _channel.QueueDeclare(_rabbitmqOptions.LicenceUpdateQueueName, false, false);
-
-            var message = JsonSerializer.Serialize(licenceUpdate);
-            var body = Encoding.UTF8.GetBytes(message);
-
-            _channel.BasicPublish(exchange: "",
-                                  routingKey: _rabbitmqOptions.LicenceUpdateQueueName,
-                                  basicProperties: null,
-                                  body: body);
-        }
-
+            AggregateType = "motorcycle",
+            AggregateId = licenceUpdate.AggregateId,
+            AggregateSequence = 0,
+            EventType = "motorcycle.licence-plate-updated.v1",
+            Destination = _rabbitmqOptions.LicenceUpdateQueueName,
+            Payload = JsonSerializer.Serialize(licenceUpdate)
+        });
     }
 }

--- a/MotoHub/MotoHubTests/Integration/CustomWebApplicationFactory.cs
+++ b/MotoHub/MotoHubTests/Integration/CustomWebApplicationFactory.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Moq;
 using MotoHub.CrossCutting;
 using MotoHub.Data;
@@ -22,6 +23,7 @@ namespace MotoHubTests.Integration
         {
             builder.ConfigureServices(services =>
             {
+                services.RemoveAll<IHostedService>();
 
                 var serviceDescriptor = services.FirstOrDefault(descriptor =>
                 descriptor.ServiceType == typeof(IRentalOperationService));
@@ -74,7 +76,12 @@ namespace MotoHubTests.Integration
                     {"Jwt:SigningKey", JwtKey},
                     {"Jwt:Issuer", JwtIssuer},
                     {"Jwt:Audience", JwtAudience},
-                    {"MotoHubApiKey", "" }
+                    {"MotoHubApiKey", "" },
+                    {"RabbitMQ:HostName", "unused"},
+                    {"RabbitMQ:VirtualHost", "unused"},
+                    {"RabbitMQ:UserName", "unused"},
+                    {"RabbitMQ:Password", "unused"},
+                    {"RabbitMQ:LicenceUpdateQueueName", "licence-update-test"}
                 };
 
                 configBuilder.Sources.Clear();

--- a/MotoHub/MotoHubTests/Integration/IntegrationTests.cs
+++ b/MotoHub/MotoHubTests/Integration/IntegrationTests.cs
@@ -1,7 +1,12 @@
 ﻿using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.EntityFrameworkCore;
+using MotoHub.Data;
 using MotoHub.DTOs;
+using MotoHub.Models;
+using MotoHub.Services;
 using Newtonsoft.Json;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net;
@@ -19,6 +24,35 @@ namespace MotoHubTests.Integration
         public IntegrationTests(CustomWebApplicationFactory<Program> factory)
         {
             _factory = factory;
+        }
+
+        [Fact]
+        public async Task Update_CommitsMotorcycleAndOutboxMessageTogether()
+        {
+            using var scope = _factory.Services.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var repositoryContext = scope.ServiceProvider.GetRequiredService<IApplicationDbContext>();
+            Assert.Same(context, repositoryContext);
+
+            var motorcycle = new Motorcycle
+            {
+                Id = Guid.NewGuid().ToString(),
+                LicensePlate = $"OUT-{Guid.NewGuid():N}",
+                Model = "Transactional outbox",
+                Year = 2026,
+                RegistrationDate = DateTime.UtcNow
+            };
+            context.Motorcycles.Add(motorcycle);
+            await context.SaveChangesAsync();
+
+            var service = scope.ServiceProvider.GetRequiredService<IMotorcycleService>();
+            var newLicencePlate = $"NEW-{Guid.NewGuid():N}";
+            await service.UpdateMotorcycleAsync(motorcycle.LicensePlate, newLicencePlate);
+
+            var message = Assert.Single(context.OutboxMessages.Local);
+            Assert.Equal(motorcycle.Id, message.AggregateId);
+            Assert.Equal(newLicencePlate, motorcycle.LicensePlate);
+            Assert.Equal(1, await context.OutboxMessages.CountAsync(item => item.Id == message.Id));
         }
 
         [Fact]

--- a/MotoHub/MotoHubTests/Integration/PostgreSql/MigrationTests.cs
+++ b/MotoHub/MotoHubTests/Integration/PostgreSql/MigrationTests.cs
@@ -36,7 +36,7 @@ public sealed class MigrationTests : IAsyncLifetime
         await context.SaveChangesAsync();
 
         Assert.Empty(await context.Database.GetPendingMigrationsAsync());
-        Assert.Equal(2, (await context.Database.GetAppliedMigrationsAsync()).Count());
+        Assert.Equal(3, (await context.Database.GetAppliedMigrationsAsync()).Count());
         Assert.Equal(1, await context.Motorcycles.CountAsync());
     }
 }

--- a/MotoHub/MotoHubTests/Integration/PostgreSql/MigrationTests.cs
+++ b/MotoHub/MotoHubTests/Integration/PostgreSql/MigrationTests.cs
@@ -36,7 +36,7 @@ public sealed class MigrationTests : IAsyncLifetime
         await context.SaveChangesAsync();
 
         Assert.Empty(await context.Database.GetPendingMigrationsAsync());
-        Assert.Single(await context.Database.GetAppliedMigrationsAsync());
+        Assert.Equal(2, (await context.Database.GetAppliedMigrationsAsync()).Count());
         Assert.Equal(1, await context.Motorcycles.CountAsync());
     }
 }

--- a/MotoHub/MotoHubTests/Integration/PostgreSql/OutboxRelayTests.cs
+++ b/MotoHub/MotoHubTests/Integration/PostgreSql/OutboxRelayTests.cs
@@ -85,6 +85,55 @@ public sealed class OutboxRelayTests : IAsyncLifetime
         }
     }
 
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ConcurrentRelays_ClaimOnlyOneHeadMessagePerAggregate()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<ApplicationDbContext>(options =>
+            options.UseNpgsql(_database.GetConnectionString()));
+        var transport = new BlockingOutboxTransport();
+        services.AddSingleton<IOutboxTransport>(transport);
+        services.AddSingleton(new OutboxRelayOptions
+        {
+            ServiceName = "moto-hub-test",
+            HostName = "unused",
+            VirtualHost = "unused",
+            UserName = "unused",
+            Password = "unused",
+            BatchSize = 1,
+            ClaimLeaseDuration = TimeSpan.FromMinutes(1)
+        });
+        services.AddTransient<OutboxRelay<ApplicationDbContext>>();
+        await using var provider = services.BuildServiceProvider();
+
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            await context.Database.MigrateAsync();
+            context.OutboxMessages.AddRange(
+                Message(sequence: 0, eventType: "motorcycle.first.v1"),
+                Message(sequence: 1, eventType: "motorcycle.second.v1"));
+            await context.SaveChangesAsync();
+        }
+
+        var firstRelay = provider.GetRequiredService<OutboxRelay<ApplicationDbContext>>();
+        var secondRelay = provider.GetRequiredService<OutboxRelay<ApplicationDbContext>>();
+        var firstDispatch = firstRelay.DispatchOnceAsync();
+        await transport.FirstPublishStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(0, await secondRelay.DispatchOnceAsync().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal(1, transport.PublishCalls);
+
+        transport.ReleaseFirstPublish();
+        Assert.Equal(1, await firstDispatch);
+        Assert.Equal(1, await secondRelay.DispatchOnceAsync());
+        Assert.Equal(
+            ["motorcycle.first.v1", "motorcycle.second.v1"],
+            transport.PublishedEventTypes);
+    }
+
     private static OutboxMessage Message(long sequence, string eventType) => new()
     {
         AggregateType = "motorcycle",
@@ -111,4 +160,30 @@ internal sealed class RecoverableOutboxTransport : IOutboxTransport
         Published.Add(message);
         return Task.CompletedTask;
     }
+}
+
+internal sealed class BlockingOutboxTransport : IOutboxTransport
+{
+    private readonly TaskCompletionSource<bool> _releaseFirstPublish = new(
+        TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly System.Collections.Concurrent.ConcurrentQueue<string> _publishedEventTypes = new();
+    private int _publishCalls;
+
+    public TaskCompletionSource<bool> FirstPublishStarted { get; } = new(
+        TaskCreationOptions.RunContinuationsAsynchronously);
+    public int PublishCalls => Volatile.Read(ref _publishCalls);
+    public string[] PublishedEventTypes => _publishedEventTypes.ToArray();
+
+    public async Task PublishAsync(OutboxMessage message, CancellationToken cancellationToken)
+    {
+        var call = Interlocked.Increment(ref _publishCalls);
+        _publishedEventTypes.Enqueue(message.EventType);
+        if (call == 1)
+        {
+            FirstPublishStarted.TrySetResult(true);
+            await _releaseFirstPublish.Task.WaitAsync(cancellationToken);
+        }
+    }
+
+    public void ReleaseFirstPublish() => _releaseFirstPublish.TrySetResult(true);
 }

--- a/MotoHub/MotoHubTests/Integration/PostgreSql/OutboxRelayTests.cs
+++ b/MotoHub/MotoHubTests/Integration/PostgreSql/OutboxRelayTests.cs
@@ -1,0 +1,114 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MotoHub.Data;
+using MotoHub.Models;
+using ProjectY.Shared.Messaging;
+using Testcontainers.PostgreSql;
+
+namespace MotoHubTests.Integration.PostgreSql;
+
+public sealed class OutboxRelayTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _database = new PostgreSqlBuilder("postgres:17.11-alpine3.24")
+        .WithDatabase("moto_hub_outbox")
+        .WithUsername("projecty")
+        .Build();
+
+    public Task InitializeAsync() => _database.StartAsync();
+
+    public Task DisposeAsync() => _database.DisposeAsync().AsTask();
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task CommittedMessages_SurviveRelayRestartAndDrainInAggregateOrderAfterBrokerRecovery()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<ApplicationDbContext>(options =>
+            options.UseNpgsql(_database.GetConnectionString()));
+        var transport = new RecoverableOutboxTransport { IsAvailable = false };
+        services.AddSingleton<IOutboxTransport>(transport);
+        services.AddSingleton(new OutboxRelayOptions
+        {
+            ServiceName = "moto-hub-test",
+            HostName = "unused",
+            VirtualHost = "unused",
+            UserName = "unused",
+            Password = "unused",
+            PollInterval = TimeSpan.FromMilliseconds(10)
+        });
+        services.AddSingleton<OutboxRelay<ApplicationDbContext>>();
+        await using var provider = services.BuildServiceProvider();
+
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            await context.Database.MigrateAsync();
+            context.Motorcycles.Add(new Motorcycle
+            {
+                Id = "motorcycle-1",
+                LicensePlate = "OUT-0001",
+                Model = "Outbox proof",
+                Year = 2026,
+                RegistrationDate = DateTime.UtcNow
+            });
+            context.OutboxMessages.AddRange(
+                Message(sequence: 1, eventType: "motorcycle.second.v1"),
+                Message(sequence: 0, eventType: "motorcycle.first.v1"));
+            await context.SaveChangesAsync();
+        }
+
+        var relayAfterCommit = provider.GetRequiredService<OutboxRelay<ApplicationDbContext>>();
+        Assert.Equal(0, await relayAfterCommit.DispatchOnceAsync());
+
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            Assert.Equal(1, await context.Motorcycles.CountAsync());
+            Assert.Equal(2, await context.OutboxMessages.CountAsync(message => message.PublishedAtUtc == null));
+            var failed = await context.OutboxMessages.SingleAsync(message => message.AggregateSequence == 0);
+            Assert.Equal(1, failed.PublishAttempts);
+            failed.NextAttemptAtUtc = DateTime.UtcNow.AddSeconds(-1);
+            await context.SaveChangesAsync();
+        }
+
+        transport.IsAvailable = true;
+        Assert.Equal(2, await relayAfterCommit.DispatchOnceAsync());
+
+        Assert.Equal(
+            ["motorcycle.first.v1", "motorcycle.second.v1"],
+            transport.Published.Select(message => message.EventType));
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            Assert.Equal(2, await context.OutboxMessages.CountAsync(message => message.PublishedAtUtc != null));
+        }
+    }
+
+    private static OutboxMessage Message(long sequence, string eventType) => new()
+    {
+        AggregateType = "motorcycle",
+        AggregateId = "motorcycle-1",
+        AggregateSequence = sequence,
+        EventType = eventType,
+        Destination = "motorcycle-events",
+        Payload = "{}"
+    };
+}
+
+internal sealed class RecoverableOutboxTransport : IOutboxTransport
+{
+    public bool IsAvailable { get; set; }
+    public List<OutboxMessage> Published { get; } = [];
+
+    public Task PublishAsync(OutboxMessage message, CancellationToken cancellationToken)
+    {
+        if (!IsAvailable)
+        {
+            throw new InvalidOperationException("Broker unavailable.");
+        }
+
+        Published.Add(message);
+        return Task.CompletedTask;
+    }
+}

--- a/MotoHub/MotoHubTests/Unit/Messaging/RabbitMqOutboxTransportTests.cs
+++ b/MotoHub/MotoHubTests/Unit/Messaging/RabbitMqOutboxTransportTests.cs
@@ -37,6 +37,12 @@ public sealed class RabbitMqOutboxTransportTests
 
         await transport.PublishAsync(message, CancellationToken.None);
 
+        channel.Verify(item => item.QueueDeclare(
+            message.Destination,
+            true,
+            false,
+            false,
+            It.IsAny<IDictionary<string, object>>()), Times.Once);
         channel.Verify(item => item.ConfirmSelect(), Times.Once);
         channel.Verify(item => item.WaitForConfirmsOrDie(options.ConfirmationTimeout), Times.Once);
         channel.Verify(item => item.BasicPublish(

--- a/MotoHub/MotoHubTests/Unit/Messaging/RabbitMqOutboxTransportTests.cs
+++ b/MotoHub/MotoHubTests/Unit/Messaging/RabbitMqOutboxTransportTests.cs
@@ -1,0 +1,50 @@
+using Moq;
+using ProjectY.Shared.Messaging;
+using RabbitMQ.Client;
+
+namespace MotoHubTests.Unit.Messaging;
+
+public sealed class RabbitMqOutboxTransportTests
+{
+    [Fact]
+    public async Task PublishAsync_EnablesAndWaitsForPublisherConfirms()
+    {
+        var channel = new Mock<IModel>();
+        var properties = new Mock<IBasicProperties>();
+        channel.Setup(item => item.CreateBasicProperties()).Returns(properties.Object);
+        var connection = new Mock<IConnection>();
+        connection.Setup(item => item.CreateModel()).Returns(channel.Object);
+        var connectionProvider = new Mock<IRabbitMqConnectionProvider>();
+        connectionProvider.Setup(item => item.Create()).Returns(connection.Object);
+        var options = new OutboxRelayOptions
+        {
+            ServiceName = "test",
+            HostName = "rabbitmq",
+            VirtualHost = "test",
+            UserName = "test",
+            Password = "test"
+        };
+        var transport = new RabbitMqOutboxTransport(options, connectionProvider.Object);
+        var message = new OutboxMessage
+        {
+            AggregateType = "motorcycle",
+            AggregateId = "motorcycle-1",
+            AggregateSequence = 0,
+            EventType = "motorcycle.updated.v1",
+            Destination = "motorcycle-events",
+            Payload = "{}"
+        };
+
+        await transport.PublishAsync(message, CancellationToken.None);
+
+        channel.Verify(item => item.ConfirmSelect(), Times.Once);
+        channel.Verify(item => item.WaitForConfirmsOrDie(options.ConfirmationTimeout), Times.Once);
+        channel.Verify(item => item.BasicPublish(
+            string.Empty,
+            message.Destination,
+            true,
+            properties.Object,
+            It.IsAny<ReadOnlyMemory<byte>>()), Times.Once);
+        properties.VerifySet(item => item.MessageId = message.Id.ToString("D"), Times.Once);
+    }
+}

--- a/MotoHub/MotoHubTests/Unit/Services/MotorcycleServicesTests.cs
+++ b/MotoHub/MotoHubTests/Unit/Services/MotorcycleServicesTests.cs
@@ -130,16 +130,19 @@ namespace MotoHubTests.Unit.Services
 
             var mockMessagingPublisherService = new Mock<IMessagingPublisherService>();
             mockMessagingPublisherService.Setup(p => p.PublishLicenceUpdate(It.Is<LicencePlateRabbitMQEntity>(m =>
-                m.newLicencePlate == newLicensePlate && m.oldLicencePlate == existingLicensePlate)))
+                m.AggregateId == existingMotorcycle.Id &&
+                m.newLicencePlate == newLicensePlate &&
+                m.oldLicencePlate == existingLicensePlate)))
                 .Verifiable("Message was not published correctly");
 
-            var service = new MotorcycleService(mockRepository.Object, mockMapper.Object, mockMessagingPublish.Object, mockCrossCutting.Object);
+            var service = new MotorcycleService(mockRepository.Object, mockMapper.Object, mockMessagingPublisherService.Object, mockCrossCutting.Object);
 
             // Act
             await service.UpdateMotorcycleAsync(existingLicensePlate, newLicensePlate);
 
             // Assert
             mockRepository.Verify();
+            mockMessagingPublisherService.Verify();
 
             Assert.Equal(newLicensePlate, existingMotorcycle.LicensePlate);
         }

--- a/RentalOperations/RentalOperations/Services/RabbitMQService/MessagingConsumerService.cs
+++ b/RentalOperations/RentalOperations/Services/RabbitMQService/MessagingConsumerService.cs
@@ -36,7 +36,7 @@ namespace RentalOperations.Services.RabbitMQService
 
         private void InitializeQueues()
         {
-            _channel.QueueDeclare(queue: _licenceUpdateQueueName, durable: false, exclusive: false);
+            _channel.QueueDeclare(queue: _licenceUpdateQueueName, durable: true, exclusive: false, autoDelete: false);
             _channel.BasicQos(prefetchSize: 0, prefetchCount: 1, global: false);
         }
 

--- a/RiderManager/RiderManager/Services/RabbitMQService/MessagingConsumerService.cs
+++ b/RiderManager/RiderManager/Services/RabbitMQService/MessagingConsumerService.cs
@@ -43,8 +43,8 @@ namespace RiderManager.Services.RabbitMQService
 
         private void InitializeQueues()
         {
-            _channel.QueueDeclare(queue: _riderInfoQueueName, durable: false, exclusive: false);
-            _channel.QueueDeclare(queue: _imageStreamQueueName, durable: false, exclusive: false);
+            _channel.QueueDeclare(queue: _riderInfoQueueName, durable: true, exclusive: false, autoDelete: false);
+            _channel.QueueDeclare(queue: _imageStreamQueueName, durable: true, exclusive: false, autoDelete: false);
             _channel.BasicQos(prefetchSize: 0, prefetchCount: 1, global: false);
         }
 

--- a/Shared/Messaging/IOutboxTransport.cs
+++ b/Shared/Messaging/IOutboxTransport.cs
@@ -1,0 +1,6 @@
+namespace ProjectY.Shared.Messaging;
+
+public interface IOutboxTransport
+{
+    Task PublishAsync(OutboxMessage message, CancellationToken cancellationToken);
+}

--- a/Shared/Messaging/IRabbitMqConnectionProvider.cs
+++ b/Shared/Messaging/IRabbitMqConnectionProvider.cs
@@ -1,0 +1,28 @@
+using RabbitMQ.Client;
+
+namespace ProjectY.Shared.Messaging;
+
+public interface IRabbitMqConnectionProvider
+{
+    IConnection Create();
+}
+
+public sealed class RabbitMqConnectionProvider : IRabbitMqConnectionProvider
+{
+    private readonly OutboxRelayOptions _options;
+
+    public RabbitMqConnectionProvider(OutboxRelayOptions options)
+    {
+        _options = options;
+    }
+
+    public IConnection Create() => new ConnectionFactory
+    {
+        HostName = _options.HostName,
+        Port = _options.Port,
+        VirtualHost = _options.VirtualHost,
+        UserName = _options.UserName,
+        Password = _options.Password,
+        AutomaticRecoveryEnabled = true
+    }.CreateConnection();
+}

--- a/Shared/Messaging/OutboxMessage.cs
+++ b/Shared/Messaging/OutboxMessage.cs
@@ -13,5 +13,7 @@ public sealed class OutboxMessage
     public DateTime? PublishedAtUtc { get; set; }
     public int PublishAttempts { get; set; }
     public DateTime? NextAttemptAtUtc { get; set; }
+    public Guid? ClaimToken { get; set; }
+    public DateTime? ClaimedUntilUtc { get; set; }
     public string? LastError { get; set; }
 }

--- a/Shared/Messaging/OutboxMessage.cs
+++ b/Shared/Messaging/OutboxMessage.cs
@@ -1,0 +1,17 @@
+namespace ProjectY.Shared.Messaging;
+
+public sealed class OutboxMessage
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public required string AggregateType { get; set; }
+    public required string AggregateId { get; set; }
+    public long AggregateSequence { get; set; }
+    public required string EventType { get; set; }
+    public required string Destination { get; set; }
+    public required string Payload { get; set; }
+    public DateTime OccurredAtUtc { get; set; } = DateTime.UtcNow;
+    public DateTime? PublishedAtUtc { get; set; }
+    public int PublishAttempts { get; set; }
+    public DateTime? NextAttemptAtUtc { get; set; }
+    public string? LastError { get; set; }
+}

--- a/Shared/Messaging/OutboxMetricsEndpoint.cs
+++ b/Shared/Messaging/OutboxMetricsEndpoint.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Globalization;
+
+namespace ProjectY.Shared.Messaging;
+
+public static class OutboxMetricsEndpoint
+{
+    public static IEndpointConventionBuilder MapOutboxMetrics<TContext>(
+        this IEndpointRouteBuilder endpoints,
+        string serviceName)
+        where TContext : DbContext
+    {
+        return endpoints.MapGet("/metrics", async (IServiceProvider services, CancellationToken cancellationToken) =>
+        {
+            await using var scope = services.CreateAsyncScope();
+            var context = scope.ServiceProvider.GetRequiredService<TContext>();
+            var pending = context.Set<OutboxMessage>().Where(message => message.PublishedAtUtc == null);
+            var depth = await pending.LongCountAsync(cancellationToken);
+            var oldest = await pending.MinAsync(message => (DateTime?)message.OccurredAtUtc, cancellationToken);
+            var lag = oldest is null ? 0 : Math.Max(0, (DateTime.UtcNow - oldest.Value).TotalSeconds);
+            var service = EscapeLabel(serviceName);
+            var payload = string.Create(
+                CultureInfo.InvariantCulture,
+                $"# TYPE projecty_outbox_depth gauge\nprojecty_outbox_depth{{service=\"{service}\"}} {depth}\n" +
+                $"# TYPE projecty_outbox_oldest_age_seconds gauge\nprojecty_outbox_oldest_age_seconds{{service=\"{service}\"}} {lag:F3}\n");
+
+            return Results.Text(payload, "text/plain; version=0.0.4; charset=utf-8");
+        }).AllowAnonymous();
+    }
+
+    private static string EscapeLabel(string value) =>
+        value.Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal);
+}

--- a/Shared/Messaging/OutboxModelBuilderExtensions.cs
+++ b/Shared/Messaging/OutboxModelBuilderExtensions.cs
@@ -21,6 +21,12 @@ public static class OutboxModelBuilderExtensions
             item.AggregateId,
             item.AggregateSequence
         });
-        message.HasIndex(item => new { item.PublishedAtUtc, item.NextAttemptAtUtc, item.OccurredAtUtc });
+        message.HasIndex(item => new
+        {
+            item.PublishedAtUtc,
+            item.ClaimedUntilUtc,
+            item.NextAttemptAtUtc,
+            item.OccurredAtUtc
+        }).HasDatabaseName("IX_OutboxMessages_PendingClaim");
     }
 }

--- a/Shared/Messaging/OutboxModelBuilderExtensions.cs
+++ b/Shared/Messaging/OutboxModelBuilderExtensions.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace ProjectY.Shared.Messaging;
+
+public static class OutboxModelBuilderExtensions
+{
+    public static void ConfigureOutbox(this ModelBuilder modelBuilder)
+    {
+        var message = modelBuilder.Entity<OutboxMessage>();
+        message.ToTable("OutboxMessages");
+        message.HasKey(item => item.Id);
+        message.Property(item => item.AggregateType).HasMaxLength(100);
+        message.Property(item => item.AggregateId).HasMaxLength(200);
+        message.Property(item => item.EventType).HasMaxLength(200);
+        message.Property(item => item.Destination).HasMaxLength(200);
+        message.Property(item => item.Payload).HasColumnType("text");
+        message.Property(item => item.LastError).HasMaxLength(2000);
+        message.HasIndex(item => new
+        {
+            item.AggregateType,
+            item.AggregateId,
+            item.AggregateSequence
+        });
+        message.HasIndex(item => new { item.PublishedAtUtc, item.NextAttemptAtUtc, item.OccurredAtUtc });
+    }
+}

--- a/Shared/Messaging/OutboxRelay.cs
+++ b/Shared/Messaging/OutboxRelay.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -38,41 +39,20 @@ public sealed class OutboxRelay<TContext> : BackgroundService
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
         var context = scope.ServiceProvider.GetRequiredService<TContext>();
-        var now = DateTime.UtcNow;
-        var messages = await context.Set<OutboxMessage>()
-            .Where(message => message.PublishedAtUtc == null)
-            .OrderBy(message => message.AggregateType)
-            .ThenBy(message => message.AggregateId)
-            .ThenBy(message => message.AggregateSequence)
-            .ThenBy(message => message.OccurredAtUtc)
-            .ThenBy(message => message.Id)
-            .Take(_options.BatchSize)
-            .ToListAsync(cancellationToken);
-        var blockedAggregates = new HashSet<string>(StringComparer.Ordinal);
         var publishedCount = 0;
 
-        foreach (var message in messages)
+        for (var index = 0; index < _options.BatchSize; index++)
         {
-            var aggregateKey = $"{message.AggregateType}\u001f{message.AggregateId}";
-            if (blockedAggregates.Contains(aggregateKey))
+            var claimToken = Guid.NewGuid();
+            var message = await ClaimNextAsync(context, claimToken, cancellationToken);
+            if (message is null)
             {
-                continue;
-            }
-
-            if (message.NextAttemptAtUtc > now)
-            {
-                blockedAggregates.Add(aggregateKey);
-                continue;
+                break;
             }
 
             try
             {
                 await _transport.PublishAsync(message, cancellationToken);
-                message.PublishedAtUtc = DateTime.UtcNow;
-                message.LastError = null;
-                message.NextAttemptAtUtc = null;
-                await context.SaveChangesAsync(cancellationToken);
-                publishedCount++;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -80,20 +60,220 @@ public sealed class OutboxRelay<TContext> : BackgroundService
             }
             catch (Exception exception)
             {
-                message.PublishAttempts++;
-                message.LastError = exception.Message;
-                message.NextAttemptAtUtc = DateTime.UtcNow.Add(RetryDelay(message.PublishAttempts));
-                await context.SaveChangesAsync(cancellationToken);
-                blockedAggregates.Add(aggregateKey);
+                await MarkFailedAsync(context, message, claimToken, exception, cancellationToken);
+                continue;
+            }
+
+            if (await MarkPublishedAsync(context, message, claimToken, cancellationToken))
+            {
+                publishedCount++;
+            }
+            else
+            {
                 _logger.LogWarning(
-                    exception,
-                    "Outbox publish failed for {MessageId} from {ServiceName}; the committed event remains pending.",
+                    "Outbox claim {ClaimToken} for message {MessageId} expired before completion in {ServiceName}.",
+                    claimToken,
                     message.Id,
                     _options.ServiceName);
             }
         }
 
         return publishedCount;
+    }
+
+    private async Task<OutboxMessage?> ClaimNextAsync(
+        TContext context,
+        Guid claimToken,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        var claimedUntil = now.Add(_options.ClaimLeaseDuration);
+
+        if (!context.Database.IsRelational())
+        {
+            var pending = await context.Set<OutboxMessage>()
+                .Where(message => message.PublishedAtUtc == null)
+                .OrderBy(message => message.AggregateType)
+                .ThenBy(message => message.AggregateId)
+                .ThenBy(message => message.AggregateSequence)
+                .ThenBy(message => message.OccurredAtUtc)
+                .ThenBy(message => message.Id)
+                .ToListAsync(cancellationToken);
+            var message = pending
+                .GroupBy(item => new { item.AggregateType, item.AggregateId })
+                .Select(group => group.First())
+                .FirstOrDefault(item =>
+                    (item.NextAttemptAtUtc is null || item.NextAttemptAtUtc <= now) &&
+                    (item.ClaimedUntilUtc is null || item.ClaimedUntilUtc <= now));
+
+            if (message is null)
+            {
+                return null;
+            }
+
+            message.ClaimToken = claimToken;
+            message.ClaimedUntilUtc = claimedUntil;
+            await context.SaveChangesAsync(cancellationToken);
+            return message;
+        }
+
+        if (!string.Equals(
+                context.Database.ProviderName,
+                "Npgsql.EntityFrameworkCore.PostgreSQL",
+                StringComparison.Ordinal))
+        {
+            throw new NotSupportedException("Atomic outbox claims require the PostgreSQL provider.");
+        }
+
+        await using var transaction = await context.Database.BeginTransactionAsync(
+            IsolationLevel.ReadCommitted,
+            cancellationToken);
+        var candidates = await context.Set<OutboxMessage>()
+            .FromSqlInterpolated($"""
+                SELECT candidate.*
+                FROM "OutboxMessages" AS candidate
+                WHERE candidate."PublishedAtUtc" IS NULL
+                  AND (candidate."NextAttemptAtUtc" IS NULL OR candidate."NextAttemptAtUtc" <= {now})
+                  AND (candidate."ClaimedUntilUtc" IS NULL OR candidate."ClaimedUntilUtc" <= {now})
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM "OutboxMessages" AS earlier
+                      WHERE earlier."PublishedAtUtc" IS NULL
+                        AND earlier."AggregateType" = candidate."AggregateType"
+                        AND earlier."AggregateId" = candidate."AggregateId"
+                        AND (
+                            earlier."AggregateSequence" < candidate."AggregateSequence"
+                            OR (
+                                earlier."AggregateSequence" = candidate."AggregateSequence"
+                                AND earlier."OccurredAtUtc" < candidate."OccurredAtUtc"
+                            )
+                            OR (
+                                earlier."AggregateSequence" = candidate."AggregateSequence"
+                                AND earlier."OccurredAtUtc" = candidate."OccurredAtUtc"
+                                AND earlier."Id" < candidate."Id"
+                            )
+                        )
+                  )
+                ORDER BY candidate."AggregateType",
+                         candidate."AggregateId",
+                         candidate."AggregateSequence",
+                         candidate."OccurredAtUtc",
+                         candidate."Id"
+                LIMIT 1
+                FOR UPDATE SKIP LOCKED
+                """)
+            .ToListAsync(cancellationToken);
+        var claimedMessage = candidates.SingleOrDefault();
+
+        if (claimedMessage is not null)
+        {
+            claimedMessage.ClaimToken = claimToken;
+            claimedMessage.ClaimedUntilUtc = claimedUntil;
+            await context.SaveChangesAsync(cancellationToken);
+        }
+
+        await transaction.CommitAsync(cancellationToken);
+        return claimedMessage;
+    }
+
+    private async Task<bool> MarkPublishedAsync(
+        TContext context,
+        OutboxMessage message,
+        Guid claimToken,
+        CancellationToken cancellationToken)
+    {
+        var publishedAt = DateTime.UtcNow;
+        if (!context.Database.IsRelational())
+        {
+            if (message.ClaimToken != claimToken || message.PublishedAtUtc is not null)
+            {
+                return false;
+            }
+
+            message.PublishedAtUtc = publishedAt;
+            message.LastError = null;
+            message.NextAttemptAtUtc = null;
+            message.ClaimToken = null;
+            message.ClaimedUntilUtc = null;
+            await context.SaveChangesAsync(cancellationToken);
+            return true;
+        }
+
+        var updated = await context.Set<OutboxMessage>()
+            .Where(item =>
+                item.Id == message.Id &&
+                item.PublishedAtUtc == null &&
+                item.ClaimToken == claimToken)
+            .ExecuteUpdateAsync(setters => setters
+                .SetProperty(item => item.PublishedAtUtc, publishedAt)
+                .SetProperty(item => item.LastError, (string?)null)
+                .SetProperty(item => item.NextAttemptAtUtc, (DateTime?)null)
+                .SetProperty(item => item.ClaimToken, (Guid?)null)
+                .SetProperty(item => item.ClaimedUntilUtc, (DateTime?)null),
+                cancellationToken);
+        return updated == 1;
+    }
+
+    private async Task MarkFailedAsync(
+        TContext context,
+        OutboxMessage message,
+        Guid claimToken,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        var attempts = message.PublishAttempts + 1;
+        var nextAttempt = DateTime.UtcNow.Add(RetryDelay(attempts));
+        var error = exception.Message.Length <= 2000
+            ? exception.Message
+            : exception.Message[..2000];
+        bool released;
+
+        if (!context.Database.IsRelational())
+        {
+            released = message.ClaimToken == claimToken && message.PublishedAtUtc is null;
+            if (released)
+            {
+                message.PublishAttempts = attempts;
+                message.LastError = error;
+                message.NextAttemptAtUtc = nextAttempt;
+                message.ClaimToken = null;
+                message.ClaimedUntilUtc = null;
+                await context.SaveChangesAsync(cancellationToken);
+            }
+        }
+        else
+        {
+            released = await context.Set<OutboxMessage>()
+                .Where(item =>
+                    item.Id == message.Id &&
+                    item.PublishedAtUtc == null &&
+                    item.ClaimToken == claimToken)
+                .ExecuteUpdateAsync(setters => setters
+                    .SetProperty(item => item.PublishAttempts, item => item.PublishAttempts + 1)
+                    .SetProperty(item => item.LastError, error)
+                    .SetProperty(item => item.NextAttemptAtUtc, nextAttempt)
+                    .SetProperty(item => item.ClaimToken, (Guid?)null)
+                    .SetProperty(item => item.ClaimedUntilUtc, (DateTime?)null),
+                    cancellationToken) == 1;
+        }
+
+        if (released)
+        {
+            _logger.LogWarning(
+                exception,
+                "Outbox publish failed for {MessageId} from {ServiceName}; the committed event remains pending.",
+                message.Id,
+                _options.ServiceName);
+        }
+        else
+        {
+            _logger.LogWarning(
+                exception,
+                "Outbox publish failed after claim {ClaimToken} for {MessageId} was lost in {ServiceName}.",
+                claimToken,
+                message.Id,
+                _options.ServiceName);
+        }
     }
 
     private static TimeSpan RetryDelay(int attempts) =>

--- a/Shared/Messaging/OutboxRelay.cs
+++ b/Shared/Messaging/OutboxRelay.cs
@@ -1,0 +1,101 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace ProjectY.Shared.Messaging;
+
+public sealed class OutboxRelay<TContext> : BackgroundService
+    where TContext : DbContext
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IOutboxTransport _transport;
+    private readonly OutboxRelayOptions _options;
+    private readonly ILogger<OutboxRelay<TContext>> _logger;
+
+    public OutboxRelay(
+        IServiceScopeFactory scopeFactory,
+        IOutboxTransport transport,
+        OutboxRelayOptions options,
+        ILogger<OutboxRelay<TContext>> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _transport = transport;
+        _options = options;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await DispatchOnceAsync(stoppingToken);
+            await Task.Delay(_options.PollInterval, stoppingToken);
+        }
+    }
+
+    public async Task<int> DispatchOnceAsync(CancellationToken cancellationToken = default)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var context = scope.ServiceProvider.GetRequiredService<TContext>();
+        var now = DateTime.UtcNow;
+        var messages = await context.Set<OutboxMessage>()
+            .Where(message => message.PublishedAtUtc == null)
+            .OrderBy(message => message.AggregateType)
+            .ThenBy(message => message.AggregateId)
+            .ThenBy(message => message.AggregateSequence)
+            .ThenBy(message => message.OccurredAtUtc)
+            .ThenBy(message => message.Id)
+            .Take(_options.BatchSize)
+            .ToListAsync(cancellationToken);
+        var blockedAggregates = new HashSet<string>(StringComparer.Ordinal);
+        var publishedCount = 0;
+
+        foreach (var message in messages)
+        {
+            var aggregateKey = $"{message.AggregateType}\u001f{message.AggregateId}";
+            if (blockedAggregates.Contains(aggregateKey))
+            {
+                continue;
+            }
+
+            if (message.NextAttemptAtUtc > now)
+            {
+                blockedAggregates.Add(aggregateKey);
+                continue;
+            }
+
+            try
+            {
+                await _transport.PublishAsync(message, cancellationToken);
+                message.PublishedAtUtc = DateTime.UtcNow;
+                message.LastError = null;
+                message.NextAttemptAtUtc = null;
+                await context.SaveChangesAsync(cancellationToken);
+                publishedCount++;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                message.PublishAttempts++;
+                message.LastError = exception.Message;
+                message.NextAttemptAtUtc = DateTime.UtcNow.Add(RetryDelay(message.PublishAttempts));
+                await context.SaveChangesAsync(cancellationToken);
+                blockedAggregates.Add(aggregateKey);
+                _logger.LogWarning(
+                    exception,
+                    "Outbox publish failed for {MessageId} from {ServiceName}; the committed event remains pending.",
+                    message.Id,
+                    _options.ServiceName);
+            }
+        }
+
+        return publishedCount;
+    }
+
+    private static TimeSpan RetryDelay(int attempts) =>
+        TimeSpan.FromSeconds(Math.Min(30, Math.Pow(2, Math.Min(attempts, 5))));
+}

--- a/Shared/Messaging/OutboxRelayOptions.cs
+++ b/Shared/Messaging/OutboxRelayOptions.cs
@@ -1,0 +1,14 @@
+namespace ProjectY.Shared.Messaging;
+
+public sealed class OutboxRelayOptions
+{
+    public required string ServiceName { get; init; }
+    public required string HostName { get; init; }
+    public int Port { get; init; } = 5672;
+    public required string VirtualHost { get; init; }
+    public required string UserName { get; init; }
+    public required string Password { get; init; }
+    public int BatchSize { get; init; } = 100;
+    public TimeSpan PollInterval { get; init; } = TimeSpan.FromSeconds(1);
+    public TimeSpan ConfirmationTimeout { get; init; } = TimeSpan.FromSeconds(5);
+}

--- a/Shared/Messaging/OutboxRelayOptions.cs
+++ b/Shared/Messaging/OutboxRelayOptions.cs
@@ -10,5 +10,6 @@ public sealed class OutboxRelayOptions
     public required string Password { get; init; }
     public int BatchSize { get; init; } = 100;
     public TimeSpan PollInterval { get; init; } = TimeSpan.FromSeconds(1);
+    public TimeSpan ClaimLeaseDuration { get; init; } = TimeSpan.FromMinutes(1);
     public TimeSpan ConfirmationTimeout { get; init; } = TimeSpan.FromSeconds(5);
 }

--- a/Shared/Messaging/RabbitMqOutboxTransport.cs
+++ b/Shared/Messaging/RabbitMqOutboxTransport.cs
@@ -1,0 +1,43 @@
+using RabbitMQ.Client;
+using System.Text;
+
+namespace ProjectY.Shared.Messaging;
+
+public sealed class RabbitMqOutboxTransport : IOutboxTransport
+{
+    private readonly OutboxRelayOptions _options;
+    private readonly IRabbitMqConnectionProvider _connectionProvider;
+
+    public RabbitMqOutboxTransport(
+        OutboxRelayOptions options,
+        IRabbitMqConnectionProvider connectionProvider)
+    {
+        _options = options;
+        _connectionProvider = connectionProvider;
+    }
+
+    public Task PublishAsync(OutboxMessage message, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using var connection = _connectionProvider.Create();
+        using var channel = connection.CreateModel();
+        channel.QueueDeclare(message.Destination, durable: false, exclusive: false, autoDelete: false);
+        channel.ConfirmSelect();
+
+        var properties = channel.CreateBasicProperties();
+        properties.Persistent = true;
+        properties.MessageId = message.Id.ToString("D");
+        properties.Type = message.EventType;
+
+        channel.BasicPublish(
+            exchange: string.Empty,
+            routingKey: message.Destination,
+            mandatory: true,
+            basicProperties: properties,
+            body: Encoding.UTF8.GetBytes(message.Payload));
+        channel.WaitForConfirmsOrDie(_options.ConfirmationTimeout);
+
+        return Task.CompletedTask;
+    }
+}

--- a/Shared/Messaging/RabbitMqOutboxTransport.cs
+++ b/Shared/Messaging/RabbitMqOutboxTransport.cs
@@ -22,7 +22,7 @@ public sealed class RabbitMqOutboxTransport : IOutboxTransport
 
         using var connection = _connectionProvider.Create();
         using var channel = connection.CreateModel();
-        channel.QueueDeclare(message.Destination, durable: false, exclusive: false, autoDelete: false);
+        channel.QueueDeclare(message.Destination, durable: true, exclusive: false, autoDelete: false);
         channel.ConfirmSelect();
 
         var properties = channel.CreateBasicProperties();

--- a/deploy/observability/grafana/dashboards/plataforma.json
+++ b/deploy/observability/grafana/dashboards/plataforma.json
@@ -343,6 +343,59 @@
         "dedupStrategy": "none",
         "sortOrder": "Descending"
       }
+    },
+    {
+      "type": "row",
+      "title": "Outbox transacional",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Eventos pendentes no outbox",
+      "description": "Profundidade da fila transacional ainda nÃ£o confirmada pelo broker.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 35 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "projecty_outbox_depth",
+          "legendFormat": "{{service}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 0, "min": 0, "color": { "mode": "palette-classic" } },
+        "overrides": []
+      }
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Idade do evento mais antigo",
+      "description": "Lag entre o commit no banco e a confirmaÃ§Ã£o do broker.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 35 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "projecty_outbox_oldest_age_seconds",
+          "legendFormat": "{{service}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "decimals": 1, "min": 0, "color": { "mode": "palette-classic" } },
+        "overrides": []
+      }
     }
   ]
 }

--- a/deploy/observability/prometheus.yml
+++ b/deploy/observability/prometheus.yml
@@ -4,6 +4,9 @@ global:
   external_labels:
     cluster: projecty-local
 
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
 scrape_configs:
   # Métricas RED derivadas dos traces pelo connector spanmetrics.
   - job_name: otel-collector
@@ -24,6 +27,10 @@ scrape_configs:
         labels: { service: risk-pricing, language: python }
       - targets: ["telemetry:4000"]
         labels: { service: telemetry, language: elixir }
+      - targets: ["auth-gate:8080"]
+        labels: { service: auth-gate, language: dotnet }
+      - targets: ["moto-hub:8100"]
+        labels: { service: moto-hub, language: dotnet }
     # Um serviço fora do ar não deve derrubar o scrape dos outros.
     honor_labels: true
 

--- a/deploy/observability/rules/outbox.yml
+++ b/deploy/observability/rules/outbox.yml
@@ -1,0 +1,20 @@
+groups:
+  - name: projecty-outbox
+    rules:
+      - alert: ProjectYOutboxBacklog
+        expr: projecty_outbox_depth > 100
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Outbox backlog in {{ $labels.service }}"
+          description: "The transactional outbox has {{ $value }} unpublished events."
+
+      - alert: ProjectYOutboxStalled
+        expr: projecty_outbox_depth > 0 and projecty_outbox_oldest_age_seconds > 300
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Outbox relay stalled in {{ $labels.service }}"
+          description: "The oldest unpublished event has been waiting for more than five minutes."

--- a/deploy/overlays/selfhost/compose.override.yaml
+++ b/deploy/overlays/selfhost/compose.override.yaml
@@ -130,6 +130,7 @@ services:
       - "9090:9090"
     volumes:
       - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./observability/rules:/etc/prometheus/rules:ro
 
   tempo:
     <<: *restart

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,6 +79,10 @@ required before the first Compose startup.
 RabbitMQ does not publish its AMQP or management ports to the host. To inspect
 it locally, run management commands inside the container or attach a temporary
 tool to the Compose network instead of adding a permanent host port mapping.
+The generated definitions declare the rider and licence-update queues as
+durable. When upgrading a stack that created those queues as non-durable,
+restart RabbitMQ before the application services so the old queues disappear;
+RabbitMQ cannot change queue durability in place.
 
 Then start the stack:
 

--- a/scripts/New-LocalSecrets.ps1
+++ b/scripts/New-LocalSecrets.ps1
@@ -202,7 +202,11 @@ $rabbitMqDefinitions = [ordered]@{
     parameters = @()
     global_parameters = @()
     policies = @()
-    queues = @()
+    queues = @(
+        [ordered]@{ name = "rider_info_queue"; vhost = "projecty-rider"; durable = $true; auto_delete = $false; arguments = @{} },
+        [ordered]@{ name = "image_stream_queue"; vhost = "projecty-rider"; durable = $true; auto_delete = $false; arguments = @{} },
+        [ordered]@{ name = "licence_update_queue"; vhost = "projecty-rental"; durable = $true; auto_delete = $false; arguments = @{} }
+    )
     exchanges = @()
     bindings = @()
 }


### PR DESCRIPTION
## Summary
- persist AuthGate and MotoHub events atomically with aggregate changes
- relay pending events with RabbitMQ publisher confirms, retry backoff, and per-aggregate ordering
- expose outbox depth/lag metrics with Prometheus alerts and Grafana panels

## Validation
- AuthGate: 30 non-Docker tests passed in Release
- MotoHub: 44 non-Docker tests passed in Release
- EF Core reports no pending model changes for either service
- PostgreSQL recovery test runs in CI through Testcontainers

Closes #53