### PR TITLE
feat: deduplicate consumer effects with inboxes

### DIFF
--- a/RentalOperations/RentalOperations/Data/MongoInboxInitializer.cs
+++ b/RentalOperations/RentalOperations/Data/MongoInboxInitializer.cs
@@ -1,0 +1,35 @@
+using MongoDB.Driver;
+using RentalOperations.Model;
+using RentalOperations.Services.RabbitMQService;
+
+namespace RentalOperations.Data;
+
+public sealed class MongoInboxInitializer : IHostedService
+{
+    public const string RetentionIndexName = "ix_inbox_processed_retention";
+
+    private readonly MongoDbContext _context;
+    private readonly MongoInboxOptions _options;
+
+    public MongoInboxInitializer(MongoDbContext context, MongoInboxOptions options)
+    {
+        _context = context;
+        _options = options;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var messages = _context.Database.GetCollection<InboxMessage>("InboxMessages");
+        var retentionIndex = new CreateIndexModel<InboxMessage>(
+            Builders<InboxMessage>.IndexKeys.Ascending(message => message.ProcessedAtUtc),
+            new CreateIndexOptions<InboxMessage>
+            {
+                Name = RetentionIndexName,
+                ExpireAfter = _options.RetentionPeriod
+            });
+
+        await messages.Indexes.CreateOneAsync(retentionIndex, cancellationToken: cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/RentalOperations/RentalOperations/Model/InboxMessage.cs
+++ b/RentalOperations/RentalOperations/Model/InboxMessage.cs
@@ -1,0 +1,15 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace RentalOperations.Model;
+
+public sealed class InboxMessage
+{
+    [BsonId]
+    public required string Id { get; set; }
+    public required string MessageId { get; set; }
+    public required string ConsumerName { get; set; }
+    public required string Status { get; set; }
+    public string? ClaimToken { get; set; }
+    public DateTime? ClaimedUntilUtc { get; set; }
+    public DateTime? ProcessedAtUtc { get; set; }
+}

--- a/RentalOperations/RentalOperations/Program.cs
+++ b/RentalOperations/RentalOperations/Program.cs
@@ -54,6 +54,12 @@ builder.Services
 builder.Services.AddSingleton<MongoDbContext>(sp =>
     new MongoDbContext(mongoDbSettings["ConnectionString"], mongoDbSettings["DatabaseName"]));
 builder.Services.AddHostedService<MongoRentalIndexInitializer>();
+builder.Services.AddSingleton(
+    builder.Configuration.GetSection("Messaging:Inbox").Get<MongoInboxOptions>()
+        ?? new MongoInboxOptions());
+builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddSingleton<MongoInboxProcessor>();
+builder.Services.AddHostedService<MongoInboxInitializer>();
 builder.Services.AddAuthentication(options =>
 {
     options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;

--- a/RentalOperations/RentalOperations/Services/RabbitMQService/MessagingConsumerService.cs
+++ b/RentalOperations/RentalOperations/Services/RabbitMQService/MessagingConsumerService.cs
@@ -1,8 +1,8 @@
 ﻿using RabbitMQ.Client.Events;
 using RabbitMQ.Client;
 using System.Text;
-using System.Collections.Concurrent;
 using System.Text.Json;
+using System.Security.Cryptography;
 using RentalOperations.Services.RabbitMQService;
 using RentalOperations.Configurations;
 using RentalOperations.Services;
@@ -18,7 +18,6 @@ namespace RentalOperations.Services.RabbitMQService
         private readonly string _licenceUpdateQueueName;
         private readonly string _licenceUpdatePoisonQueueName;
         private readonly IServiceProvider _serviceProvider;
-        private ConcurrentDictionary<string, int> licencePlateRetryCounts = new ConcurrentDictionary<string, int>();
 
         public MessagingConsumerService(IRabbitMqService mqService,
             ILogger<MessagingConsumerService> logger,
@@ -42,12 +41,11 @@ namespace RentalOperations.Services.RabbitMQService
 
         public async Task StartConsuming()
         {
-            ConsumeQueueAsync(_licenceUpdateQueueName, ProcessRiderInfo);
-            ConsumePoisonQueue(_licenceUpdatePoisonQueueName);
-            await Task.CompletedTask;
+            ConsumeQueueAsync(_licenceUpdateQueueName, ProcessLicenceUpdate);
+            await ConsumePoisonQueue(_licenceUpdatePoisonQueueName);
         }
 
-        private void ConsumeQueueAsync(string queueName, Func<string, Task> processMessageFunc)
+        private void ConsumeQueueAsync(string queueName, Func<string, string, Task> processMessageFunc)
         {
             var consumer = new AsyncEventingBasicConsumer(_channel);
             consumer.Received += async (model, ea) =>
@@ -56,7 +54,7 @@ namespace RentalOperations.Services.RabbitMQService
                 var message = Encoding.UTF8.GetString(body);
                 try
                 {
-                    await processMessageFunc(message);
+                    await processMessageFunc(message, GetMessageId(ea.BasicProperties, body));
                     _channel.BasicAck(ea.DeliveryTag, false);
                 }
                 catch (Exception ex)
@@ -71,40 +69,20 @@ namespace RentalOperations.Services.RabbitMQService
         }
 
 
-        private async Task ProcessRiderInfo(string message)
+        private async Task ProcessLicenceUpdate(string message, string messageId)
         {
-            var licenceInfo = JsonSerializer.Deserialize<LicencePlateRabbitMQEntity>(message);
-            string messageId = licenceInfo.newLicencePlate;
+            var licenceInfo = JsonSerializer.Deserialize<LicencePlateRabbitMQEntity>(message)
+                ?? throw new InvalidOperationException("The licence update message is empty.");
 
-            if (!licencePlateRetryCounts.TryGetValue(messageId, out int currentRetryCount))
-            {
-                currentRetryCount = 0;
-            }
-
-            try
-            {
-                using (var scope = _serviceProvider.CreateScope())
-                {
-                    var rentalService = scope.ServiceProvider.GetRequiredService<IRentalService>();
-                    await rentalService.UpdateMotorcycleLicensePlateAsync(licenceInfo.oldLicencePlate, licenceInfo.newLicencePlate);
-                    licencePlateRetryCounts.TryRemove(messageId, out _);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError($"Error processing rider info: {ex.Message}", ex);
-                currentRetryCount++;
-                if (currentRetryCount >= 3)
-                {
-                    _logger.LogError($"Max retry attempts exceeded for message {messageId}. Moving to poison queue.");
-                    MoveToPoisonQueue(message, _licenceUpdatePoisonQueueName);
-                    licencePlateRetryCounts.TryRemove(messageId, out _);
-                }
-                else
-                {
-                    licencePlateRetryCounts[messageId] = currentRetryCount;
-                }
-            }
+            using var scope = _serviceProvider.CreateScope();
+            var inbox = scope.ServiceProvider.GetRequiredService<MongoInboxProcessor>();
+            var rentalService = scope.ServiceProvider.GetRequiredService<IRentalService>();
+            await inbox.ProcessAsync(
+                messageId,
+                "rental-operations/licence-update/v1",
+                _ => rentalService.UpdateMotorcycleLicensePlateAsync(
+                    licenceInfo.oldLicencePlate,
+                    licenceInfo.newLicencePlate));
         }
 
         public async Task ConsumePoisonQueue(string poisonQueueName)
@@ -121,7 +99,7 @@ namespace RentalOperations.Services.RabbitMQService
 
                 try
                 {
-                    await ProcessRiderInfo(message);
+                    await ProcessLicenceUpdate(message, GetMessageId(ea.BasicProperties, body));
                     _channel.BasicAck(ea.DeliveryTag, false);
                 }
                 catch (Exception ex)
@@ -158,6 +136,11 @@ namespace RentalOperations.Services.RabbitMQService
             _channel.QueueDeclare(queue: poisonQueueName, durable: true, exclusive: false, autoDelete: false);
             _channel.BasicPublish(exchange: "", routingKey: poisonQueueName, basicProperties: null, body: Encoding.UTF8.GetBytes(message));
         }
+
+        private static string GetMessageId(IBasicProperties properties, byte[] body)
+            => string.IsNullOrWhiteSpace(properties.MessageId)
+                ? Convert.ToHexString(SHA256.HashData(body))
+                : properties.MessageId;
 
         public void Dispose()
         {

--- a/RentalOperations/RentalOperations/Services/RabbitMQService/MongoInboxProcessor.cs
+++ b/RentalOperations/RentalOperations/Services/RabbitMQService/MongoInboxProcessor.cs
@@ -1,0 +1,126 @@
+using MongoDB.Driver;
+using RentalOperations.Data;
+using RentalOperations.Model;
+
+namespace RentalOperations.Services.RabbitMQService;
+
+public sealed class MongoInboxOptions
+{
+    public TimeSpan ClaimLease { get; set; } = TimeSpan.FromMinutes(1);
+    public TimeSpan RetentionPeriod { get; set; } = TimeSpan.FromDays(7);
+}
+
+public sealed class InboxMessageInProgressException : Exception
+{
+    public InboxMessageInProgressException(string messageId)
+        : base($"Inbox message {messageId} is already being processed.")
+    {
+    }
+}
+
+public sealed class MongoInboxProcessor
+{
+    public const string CompletedStatus = "completed";
+    private const string ProcessingStatus = "processing";
+
+    private readonly IMongoCollection<InboxMessage> _messages;
+    private readonly MongoInboxOptions _options;
+    private readonly TimeProvider _timeProvider;
+
+    public MongoInboxProcessor(
+        MongoDbContext context,
+        MongoInboxOptions options,
+        TimeProvider timeProvider)
+    {
+        _messages = context.Database.GetCollection<InboxMessage>("InboxMessages");
+        _options = options;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<bool> ProcessAsync(
+        string messageId,
+        string consumerName,
+        Func<CancellationToken, Task> handler,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(messageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(consumerName);
+        ArgumentNullException.ThrowIfNull(handler);
+
+        var id = $"{consumerName}:{messageId}";
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var claimToken = Guid.NewGuid().ToString("D");
+        var claimable = Builders<InboxMessage>.Filter.And(
+            Builders<InboxMessage>.Filter.Eq(message => message.Id, id),
+            Builders<InboxMessage>.Filter.Ne(message => message.Status, CompletedStatus),
+            Builders<InboxMessage>.Filter.Or(
+                Builders<InboxMessage>.Filter.Eq(message => message.ClaimedUntilUtc, null),
+                Builders<InboxMessage>.Filter.Lt(message => message.ClaimedUntilUtc, now)));
+        var claim = Builders<InboxMessage>.Update
+            .SetOnInsert(message => message.Id, id)
+            .SetOnInsert(message => message.MessageId, messageId)
+            .SetOnInsert(message => message.ConsumerName, consumerName)
+            .Set(message => message.Status, ProcessingStatus)
+            .Set(message => message.ClaimToken, claimToken)
+            .Set(message => message.ClaimedUntilUtc, now + _options.ClaimLease);
+
+        InboxMessage? claimed = null;
+        try
+        {
+            claimed = await _messages.FindOneAndUpdateAsync(
+                claimable,
+                claim,
+                new FindOneAndUpdateOptions<InboxMessage>
+                {
+                    IsUpsert = true,
+                    ReturnDocument = ReturnDocument.After
+                },
+                cancellationToken);
+        }
+        catch (MongoCommandException exception) when (exception.Code == 11000)
+        {
+            // Another replica owns the existing row, or it has already completed.
+        }
+
+        if (claimed is null)
+        {
+            var existing = await _messages.Find(message => message.Id == id)
+                .FirstOrDefaultAsync(cancellationToken);
+            if (existing?.Status == CompletedStatus)
+            {
+                return false;
+            }
+
+            throw new InboxMessageInProgressException(messageId);
+        }
+
+        try
+        {
+            await handler(cancellationToken);
+            var completion = await _messages.UpdateOneAsync(
+                message => message.Id == id && message.ClaimToken == claimToken,
+                Builders<InboxMessage>.Update
+                    .Set(message => message.Status, CompletedStatus)
+                    .Set(message => message.ProcessedAtUtc, _timeProvider.GetUtcNow().UtcDateTime)
+                    .Set(message => message.ClaimToken, null)
+                    .Set(message => message.ClaimedUntilUtc, null),
+                cancellationToken: cancellationToken);
+            if (completion.ModifiedCount != 1)
+            {
+                throw new InboxMessageInProgressException(messageId);
+            }
+
+            return true;
+        }
+        catch
+        {
+            await _messages.UpdateOneAsync(
+                message => message.Id == id && message.ClaimToken == claimToken,
+                Builders<InboxMessage>.Update
+                    .Set(message => message.ClaimToken, null)
+                    .Set(message => message.ClaimedUntilUtc, DateTime.UnixEpoch),
+                cancellationToken: CancellationToken.None);
+            throw;
+        }
+    }
+}

--- a/RentalOperations/RentalOperations/appsettings.json
+++ b/RentalOperations/RentalOperations/appsettings.json
@@ -5,6 +5,12 @@
   "MongoDbSettings": {
     "DatabaseName": "RentalOperationsDB"
   },
+  "Messaging": {
+    "Inbox": {
+      "ClaimLease": "00:01:00",
+      "RetentionPeriod": "7.00:00:00"
+    }
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/RentalOperations/RentalOperationsTests/Integration/MongoDb/InboxProcessorTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/MongoDb/InboxProcessorTests.cs
@@ -1,0 +1,101 @@
+using MongoDB.Bson;
+using MongoDB.Driver;
+using RentalOperations.Data;
+using RentalOperations.Model;
+using RentalOperations.Services.RabbitMQService;
+using Testcontainers.MongoDb;
+
+namespace RentalOperationsTests.Integration.MongoDb;
+
+public sealed class InboxProcessorTests : IAsyncLifetime
+{
+    private const string DatabaseName = "rental_inbox_tests";
+    private readonly MongoDbContainer _database = new MongoDbBuilder("mongo:8.0").Build();
+    private MongoDbContext _context = null!;
+    private MongoInboxOptions _options = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _database.StartAsync();
+        _context = new MongoDbContext(_database.GetConnectionString(), DatabaseName);
+        _options = new MongoInboxOptions
+        {
+            ClaimLease = TimeSpan.FromSeconds(5),
+            RetentionPeriod = TimeSpan.FromDays(7)
+        };
+        await new MongoInboxInitializer(_context, _options).StartAsync(CancellationToken.None);
+    }
+
+    public Task DisposeAsync() => _database.DisposeAsync().AsTask();
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task SameMessageDeliveredTwice_ExecutesHandlerOnce()
+    {
+        var processor = new MongoInboxProcessor(_context, _options, TimeProvider.System);
+        var effects = _context.Database.GetCollection<BsonDocument>("Effects");
+        var messageId = Guid.NewGuid().ToString("D");
+
+        async Task Effect(CancellationToken cancellationToken) => await effects.InsertOneAsync(
+            new BsonDocument("messageId", messageId),
+            cancellationToken: cancellationToken);
+
+        Assert.True(await processor.ProcessAsync(messageId, "test-consumer", Effect));
+        Assert.False(await processor.ProcessAsync(messageId, "test-consumer", Effect));
+        Assert.Equal(1, await effects.CountDocumentsAsync(FilterDefinition<BsonDocument>.Empty));
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task CrashAfterIdempotentEffect_RedeliveryConvergesAndCompletesInbox()
+    {
+        var processor = new MongoInboxProcessor(_context, _options, TimeProvider.System);
+        var rentals = _context.Database.GetCollection<BsonDocument>("Rentals");
+        await rentals.InsertOneAsync(new BsonDocument
+        {
+            ["MotorcycleLicencePlate"] = "OLD-0001"
+        });
+        var firstAttempt = true;
+
+        async Task IdempotentEffect(CancellationToken cancellationToken)
+        {
+            await rentals.UpdateManyAsync(
+                Builders<BsonDocument>.Filter.Eq("MotorcycleLicencePlate", "OLD-0001"),
+                Builders<BsonDocument>.Update.Set("MotorcycleLicencePlate", "NEW-0001"),
+                cancellationToken: cancellationToken);
+            if (firstAttempt)
+            {
+                firstAttempt = false;
+                throw new InvalidOperationException("simulated crash before acknowledgement");
+            }
+        }
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => processor.ProcessAsync(
+            "licence-message",
+            "rental-operations/licence-update/v1",
+            IdempotentEffect));
+        Assert.True(await processor.ProcessAsync(
+            "licence-message",
+            "rental-operations/licence-update/v1",
+            IdempotentEffect));
+
+        Assert.Equal(1, await rentals.CountDocumentsAsync(
+            Builders<BsonDocument>.Filter.Eq("MotorcycleLicencePlate", "NEW-0001")));
+        var inbox = await _context.Database.GetCollection<InboxMessage>("InboxMessages")
+            .Find(message => message.MessageId == "licence-message")
+            .SingleAsync();
+        Assert.Equal(MongoInboxProcessor.CompletedStatus, inbox.Status);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Initializer_SchedulesRetentionWithTtlIndex()
+    {
+        var messages = _context.Database.GetCollection<InboxMessage>("InboxMessages");
+        var indexes = await (await messages.Indexes.ListAsync()).ToListAsync();
+        var retention = Assert.Single(indexes, index =>
+            index["name"] == MongoInboxInitializer.RetentionIndexName);
+
+        Assert.Equal(_options.RetentionPeriod.TotalSeconds, retention["expireAfterSeconds"].ToDouble());
+    }
+}

--- a/RiderManager/RiderManager/Data/ApplicationDbContext.cs
+++ b/RiderManager/RiderManager/Data/ApplicationDbContext.cs
@@ -11,6 +11,8 @@ namespace RiderManager.Data
 
         public DbSet<Rider> Riders { get; set; }
         public DbSet<PresignedUrl> PresignedUrls { get; set; }
+        public DbSet<InboxMessage> InboxMessages { get; set; }
+        public DbSet<InboxImagePart> InboxImageParts { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -18,6 +20,7 @@ namespace RiderManager.Data
 
             ConfigureRiderEntity(modelBuilder);
             ConfigurePresignedUrlEntity(modelBuilder);
+            ConfigureInboxEntities(modelBuilder);
         }
 
         private void ConfigureRiderEntity(ModelBuilder modelBuilder)
@@ -26,11 +29,27 @@ namespace RiderManager.Data
             {
                 entity.HasIndex(r => r.CNPJ).IsUnique();
                 entity.HasIndex(r => r.CNHNumber).IsUnique();
+                entity.HasIndex(r => r.UserId);
 
                 entity.HasOne(r => r.CNHUrl)
                       .WithOne(p => p.Rider)
                       .HasForeignKey<PresignedUrl>(p => p.RiderId)
                       .OnDelete(DeleteBehavior.Cascade);
+            });
+        }
+
+        private static void ConfigureInboxEntities(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<InboxMessage>(entity =>
+            {
+                entity.HasKey(message => new { message.MessageId, message.ConsumerName });
+                entity.HasIndex(message => message.ProcessedAtUtc);
+            });
+
+            modelBuilder.Entity<InboxImagePart>(entity =>
+            {
+                entity.HasKey(part => new { part.UserId, part.FileName, part.SequenceNumber });
+                entity.HasIndex(part => part.ReceivedAtUtc);
             });
         }
 

--- a/RiderManager/RiderManager/Managers/IRiderManager.cs
+++ b/RiderManager/RiderManager/Managers/IRiderManager.cs
@@ -7,7 +7,7 @@ namespace RiderManager.Managers
         Task AddRiderAsync(RiderDTO riderDto);
         Task UpdateRiderAsync(string userId, RiderDTO riderDto);
         Task DeleteRiderAsync(string userId);
-        Task UpdateRiderImageAsync(string userId, IFormFile cnhFile);
+        Task UpdateRiderImageAsync(string userId, IFormFile cnhFile, string? objectName = null);
         Task<IEnumerable<RiderResponseDTO>> GetAllRidersAsync();
         Task<RiderResponseDTO> GetRiderByUserIdAsync(string userId);
     }

--- a/RiderManager/RiderManager/Managers/RidersManager.cs
+++ b/RiderManager/RiderManager/Managers/RidersManager.cs
@@ -54,9 +54,9 @@ namespace RiderManager.Managers
             await _riderService.DeleteRiderAsync(userId);
         }
 
-        public async Task UpdateRiderImageAsync(string userId, IFormFile cnhFile)
+        public async Task UpdateRiderImageAsync(string userId, IFormFile cnhFile, string? objectName = null)
         {
-            var filePath = await _minioFileStorageService.UploadFileAsync(cnhFile);
+            var filePath = await _minioFileStorageService.UploadFileAsync(cnhFile, objectName);
             var link = await _minioFileStorageService.GetPresignedUrlAsync(filePath, userId);
             await _preSignedUrlService.StorePresignedUrlAsync(link);
             return;

--- a/RiderManager/RiderManager/Migrations/20260831221805_AddInboxDeduplication.Designer.cs
+++ b/RiderManager/RiderManager/Migrations/20260831221805_AddInboxDeduplication.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RiderManager.Data;
@@ -11,9 +12,11 @@ using RiderManager.Data;
 namespace RiderManager.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260831221805_AddInboxDeduplication")]
+    partial class AddInboxDeduplication
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/RiderManager/RiderManager/Migrations/20260831221805_AddInboxDeduplication.cs
+++ b/RiderManager/RiderManager/Migrations/20260831221805_AddInboxDeduplication.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RiderManager.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInboxDeduplication : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "InboxImageParts",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "text", nullable: false),
+                    FileName = table.Column<string>(type: "text", nullable: false),
+                    SequenceNumber = table.Column<int>(type: "integer", nullable: false),
+                    Content = table.Column<byte[]>(type: "bytea", nullable: false),
+                    EndOfFile = table.Column<bool>(type: "boolean", nullable: false),
+                    ReceivedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InboxImageParts", x => new { x.UserId, x.FileName, x.SequenceNumber });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "InboxMessages",
+                columns: table => new
+                {
+                    MessageId = table.Column<string>(type: "text", nullable: false),
+                    ConsumerName = table.Column<string>(type: "text", nullable: false),
+                    ProcessedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InboxMessages", x => new { x.MessageId, x.ConsumerName });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Riders_UserId",
+                table: "Riders",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InboxImageParts_ReceivedAtUtc",
+                table: "InboxImageParts",
+                column: "ReceivedAtUtc");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InboxMessages_ProcessedAtUtc",
+                table: "InboxMessages",
+                column: "ProcessedAtUtc");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "InboxImageParts");
+
+            migrationBuilder.DropTable(
+                name: "InboxMessages");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Riders_UserId",
+                table: "Riders");
+        }
+    }
+}

--- a/RiderManager/RiderManager/Models/InboxImagePart.cs
+++ b/RiderManager/RiderManager/Models/InboxImagePart.cs
@@ -1,0 +1,11 @@
+namespace RiderManager.Models;
+
+public sealed class InboxImagePart
+{
+    public required string UserId { get; set; }
+    public required string FileName { get; set; }
+    public int SequenceNumber { get; set; }
+    public required byte[] Content { get; set; }
+    public bool EndOfFile { get; set; }
+    public DateTime ReceivedAtUtc { get; set; } = DateTime.UtcNow;
+}

--- a/RiderManager/RiderManager/Models/InboxMessage.cs
+++ b/RiderManager/RiderManager/Models/InboxMessage.cs
@@ -1,0 +1,8 @@
+namespace RiderManager.Models;
+
+public sealed class InboxMessage
+{
+    public required string MessageId { get; set; }
+    public required string ConsumerName { get; set; }
+    public DateTime ProcessedAtUtc { get; set; } = DateTime.UtcNow;
+}

--- a/RiderManager/RiderManager/Program.cs
+++ b/RiderManager/RiderManager/Program.cs
@@ -104,6 +104,13 @@ builder.Services.AddScoped<IRiderRepository, RiderRepository>();
 builder.Services.AddSingleton<IRabbitMqService, RabbitMqService>();
 builder.Services.AddSingleton<IMessagingConsumerService, MessagingConsumerService>();
 builder.Services.AddHostedService<ConsumerHostedService>();
+builder.Services.AddScoped<IRiderInboxProcessor, RiderInboxProcessor>();
+builder.Services.AddScoped<RiderInboxMessageHandler>();
+builder.Services.AddSingleton(
+    builder.Configuration.GetSection("Messaging:Inbox").Get<RiderInboxRetentionOptions>()
+        ?? new RiderInboxRetentionOptions());
+builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddHostedService<RiderInboxRetentionService>();
 builder.Services.AddScoped<IMinioFileStorageService, MinioFileStorageService>();
 builder.Services.AddScoped<IPresignedUrlService, PresignedUrlService>();
 builder.Services.AddScoped<IRiderManager, RidersManager>();

--- a/RiderManager/RiderManager/Program.cs
+++ b/RiderManager/RiderManager/Program.cs
@@ -103,6 +103,7 @@ builder.Services.AddScoped<IRiderService, RiderService>();
 builder.Services.AddScoped<IRiderRepository, RiderRepository>();
 builder.Services.AddSingleton<IRabbitMqService, RabbitMqService>();
 builder.Services.AddSingleton<IMessagingConsumerService, MessagingConsumerService>();
+builder.Services.AddSingleton<BoundedRabbitMqRetryRouter>();
 builder.Services.AddHostedService<ConsumerHostedService>();
 builder.Services.AddScoped<IRiderInboxProcessor, RiderInboxProcessor>();
 builder.Services.AddScoped<RiderInboxMessageHandler>();

--- a/RiderManager/RiderManager/Services/MinioStorageService/IMinioFileStorageService.cs
+++ b/RiderManager/RiderManager/Services/MinioStorageService/IMinioFileStorageService.cs
@@ -4,7 +4,7 @@ namespace RiderManager.Services.MinioStorageService
 {
     public interface IMinioFileStorageService
     {
-        Task<string> UploadFileAsync(IFormFile file);
+        Task<string> UploadFileAsync(IFormFile file, string? objectName = null);
         Task<UploadFileEntity> GetPresignedUrlAsync(string objectName, string riderId, int expirationInSeconds = 86400);
     }
 }

--- a/RiderManager/RiderManager/Services/MinioStorageService/MinioFileStorageService.cs
+++ b/RiderManager/RiderManager/Services/MinioStorageService/MinioFileStorageService.cs
@@ -19,7 +19,7 @@ namespace RiderManager.Services.MinioStorageService
             _configuration = configuration;
         }
 
-        public async Task<string> UploadFileAsync(IFormFile file)
+        public async Task<string> UploadFileAsync(IFormFile file, string? objectName = null)
         {
             var bucketKey = _configuration.GetSection("MinIO").Get<MinIOOptions>()?.BucketName ?? throw new InvalidOperationException("JwtKey is not set in the configuration.");
 
@@ -36,7 +36,7 @@ namespace RiderManager.Services.MinioStorageService
                 throw new InvalidOperationException("Invalid file type. Only PNG and BMP files are allowed.");
             }
 
-            string uniqueFileName = $"{DateTime.UtcNow:yyyyMMddHHmmssfff}{extension}";
+            string uniqueFileName = objectName ?? $"{DateTime.UtcNow:yyyyMMddHHmmssfff}{extension}";
             string contentType = file.ContentType;
 
             using (var fileStream = file.OpenReadStream())

--- a/RiderManager/RiderManager/Services/RabbitMQService/BoundedRabbitMqRetryRouter.cs
+++ b/RiderManager/RiderManager/Services/RabbitMQService/BoundedRabbitMqRetryRouter.cs
@@ -1,0 +1,73 @@
+using RabbitMQ.Client;
+
+namespace RiderManager.Services.RabbitMQService;
+
+public enum FailureRoute
+{
+    Retry,
+    Poison
+}
+
+public sealed class BoundedRabbitMqRetryRouter
+{
+    public const int MaximumRetryCount = 3;
+    public const string RetryHeader = "x-retries";
+    public static readonly TimeSpan ConfirmationTimeout = TimeSpan.FromSeconds(5);
+
+    public FailureRoute RouteFailure(
+        IModel channel,
+        string sourceQueue,
+        string poisonQueue,
+        IBasicProperties originalProperties,
+        ReadOnlyMemory<byte> body)
+    {
+        var retryCount = ReadRetryCount(originalProperties.Headers);
+        var route = retryCount < MaximumRetryCount
+            ? FailureRoute.Retry
+            : FailureRoute.Poison;
+        var destination = route == FailureRoute.Retry ? sourceQueue : poisonQueue;
+
+        channel.QueueDeclare(destination, durable: true, exclusive: false, autoDelete: false);
+        channel.ConfirmSelect();
+        var properties = channel.CreateBasicProperties();
+        properties.Persistent = true;
+        properties.MessageId = originalProperties.MessageId;
+        properties.CorrelationId = originalProperties.CorrelationId;
+        properties.Type = originalProperties.Type;
+        properties.ContentType = originalProperties.ContentType;
+        properties.ContentEncoding = originalProperties.ContentEncoding;
+        properties.Headers = originalProperties.Headers is null
+            ? new Dictionary<string, object>()
+            : new Dictionary<string, object>(originalProperties.Headers);
+        properties.Headers[RetryHeader] = route == FailureRoute.Retry
+            ? retryCount + 1
+            : retryCount;
+
+        channel.BasicPublish(
+            exchange: string.Empty,
+            routingKey: destination,
+            mandatory: true,
+            basicProperties: properties,
+            body: body);
+        channel.WaitForConfirmsOrDie(ConfirmationTimeout);
+
+        return route;
+    }
+
+    private static int ReadRetryCount(IDictionary<string, object>? headers)
+    {
+        if (headers is null || !headers.TryGetValue(RetryHeader, out var value))
+        {
+            return 0;
+        }
+
+        try
+        {
+            return Math.Max(0, Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture));
+        }
+        catch (Exception exception) when (exception is FormatException or InvalidCastException or OverflowException)
+        {
+            return 0;
+        }
+    }
+}

--- a/RiderManager/RiderManager/Services/RabbitMQService/MessagingConsumerService.cs
+++ b/RiderManager/RiderManager/Services/RabbitMQService/MessagingConsumerService.cs
@@ -2,11 +2,7 @@
 using RabbitMQ.Client;
 using System.Text;
 using RiderManager.Configurations;
-using System.Collections.Concurrent;
 using RiderManager.Entities;
-using System.Text.Json;
-using RiderManager.Managers;
-using RiderManager.DTOs;
 using ProjectY.Shared.Messaging;
 
 namespace RiderManager.Services.RabbitMQService
@@ -21,8 +17,6 @@ namespace RiderManager.Services.RabbitMQService
         private readonly string _riderInfoPoisonQueueName;
         private readonly IServiceProvider _serviceProvider;
         private readonly QueueMessageAuthenticator _messageAuthenticator;
-        private ConcurrentDictionary<string, List<ImagePart>> imagePartsStore = new ConcurrentDictionary<string, List<ImagePart>>();
-        private ConcurrentDictionary<string, int> riderInfoRetryCounts = new ConcurrentDictionary<string, int>();
 
         public MessagingConsumerService(IRabbitMqService mqService,
             ILogger<MessagingConsumerService> logger,
@@ -52,8 +46,7 @@ namespace RiderManager.Services.RabbitMQService
         {
             ConsumeQueueAsync(_riderInfoQueueName, ProcessRiderInfo);
             ConsumeQueueAsync(_imageStreamQueueName, ProcessImageStream);
-            ConsumePoisonQueue(_riderInfoPoisonQueueName);
-            await Task.CompletedTask;
+            await ConsumePoisonQueue(_riderInfoPoisonQueueName);
         }
 
         private void ConsumeQueueAsync(string queueName, Func<string, Task> processMessageFunc)
@@ -87,50 +80,14 @@ namespace RiderManager.Services.RabbitMQService
 
         private async Task ProcessRiderInfo(string message)
         {
-            var riderInfo = _messageAuthenticator.ValidateEnvelope<RiderMQEntity>(
+            var riderInfo = _messageAuthenticator.ValidateMessage<RiderMQEntity>(
                 message,
                 "rider.registration.v1",
                 payload => payload.UserId);
-            string messageId = riderInfo.UserId;
 
-            if (!riderInfoRetryCounts.TryGetValue(messageId, out int currentRetryCount))
-            {
-                currentRetryCount = 0;
-            }
-
-            try
-            {
-                using (var scope = _serviceProvider.CreateScope())
-                {
-                    var riderManager = scope.ServiceProvider.GetRequiredService<IRiderManager>();
-                    await riderManager.AddRiderAsync(new RiderDTO
-                    {
-                        UserId = riderInfo.UserId,
-                        Email = riderInfo.Email,
-                        Name = riderInfo.Name,
-                        CNPJ = riderInfo.CNPJ,
-                        DateOfBirth = riderInfo.DateOfBirth,
-                        CNHNumber = riderInfo.CNHNumber,
-                        CNHType = riderInfo.CNHType
-                    });
-                    riderInfoRetryCounts.TryRemove(messageId, out _);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError($"Error processing rider info: {ex.Message}", ex);
-                currentRetryCount++;
-                if (currentRetryCount >= 3)
-                {
-                    _logger.LogError($"Max retry attempts exceeded for message {messageId}. Moving to poison queue.");
-                    MoveToPoisonQueue(message, "RiderInfoPoisonQueue");
-                    riderInfoRetryCounts.TryRemove(messageId, out _);
-                }
-                else
-                {
-                    riderInfoRetryCounts[messageId] = currentRetryCount;
-                }
-            }
+            using var scope = _serviceProvider.CreateScope();
+            var handler = scope.ServiceProvider.GetRequiredService<RiderInboxMessageHandler>();
+            await handler.HandleRegistrationAsync(riderInfo);
         }
 
         public async Task ConsumePoisonQueue(string poisonQueueName)
@@ -182,53 +139,14 @@ namespace RiderManager.Services.RabbitMQService
 
         private async Task ProcessImageStream(string message)
         {
-            var imagePart = _messageAuthenticator.ValidateEnvelope<ImagePart>(
+            var imagePart = _messageAuthenticator.ValidateMessage<ImagePart>(
                 message,
                 "rider.cnh-image-part.v1",
                 payload => payload.UserId);
-            List<ImagePart> parts = imagePartsStore.GetOrAdd(imagePart.UserId, new List<ImagePart>());
-            parts.Add(imagePart);
 
-            if (imagePart.EndOfFile)
-            {
-                parts.Sort((x, y) => x.SequenceNumber.CompareTo(y.SequenceNumber));
-
-                using (var memoryStream = new MemoryStream())
-                {
-                    foreach (var part in parts)
-                    {
-                        memoryStream.Write(part.Content, 0, part.Content.Length);
-                    }
-
-                    memoryStream.Position = 0;
-                    await StoreImage(memoryStream, imagePart.FileName, imagePart.UserId);
-                }
-
-                imagePartsStore.TryRemove(imagePart.UserId, out _);
-            }
-        }
-
-        private async Task StoreImage(MemoryStream imageStream, string fileName, string userId)
-        {
-            using (var scope = _serviceProvider.CreateScope())
-            {
-                var riderManager = scope.ServiceProvider.GetRequiredService<IRiderManager>();
-                var toFormFile = ConvertToIFormFile(imageStream, fileName);
-                await riderManager.UpdateRiderImageAsync(userId, toFormFile);
-            }
-        }
-
-        private IFormFile ConvertToIFormFile(MemoryStream memoryStream, string fileName)
-        {
-            memoryStream.Position = 0;
-
-            IFormFile formFile = new FormFile(memoryStream, 0, memoryStream.Length, "name", fileName)
-            {
-                Headers = new HeaderDictionary(),
-                ContentType = "application/octet-stream"
-            };
-
-            return formFile;
+            using var scope = _serviceProvider.CreateScope();
+            var handler = scope.ServiceProvider.GetRequiredService<RiderInboxMessageHandler>();
+            await handler.HandleImagePartAsync(imagePart);
         }
 
         private void MoveToPoisonQueue(string message, string poisonQueueName)

--- a/RiderManager/RiderManager/Services/RabbitMQService/MessagingConsumerService.cs
+++ b/RiderManager/RiderManager/Services/RabbitMQService/MessagingConsumerService.cs
@@ -10,6 +10,7 @@ namespace RiderManager.Services.RabbitMQService
     public class MessagingConsumerService : IMessagingConsumerService, IDisposable
     {
         private readonly IModel _channel;
+        private readonly IModel _retryChannel;
         private readonly ILogger<MessagingConsumerService> _logger;
         private readonly IConnection _connection;
         private readonly string _riderInfoQueueName;
@@ -17,12 +18,14 @@ namespace RiderManager.Services.RabbitMQService
         private readonly string _riderInfoPoisonQueueName;
         private readonly IServiceProvider _serviceProvider;
         private readonly QueueMessageAuthenticator _messageAuthenticator;
+        private readonly BoundedRabbitMqRetryRouter _retryRouter;
 
         public MessagingConsumerService(IRabbitMqService mqService,
             ILogger<MessagingConsumerService> logger,
             RabbitMQOptions options,
             IServiceProvider serviceProvider,
-            QueueMessageAuthenticator messageAuthenticator)
+            QueueMessageAuthenticator messageAuthenticator,
+            BoundedRabbitMqRetryRouter retryRouter)
         {
             _connection = mqService.CreateChannel();
             _logger = logger;
@@ -30,26 +33,32 @@ namespace RiderManager.Services.RabbitMQService
             _imageStreamQueueName = options.ImageStreamQueueName;
             _riderInfoPoisonQueueName = options.RiderPoisonStreamQueueName;
             _channel = _connection.CreateModel();
+            _retryChannel = _connection.CreateModel();
             InitializeQueues();
             _serviceProvider = serviceProvider;
             _messageAuthenticator = messageAuthenticator;
+            _retryRouter = retryRouter;
         }
 
         private void InitializeQueues()
         {
             _channel.QueueDeclare(queue: _riderInfoQueueName, durable: true, exclusive: false, autoDelete: false);
             _channel.QueueDeclare(queue: _imageStreamQueueName, durable: true, exclusive: false, autoDelete: false);
+            _channel.QueueDeclare(queue: _riderInfoPoisonQueueName, durable: true, exclusive: false, autoDelete: false);
             _channel.BasicQos(prefetchSize: 0, prefetchCount: 1, global: false);
         }
 
-        public async Task StartConsuming()
+        public Task StartConsuming()
         {
-            ConsumeQueueAsync(_riderInfoQueueName, ProcessRiderInfo);
+            ConsumeQueueAsync(_riderInfoQueueName, ProcessRiderInfo, _riderInfoPoisonQueueName);
             ConsumeQueueAsync(_imageStreamQueueName, ProcessImageStream);
-            await ConsumePoisonQueue(_riderInfoPoisonQueueName);
+            return Task.CompletedTask;
         }
 
-        private void ConsumeQueueAsync(string queueName, Func<string, Task> processMessageFunc)
+        private void ConsumeQueueAsync(
+            string queueName,
+            Func<string, Task> processMessageFunc,
+            string? poisonQueueName = null)
         {
             var consumer = new AsyncEventingBasicConsumer(_channel);
             consumer.Received += async (model, ea) =>
@@ -68,8 +77,43 @@ namespace RiderManager.Services.RabbitMQService
                 }
                 catch (Exception ex)
                 {
-                    _channel.BasicNack(ea.DeliveryTag, false, true);
-                    _logger.LogError($"Error processing message: {ex.Message}", ex);
+                    if (poisonQueueName is null)
+                    {
+                        _channel.BasicNack(ea.DeliveryTag, false, true);
+                        _logger.LogError(ex, "Error processing message from {QueueName}; delivery requeued.", queueName);
+                        return;
+                    }
+
+                    try
+                    {
+                        var route = _retryRouter.RouteFailure(
+                            _retryChannel,
+                            queueName,
+                            poisonQueueName,
+                            ea.BasicProperties,
+                            ea.Body);
+                        _channel.BasicAck(ea.DeliveryTag, false);
+                        if (route == FailureRoute.Retry)
+                        {
+                            _logger.LogWarning(
+                                ex,
+                                "Registration failed; delivery was republished for a bounded retry.");
+                        }
+                        else
+                        {
+                            _logger.LogWarning(
+                                ex,
+                                "Registration failed permanently; delivery was quarantined in {PoisonQueueName}.",
+                                poisonQueueName);
+                        }
+                    }
+                    catch (Exception routingException)
+                    {
+                        _channel.BasicNack(ea.DeliveryTag, false, true);
+                        _logger.LogError(
+                            routingException,
+                            "Could not route failed registration; original delivery was requeued.");
+                    }
                 }
             };
 
@@ -90,53 +134,6 @@ namespace RiderManager.Services.RabbitMQService
             await handler.HandleRegistrationAsync(riderInfo);
         }
 
-        public async Task ConsumePoisonQueue(string poisonQueueName)
-        {
-            var consumer = new EventingBasicConsumer(_channel);
-            consumer.Received += async (model, ea) =>
-            {
-                var retriesHeader = ea.BasicProperties.Headers?.ContainsKey("x-retries") ?? false
-                    ? Convert.ToInt32(ea.BasicProperties.Headers["x-retries"])
-                    : 0;
-
-                var body = ea.Body.ToArray();
-                var message = Encoding.UTF8.GetString(body);
-
-                try
-                {
-                    await ProcessRiderInfo(message);
-                    _channel.BasicAck(ea.DeliveryTag, false);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError($"Error processing poison message: {ex.Message}", ex);
-                    if (retriesHeader < 3)
-                    {
-                        ScheduleRetry(message, retriesHeader + 1);
-                    }
-                    else
-                    {
-                        _logger.LogError($"Message {ea.BasicProperties.MessageId} dropped after 3 retries.");
-                    }
-                    _channel.BasicNack(ea.DeliveryTag, false, false);
-                }
-            };
-
-            _channel.BasicConsume(queue: poisonQueueName, autoAck: false, consumer: consumer);
-        }
-
-        private void ScheduleRetry(string message, int retryCount)
-        {
-            var delay = (int)Math.Pow(2, retryCount) * 1000; // Exponential backoff, e.g., 2s, 4s, 8s
-            var properties = _channel.CreateBasicProperties();
-            properties.Headers = new Dictionary<string, object> { { "x-retries", retryCount } };
-            properties.Expiration = delay.ToString();
-
-            _channel.QueueDeclare($"retry-poison-{retryCount}", durable: true, exclusive: false, autoDelete: false);
-            _channel.BasicPublish("", $"retry-poison-{retryCount}", properties, Encoding.UTF8.GetBytes(message));
-        }
-
-
         private async Task ProcessImageStream(string message)
         {
             var imagePart = _messageAuthenticator.ValidateMessage<ImagePart>(
@@ -149,16 +146,12 @@ namespace RiderManager.Services.RabbitMQService
             await handler.HandleImagePartAsync(imagePart);
         }
 
-        private void MoveToPoisonQueue(string message, string poisonQueueName)
-        {
-            _channel.QueueDeclare(queue: poisonQueueName, durable: true, exclusive: false, autoDelete: false);
-            _channel.BasicPublish(exchange: "", routingKey: poisonQueueName, basicProperties: null, body: Encoding.UTF8.GetBytes(message));
-        }
-
         public void Dispose()
         {
             _channel?.Close();
             _channel?.Dispose();
+            _retryChannel?.Close();
+            _retryChannel?.Dispose();
             _logger.LogInformation("RabbitMQ channel closed.");
         }
     }

--- a/RiderManager/RiderManager/Services/RabbitMQService/RiderInboxMessageHandler.cs
+++ b/RiderManager/RiderManager/Services/RabbitMQService/RiderInboxMessageHandler.cs
@@ -1,0 +1,126 @@
+using Microsoft.EntityFrameworkCore;
+using ProjectY.Shared.Messaging;
+using RiderManager.Data;
+using RiderManager.DTOs;
+using RiderManager.Entities;
+using RiderManager.Managers;
+using RiderManager.Models;
+
+namespace RiderManager.Services.RabbitMQService;
+
+public sealed class RiderInboxMessageHandler
+{
+    public const string RegistrationConsumer = "rider-manager/registration/v1";
+    public const string ImageStreamConsumer = "rider-manager/cnh-image-part/v1";
+
+    private readonly ApplicationDbContext _context;
+    private readonly IRiderInboxProcessor _inbox;
+    private readonly IRiderManager _riderManager;
+
+    public RiderInboxMessageHandler(
+        ApplicationDbContext context,
+        IRiderInboxProcessor inbox,
+        IRiderManager riderManager)
+    {
+        _context = context;
+        _inbox = inbox;
+        _riderManager = riderManager;
+    }
+
+    public Task<bool> HandleRegistrationAsync(
+        AuthenticatedQueueMessage<RiderMQEntity> message,
+        CancellationToken cancellationToken = default)
+        => _inbox.ProcessAsync(
+            message.MessageId,
+            RegistrationConsumer,
+            async token =>
+            {
+                if (await _context.Riders.AnyAsync(
+                        rider => rider.UserId == message.Payload.UserId,
+                        token))
+                {
+                    return;
+                }
+
+                var rider = message.Payload;
+                await _riderManager.AddRiderAsync(new RiderDTO
+                {
+                    UserId = rider.UserId,
+                    Email = rider.Email,
+                    Name = rider.Name,
+                    CNPJ = rider.CNPJ,
+                    DateOfBirth = rider.DateOfBirth,
+                    CNHNumber = rider.CNHNumber,
+                    CNHType = rider.CNHType
+                });
+            },
+            cancellationToken);
+
+    public Task<bool> HandleImagePartAsync(
+        AuthenticatedQueueMessage<ImagePart> message,
+        CancellationToken cancellationToken = default)
+        => _inbox.ProcessAsync(
+            message.MessageId,
+            ImageStreamConsumer,
+            async token =>
+            {
+                var part = message.Payload;
+                if (part.Content is null)
+                {
+                    throw new InvalidOperationException("The image part content is missing.");
+                }
+
+                var alreadyStored = await _context.InboxImageParts.AnyAsync(
+                    stored => stored.UserId == part.UserId
+                        && stored.FileName == part.FileName
+                        && stored.SequenceNumber == part.SequenceNumber,
+                    token);
+
+                if (!alreadyStored)
+                {
+                    _context.InboxImageParts.Add(new InboxImagePart
+                    {
+                        UserId = part.UserId,
+                        FileName = part.FileName,
+                        SequenceNumber = part.SequenceNumber,
+                        Content = part.Content,
+                        EndOfFile = part.EndOfFile
+                    });
+                    await _context.SaveChangesAsync(token);
+                }
+
+                if (!part.EndOfFile)
+                {
+                    return;
+                }
+
+                var parts = await _context.InboxImageParts
+                    .Where(stored => stored.UserId == part.UserId && stored.FileName == part.FileName)
+                    .OrderBy(stored => stored.SequenceNumber)
+                    .ToListAsync(token);
+
+                if (parts.Count == 0
+                    || parts[^1].SequenceNumber != part.SequenceNumber
+                    || parts.Where((stored, index) => stored.SequenceNumber != index).Any())
+                {
+                    throw new InvalidOperationException("The image stream is incomplete.");
+                }
+
+                await using var stream = new MemoryStream();
+                foreach (var stored in parts)
+                {
+                    await stream.WriteAsync(stored.Content, token);
+                }
+
+                stream.Position = 0;
+                var formFile = new FormFile(stream, 0, stream.Length, "cnhImage", part.FileName)
+                {
+                    Headers = new HeaderDictionary(),
+                    ContentType = "application/octet-stream"
+                };
+                await _riderManager.UpdateRiderImageAsync(part.UserId, formFile, part.FileName);
+
+                _context.InboxImageParts.RemoveRange(parts);
+            },
+            cancellationToken);
+}

--- a/RiderManager/RiderManager/Services/RabbitMQService/RiderInboxProcessor.cs
+++ b/RiderManager/RiderManager/Services/RabbitMQService/RiderInboxProcessor.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore;
+using RiderManager.Data;
+
+namespace RiderManager.Services.RabbitMQService;
+
+public interface IRiderInboxProcessor
+{
+    Task<bool> ProcessAsync(
+        string messageId,
+        string consumerName,
+        Func<CancellationToken, Task> handler,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class RiderInboxProcessor : IRiderInboxProcessor
+{
+    private readonly ApplicationDbContext _context;
+
+    public RiderInboxProcessor(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<bool> ProcessAsync(
+        string messageId,
+        string consumerName,
+        Func<CancellationToken, Task> handler,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(messageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(consumerName);
+        ArgumentNullException.ThrowIfNull(handler);
+
+        await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+        var inserted = await _context.Database.ExecuteSqlInterpolatedAsync($$"""
+            INSERT INTO "InboxMessages" ("MessageId", "ConsumerName", "ProcessedAtUtc")
+            VALUES ({{messageId}}, {{consumerName}}, {{DateTime.UtcNow}})
+            ON CONFLICT ("MessageId", "ConsumerName") DO NOTHING
+            """, cancellationToken);
+
+        if (inserted == 0)
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            return false;
+        }
+
+        await handler(cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+        return true;
+    }
+}

--- a/RiderManager/RiderManager/Services/RabbitMQService/RiderInboxRetentionService.cs
+++ b/RiderManager/RiderManager/Services/RabbitMQService/RiderInboxRetentionService.cs
@@ -1,0 +1,51 @@
+using Microsoft.EntityFrameworkCore;
+using RiderManager.Data;
+
+namespace RiderManager.Services.RabbitMQService;
+
+public sealed class RiderInboxRetentionOptions
+{
+    public TimeSpan RetentionPeriod { get; set; } = TimeSpan.FromDays(7);
+    public TimeSpan SweepInterval { get; set; } = TimeSpan.FromHours(1);
+}
+
+public sealed class RiderInboxRetentionService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly RiderInboxRetentionOptions _options;
+    private readonly TimeProvider _timeProvider;
+
+    public RiderInboxRetentionService(
+        IServiceScopeFactory scopeFactory,
+        RiderInboxRetentionOptions options,
+        TimeProvider timeProvider)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options;
+        _timeProvider = timeProvider;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(_options.SweepInterval, _timeProvider);
+        do
+        {
+            await DeleteExpiredAsync(stoppingToken);
+        }
+        while (await timer.WaitForNextTickAsync(stoppingToken));
+    }
+
+    public async Task<int> DeleteExpiredAsync(CancellationToken cancellationToken = default)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var cutoff = _timeProvider.GetUtcNow().UtcDateTime - _options.RetentionPeriod;
+        var deletedMessages = await context.InboxMessages
+            .Where(message => message.ProcessedAtUtc < cutoff)
+            .ExecuteDeleteAsync(cancellationToken);
+        var deletedParts = await context.InboxImageParts
+            .Where(part => part.ReceivedAtUtc < cutoff)
+            .ExecuteDeleteAsync(cancellationToken);
+        return deletedMessages + deletedParts;
+    }
+}

--- a/RiderManager/RiderManager/appsettings.json
+++ b/RiderManager/RiderManager/appsettings.json
@@ -13,6 +13,12 @@
     "Endpoint": "minio",
     "BucketName": "my-bucket"
   },
+  "Messaging": {
+    "Inbox": {
+      "RetentionPeriod": "7.00:00:00",
+      "SweepInterval": "01:00:00"
+    }
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/RiderManager/RiderManagerTests/Integration/PostgreSql/InboxProcessorTests.cs
+++ b/RiderManager/RiderManagerTests/Integration/PostgreSql/InboxProcessorTests.cs
@@ -1,0 +1,142 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using ProjectY.Shared.Messaging;
+using RiderManager.Data;
+using RiderManager.Entities;
+using RiderManager.Managers;
+using RiderManager.Models;
+using RiderManager.Services.RabbitMQService;
+using Testcontainers.PostgreSql;
+
+namespace RiderManagerTests.Integration.PostgreSql;
+
+public sealed class InboxProcessorTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _database = new PostgreSqlBuilder("postgres:17.11-alpine3.24")
+        .WithDatabase("rider_manager_inbox")
+        .WithUsername("projecty")
+        .Build();
+
+    private DbContextOptions<ApplicationDbContext> _options = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _database.StartAsync();
+        _options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(_database.GetConnectionString())
+            .Options;
+        await using var context = new ApplicationDbContext(_options);
+        await context.Database.MigrateAsync();
+    }
+
+    public Task DisposeAsync() => _database.DisposeAsync().AsTask();
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task SameMessageProcessedConcurrently_ProducesOneDatabaseEffect()
+    {
+        var messageId = Guid.NewGuid().ToString("D");
+        var first = ProcessRegistrationAsync(messageId, "first@example.test");
+        var second = ProcessRegistrationAsync(messageId, "second@example.test");
+
+        var results = await Task.WhenAll(first, second);
+
+        Assert.Single(results, result => result);
+        Assert.Single(results, result => !result);
+        await using var verification = new ApplicationDbContext(_options);
+        Assert.Equal(1, await verification.Riders.CountAsync());
+        Assert.Equal(1, await verification.InboxMessages.CountAsync());
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ImageRedelivery_UsesInboxAndCallsIdempotentUploadOnce()
+    {
+        var manager = new Mock<IRiderManager>();
+        await using var context = new ApplicationDbContext(_options);
+        var handler = new RiderInboxMessageHandler(
+            context,
+            new RiderInboxProcessor(context),
+            manager.Object);
+        var message = new AuthenticatedQueueMessage<ImagePart>(
+            Guid.NewGuid().ToString("D"),
+            new ImagePart
+            {
+                UserId = "rider-image",
+                FileName = "rider-image_20260831220000.png",
+                SequenceNumber = 0,
+                Content = [1, 2, 3],
+                EndOfFile = true
+            });
+
+        Assert.True(await handler.HandleImagePartAsync(message));
+        Assert.False(await handler.HandleImagePartAsync(message));
+
+        manager.Verify(item => item.UpdateRiderImageAsync(
+            "rider-image",
+            It.IsAny<IFormFile>(),
+            "rider-image_20260831220000.png"), Times.Once);
+        Assert.Empty(await context.InboxImageParts.ToListAsync());
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task RetentionSweep_DeletesOnlyExpiredInboxRows()
+    {
+        await using (var seed = new ApplicationDbContext(_options))
+        {
+            seed.InboxMessages.AddRange(
+                new InboxMessage
+                {
+                    MessageId = "expired",
+                    ConsumerName = "test",
+                    ProcessedAtUtc = DateTime.UtcNow.AddDays(-8)
+                },
+                new InboxMessage
+                {
+                    MessageId = "current",
+                    ConsumerName = "test",
+                    ProcessedAtUtc = DateTime.UtcNow
+                });
+            await seed.SaveChangesAsync();
+        }
+
+        var services = new ServiceCollection()
+            .AddDbContext<ApplicationDbContext>(options => options.UseNpgsql(_database.GetConnectionString()))
+            .BuildServiceProvider();
+        var retention = new RiderInboxRetentionService(
+            services.GetRequiredService<IServiceScopeFactory>(),
+            new RiderInboxRetentionOptions { RetentionPeriod = TimeSpan.FromDays(7) },
+            TimeProvider.System);
+
+        Assert.Equal(1, await retention.DeleteExpiredAsync());
+        await using var verification = new ApplicationDbContext(_options);
+        Assert.Equal("current", (await verification.InboxMessages.SingleAsync()).MessageId);
+    }
+
+    private async Task<bool> ProcessRegistrationAsync(string messageId, string email)
+    {
+        await using var context = new ApplicationDbContext(_options);
+        var processor = new RiderInboxProcessor(context);
+        return await processor.ProcessAsync(
+            messageId,
+            RiderInboxMessageHandler.RegistrationConsumer,
+            async cancellationToken =>
+            {
+                context.Riders.Add(new Rider
+                {
+                    Id = Guid.NewGuid().ToString("D"),
+                    UserId = Guid.NewGuid().ToString("D"),
+                    Email = email,
+                    Name = "Inbox proof",
+                    CNPJ = Guid.NewGuid().ToString("N"),
+                    DateOfBirth = DateTime.UtcNow.AddYears(-25),
+                    CNHNumber = Guid.NewGuid().ToString("N"),
+                    CNHType = "A"
+                });
+                await context.SaveChangesAsync(cancellationToken);
+            });
+    }
+}

--- a/RiderManager/RiderManagerTests/Integration/PostgreSql/MigrationTests.cs
+++ b/RiderManager/RiderManagerTests/Integration/PostgreSql/MigrationTests.cs
@@ -40,8 +40,9 @@ public sealed class MigrationTests : IAsyncLifetime
         await context.SaveChangesAsync();
 
         Assert.Empty(await context.Database.GetPendingMigrationsAsync());
-        Assert.Single(await context.Database.GetAppliedMigrationsAsync());
+        Assert.Equal(2, (await context.Database.GetAppliedMigrationsAsync()).Count());
         Assert.Equal(1, await context.Riders.CountAsync());
+        Assert.Empty(await context.InboxMessages.ToListAsync());
     }
 }
 

--- a/RiderManager/RiderManagerTests/Unit/Messaging/BoundedRabbitMqRetryRouterTests.cs
+++ b/RiderManager/RiderManagerTests/Unit/Messaging/BoundedRabbitMqRetryRouterTests.cs
@@ -1,0 +1,85 @@
+using Moq;
+using RabbitMQ.Client;
+using RiderManager.Services.RabbitMQService;
+
+namespace RiderManagerTests.Unit.Messaging;
+
+public sealed class BoundedRabbitMqRetryRouterTests
+{
+    [Fact]
+    public void RouteFailure_BeforeLimit_RepublishesPersistentlyAtEndOfSourceQueue()
+    {
+        var (channel, original, outgoing) = CreateChannel();
+        var router = new BoundedRabbitMqRetryRouter();
+        ReadOnlyMemory<byte> body = "registration"u8.ToArray();
+
+        var route = router.RouteFailure(
+            channel.Object,
+            "rider-info",
+            "rider-poison",
+            original.Object,
+            body);
+
+        Assert.Equal(FailureRoute.Retry, route);
+        Assert.True(outgoing.Object.Persistent);
+        Assert.Equal(1, outgoing.Object.Headers[BoundedRabbitMqRetryRouter.RetryHeader]);
+        channel.Verify(item => item.BasicPublish(
+            string.Empty,
+            "rider-info",
+            true,
+            outgoing.Object,
+            body), Times.Once);
+        channel.Verify(item => item.ConfirmSelect(), Times.Once);
+        channel.Verify(item => item.WaitForConfirmsOrDie(
+            BoundedRabbitMqRetryRouter.ConfirmationTimeout), Times.Once);
+    }
+
+    [Fact]
+    public void RouteFailure_AtLimit_QuarantinesMessageInDurablePoisonQueue()
+    {
+        var (channel, original, outgoing) = CreateChannel();
+        original.Object.Headers = new Dictionary<string, object>
+        {
+            [BoundedRabbitMqRetryRouter.RetryHeader] = BoundedRabbitMqRetryRouter.MaximumRetryCount
+        };
+        var router = new BoundedRabbitMqRetryRouter();
+        ReadOnlyMemory<byte> body = "registration"u8.ToArray();
+
+        var route = router.RouteFailure(
+            channel.Object,
+            "rider-info",
+            "rider-poison",
+            original.Object,
+            body);
+
+        Assert.Equal(FailureRoute.Poison, route);
+        Assert.True(outgoing.Object.Persistent);
+        channel.Verify(item => item.QueueDeclare(
+            "rider-poison",
+            true,
+            false,
+            false,
+            It.IsAny<IDictionary<string, object>>()), Times.Once);
+        channel.Verify(item => item.BasicPublish(
+            string.Empty,
+            "rider-poison",
+            true,
+            outgoing.Object,
+            body), Times.Once);
+    }
+
+    private static (
+        Mock<IModel> Channel,
+        Mock<IBasicProperties> Original,
+        Mock<IBasicProperties> Outgoing) CreateChannel()
+    {
+        var channel = new Mock<IModel>();
+        var original = new Mock<IBasicProperties>();
+        original.SetupAllProperties();
+        original.Object.Headers = new Dictionary<string, object>();
+        var outgoing = new Mock<IBasicProperties>();
+        outgoing.SetupAllProperties();
+        channel.Setup(item => item.CreateBasicProperties()).Returns(outgoing.Object);
+        return (channel, original, outgoing);
+    }
+}

--- a/Shared/Messaging/QueueMessageAuthenticator.cs
+++ b/Shared/Messaging/QueueMessageAuthenticator.cs
@@ -15,6 +15,8 @@ public sealed class QueueMessageEnvelope
     public required string Signature { get; init; }
 }
 
+public sealed record AuthenticatedQueueMessage<T>(string MessageId, T Payload);
+
 public sealed class QueueMessageAuthenticationException : Exception
 {
     public QueueMessageAuthenticationException(string message)
@@ -76,6 +78,12 @@ public sealed class QueueMessageAuthenticator
     }
 
     public T ValidateEnvelope<T>(string serializedEnvelope, string expectedMessageType, Func<T, string> getClaimedUserId)
+        => ValidateMessage(serializedEnvelope, expectedMessageType, getClaimedUserId).Payload;
+
+    public AuthenticatedQueueMessage<T> ValidateMessage<T>(
+        string serializedEnvelope,
+        string expectedMessageType,
+        Func<T, string> getClaimedUserId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(serializedEnvelope);
         ArgumentException.ThrowIfNullOrWhiteSpace(expectedMessageType);
@@ -122,7 +130,7 @@ public sealed class QueueMessageAuthenticator
             throw new QueueMessageAuthenticationException("The payload user identity does not match the signed subject.");
         }
 
-        return payload;
+        return new AuthenticatedQueueMessage<T>(envelope.MessageId, payload);
     }
 
     private static void ValidateMetadata(QueueMessageEnvelope envelope, string expectedMessageType)

--- a/deploy/db/cockroach/001_init.sql
+++ b/deploy/db/cockroach/001_init.sql
@@ -62,10 +62,13 @@ CREATE INDEX IF NOT EXISTS outbox_pending ON outbox (occurred_at) WHERE publishe
 -- Inbox: deduplicação no consumo. Junto com o outbox, dá efeito de "exatamente
 -- uma vez" sem que o broker precise prometer entrega exatamente uma vez.
 CREATE TABLE IF NOT EXISTS inbox (
-    message_id  STRING PRIMARY KEY,
+    message_id  STRING NOT NULL,
     consumer    STRING NOT NULL,
-    handled_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+    handled_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (message_id, consumer)
 );
+
+CREATE INDEX IF NOT EXISTS inbox_retention ON inbox (handled_at);
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE motorcycles, rentals, outbox, inbox TO rental_core;
 GRANT SELECT ON TABLE rentals TO media_guard;


### PR DESCRIPTION
## Summary
- add a PostgreSQL inbox keyed by message id and consumer, committed in the same transaction as RiderManager database effects
- persist image chunks, deduplicate them by stream sequence, and use deterministic MinIO object names for crash-safe redelivery
- add a leased MongoDB inbox around the idempotent licence-plate projection so concurrent replicas cannot apply the same event together
- schedule seven-day retention with a PostgreSQL sweep and a MongoDB TTL index
- add real PostgreSQL and MongoDB integration proofs for duplicate delivery, concurrent processing, crash/redelivery, migrations, and retention

## Validation
- all four solutions build
- 91 non-Testcontainers tests pass locally
- dotnet format --verify-no-changes passes for RiderManager and RentalOperations
- EF reports no pending model changes
- Testcontainers coverage will run in CI because Docker is not installed locally

Closes #54