### PR TITLE
feat: honor Idempotency-Key on write endpoints

### DIFF
--- a/AuthGate/AuthGate/AuthGate.csproj
+++ b/AuthGate/AuthGate/AuthGate.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Http" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.InMemory" Version="0.11.0" />
+    <PackageReference Include="StackExchange.Redis" Version="3.1.31" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
@@ -47,6 +48,7 @@
     <Compile Include="..\..\Shared\Messaging\OutboxRelay.cs" Link="Shared\Messaging\OutboxRelay.cs" />
     <Compile Include="..\..\Shared\Messaging\OutboxRelayOptions.cs" Link="Shared\Messaging\OutboxRelayOptions.cs" />
     <Compile Include="..\..\Shared\Messaging\RabbitMqOutboxTransport.cs" Link="Shared\Messaging\RabbitMqOutboxTransport.cs" />
+    <Compile Include="..\..\Shared\Idempotency\*.cs" Link="Shared\Idempotency\%(Filename)%(Extension)" />
   </ItemGroup>
   
 </Project>

--- a/AuthGate/AuthGate/Program.cs
+++ b/AuthGate/AuthGate/Program.cs
@@ -15,6 +15,7 @@ using ProjectY.Shared.Health;
 using ProjectY.Shared.Hosting;
 using Serilog.Sinks.Elasticsearch;
 using ProjectY.Shared.Messaging;
+using ProjectY.Shared.Idempotency;
 
 if (await HealthProbeCommand.TryRunAsync(args))
 {
@@ -58,10 +59,11 @@ builder.Services
 builder.Services.AddSingleton(new QueueMessageAuthenticator(
     builder.Configuration["Messaging:SigningKey"]
         ?? throw new InvalidOperationException("Messaging:SigningKey is not configured.")));
+builder.Services.AddProjectYIdempotency(builder.Configuration, "auth-gate");
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(options => options.OperationFilter<IdempotencyKeyOperationFilter>());
 
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("Postgresql")));
@@ -132,6 +134,7 @@ app.UseHttpsRedirection();
 
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseProjectYIdempotency();
 
 app.MapControllers();
 app.MapProjectYHealthChecks();

--- a/AuthGate/AuthGate/appsettings.json
+++ b/AuthGate/AuthGate/appsettings.json
@@ -2,6 +2,14 @@
   "Swagger": {
     "Enabled": false
   },
+  "Redis": {
+    "ConnectionString": "redis:6379"
+  },
+  "Idempotency": {
+    "ClaimTtl": "00:01:00",
+    "ResponseTtl": "1.00:00:00",
+    "MaximumKeyLength": 200
+  },
   "RabbitMQ": {
     "HostName": "rabbitmq",
     "VirtualHost": "projecty-rider",

--- a/AuthGate/AuthGate/appsettings.json
+++ b/AuthGate/AuthGate/appsettings.json
@@ -6,7 +6,6 @@
     "ConnectionString": "redis:6379"
   },
   "Idempotency": {
-    "ClaimTtl": "00:01:00",
     "ResponseTtl": "1.00:00:00",
     "MaximumKeyLength": 200
   },

--- a/MotoHub/MotoHub/MotoHub.csproj
+++ b/MotoHub/MotoHub/MotoHub.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Http" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="StackExchange.Redis" Version="3.1.31" />
   </ItemGroup>
 
   <ItemGroup>
@@ -45,6 +46,7 @@
     <Compile Include="..\..\Shared\Messaging\OutboxRelay.cs" Link="Shared\Messaging\OutboxRelay.cs" />
     <Compile Include="..\..\Shared\Messaging\OutboxRelayOptions.cs" Link="Shared\Messaging\OutboxRelayOptions.cs" />
     <Compile Include="..\..\Shared\Messaging\RabbitMqOutboxTransport.cs" Link="Shared\Messaging\RabbitMqOutboxTransport.cs" />
+    <Compile Include="..\..\Shared\Idempotency\*.cs" Link="Shared\Idempotency\%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/MotoHub/MotoHub/Program.cs
+++ b/MotoHub/MotoHub/Program.cs
@@ -17,6 +17,7 @@ using Npgsql;
 using ProjectY.Shared.Health;
 using ProjectY.Shared.Hosting;
 using ProjectY.Shared.Messaging;
+using ProjectY.Shared.Idempotency;
 
 if (await HealthProbeCommand.TryRunAsync(args))
 {
@@ -53,6 +54,7 @@ builder.Host.UseSerilog();
 var rabbitMQConfig = builder.Configuration.GetSection("RabbitMQ").Get<RabbitMQOptions>()
     ?? throw new InvalidOperationException("RabbitMQ configuration is missing.");
 builder.Services.AddSingleton<RabbitMQOptions>(rabbitMQConfig);
+builder.Services.AddProjectYIdempotency(builder.Configuration, "moto-hub");
 var postgresConnection = new NpgsqlConnectionStringBuilder(
     builder.Configuration.GetConnectionString("Postgresql") ?? "Host=postgres;Port=5432");
 builder.Services
@@ -107,6 +109,7 @@ builder.Services.AddScoped<IRentalOperationService, RentalOperationService>();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
+    c.OperationFilter<IdempotencyKeyOperationFilter>();
     c.SwaggerDoc("v1", new OpenApiInfo { Title = "MotoHub", Version = "v1" });
     var securityScheme = new OpenApiSecurityScheme
     {
@@ -147,8 +150,8 @@ if (SwaggerPolicy.IsEnabled(app.Environment, app.Configuration))
 app.UseHttpsRedirection();
 
 app.UseAuthentication();
-
 app.UseAuthorization();
+app.UseProjectYIdempotency();
 
 app.MapControllers();
 app.MapProjectYHealthChecks();

--- a/MotoHub/MotoHub/appsettings.json
+++ b/MotoHub/MotoHub/appsettings.json
@@ -2,6 +2,14 @@
   "Swagger": {
     "Enabled": false
   },
+  "Redis": {
+    "ConnectionString": "redis:6379"
+  },
+  "Idempotency": {
+    "ClaimTtl": "00:01:00",
+    "ResponseTtl": "1.00:00:00",
+    "MaximumKeyLength": 200
+  },
   "RabbitMQ": {
     "HostName": "rabbitmq",
     "VirtualHost": "projecty-rental",

--- a/MotoHub/MotoHub/appsettings.json
+++ b/MotoHub/MotoHub/appsettings.json
@@ -6,7 +6,6 @@
     "ConnectionString": "redis:6379"
   },
   "Idempotency": {
-    "ClaimTtl": "00:01:00",
     "ResponseTtl": "1.00:00:00",
     "MaximumKeyLength": 200
   },

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ isolated local environment.
 
 Database-backed tests use the shared
 [PostgreSQL Testcontainers pattern](docs/testing/testcontainers-postgres.md).
+State-changing API retries follow the shared
+[`Idempotency-Key` contract](docs/api/idempotency.md).
 
 ### Modernization development loop
 

--- a/RentalOperations/RentalOperations/Program.cs
+++ b/RentalOperations/RentalOperations/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.OpenApi.Models;
 using MongoDB.Driver;
 using ProjectY.Shared.Health;
 using ProjectY.Shared.Hosting;
+using ProjectY.Shared.Idempotency;
 using RentalOperations.Configurations;
 using RentalOperations.CrossCutting.Services;
 using RentalOperations.Data;
@@ -40,6 +41,7 @@ Log.Logger = new LoggerConfiguration()
 
 builder.Services.Configure<RiderManagerSettings>(builder.Configuration.GetSection("RiderManagerSettings"));
 builder.Services.Configure<MotoHubSettings>(builder.Configuration.GetSection("MotoHubSettings"));
+builder.Services.AddProjectYIdempotency(builder.Configuration, "rental-operations");
 
 var rabbitMQConfig = builder.Configuration.GetSection("RabbitMQ").Get<RabbitMQOptions>();
 builder.Services.AddSingleton<RabbitMQOptions>(rabbitMQConfig);
@@ -86,6 +88,7 @@ builder.Services.AddScoped<AdminAuthorizationFilter>();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
+    c.OperationFilter<IdempotencyKeyOperationFilter>();
     c.SwaggerDoc("v1", new OpenApiInfo { Title = "RentalOperations", Version = "v1" });
 
     // Configuração do esquema de segurança JWT no Swagger
@@ -137,6 +140,7 @@ app.UseHttpsRedirection();
 
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseProjectYIdempotency();
 
 app.MapControllers();
 app.MapProjectYHealthChecks();

--- a/RentalOperations/RentalOperations/RentalOperations.csproj
+++ b/RentalOperations/RentalOperations/RentalOperations.csproj
@@ -23,11 +23,13 @@
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Http" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="StackExchange.Redis" Version="3.1.31" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\..\Shared\Health\ServiceHealthChecks.cs" Link="Shared\Health\ServiceHealthChecks.cs" />
     <Compile Include="..\..\Shared\Hosting\SwaggerPolicy.cs" Link="Shared\Hosting\SwaggerPolicy.cs" />
+    <Compile Include="..\..\Shared\Idempotency\*.cs" Link="Shared\Idempotency\%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/RentalOperations/RentalOperations/appsettings.json
+++ b/RentalOperations/RentalOperations/appsettings.json
@@ -2,6 +2,14 @@
   "Swagger": {
     "Enabled": false
   },
+  "Redis": {
+    "ConnectionString": "redis:6379"
+  },
+  "Idempotency": {
+    "ClaimTtl": "00:01:00",
+    "ResponseTtl": "1.00:00:00",
+    "MaximumKeyLength": 200
+  },
   "MongoDbSettings": {
     "DatabaseName": "RentalOperationsDB"
   },

--- a/RentalOperations/RentalOperations/appsettings.json
+++ b/RentalOperations/RentalOperations/appsettings.json
@@ -6,7 +6,6 @@
     "ConnectionString": "redis:6379"
   },
   "Idempotency": {
-    "ClaimTtl": "00:01:00",
     "ResponseTtl": "1.00:00:00",
     "MaximumKeyLength": 200
   },

--- a/RiderManager/RiderManager/Program.cs
+++ b/RiderManager/RiderManager/Program.cs
@@ -22,6 +22,7 @@ using ProjectY.Shared.Health;
 using ProjectY.Shared.Hosting;
 using Serilog.Sinks.Elasticsearch;
 using ProjectY.Shared.Messaging;
+using ProjectY.Shared.Idempotency;
 
 if (await HealthProbeCommand.TryRunAsync(args))
 {
@@ -51,6 +52,7 @@ builder.Services
 builder.Services.AddSingleton(new QueueMessageAuthenticator(
     builder.Configuration["Messaging:SigningKey"]
         ?? throw new InvalidOperationException("Messaging:SigningKey is not configured.")));
+builder.Services.AddProjectYIdempotency(builder.Configuration, "rider-manager");
 
 
 var applicationName = builder.Configuration["ApplicationName"];
@@ -117,6 +119,7 @@ builder.Services.AddScoped<IPresignedUrlService, PresignedUrlService>();
 builder.Services.AddScoped<IRiderManager, RidersManager>();
 builder.Services.AddSwaggerGen(c =>
 {
+    c.OperationFilter<IdempotencyKeyOperationFilter>();
     c.SwaggerDoc("v1", new OpenApiInfo { Title = "RiderManager", Version = "v1" });
 
     // Configuração do esquema de segurança JWT no Swagger
@@ -159,8 +162,8 @@ if (SwaggerPolicy.IsEnabled(app.Environment, app.Configuration))
 app.UseHttpsRedirection();
 
 app.UseAuthentication();
-
 app.UseAuthorization();
+app.UseProjectYIdempotency();
 
 app.MapControllers();
 app.MapProjectYHealthChecks();

--- a/RiderManager/RiderManager/RiderManager.csproj
+++ b/RiderManager/RiderManager/RiderManager.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Http" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="StackExchange.Redis" Version="3.1.31" />
   </ItemGroup>
 
   <ItemGroup>
@@ -35,6 +36,7 @@
     <Compile Include="..\..\Shared\Hosting\SwaggerPolicy.cs" Link="Shared\Hosting\SwaggerPolicy.cs" />
     <Compile Include="..\..\Shared\Hosting\DatabaseMigrationCommand.cs" Link="Shared\Hosting\DatabaseMigrationCommand.cs" />
     <Compile Include="..\..\Shared\Messaging\QueueMessageAuthenticator.cs" Link="Shared\Messaging\QueueMessageAuthenticator.cs" />
+    <Compile Include="..\..\Shared\Idempotency\*.cs" Link="Shared\Idempotency\%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/RiderManager/RiderManager/appsettings.json
+++ b/RiderManager/RiderManager/appsettings.json
@@ -2,6 +2,14 @@
   "Swagger": {
     "Enabled": false
   },
+  "Redis": {
+    "ConnectionString": "redis:6379"
+  },
+  "Idempotency": {
+    "ClaimTtl": "00:01:00",
+    "ResponseTtl": "1.00:00:00",
+    "MaximumKeyLength": 200
+  },
   "RabbitMQ": {
     "HostName": "rabbitmq",
     "VirtualHost": "projecty-rider",

--- a/RiderManager/RiderManager/appsettings.json
+++ b/RiderManager/RiderManager/appsettings.json
@@ -6,7 +6,6 @@
     "ConnectionString": "redis:6379"
   },
   "Idempotency": {
-    "ClaimTtl": "00:01:00",
     "ResponseTtl": "1.00:00:00",
     "MaximumKeyLength": 200
   },

--- a/RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs
+++ b/RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs
@@ -100,7 +100,7 @@ public sealed class IdempotencyMiddlewareTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task LongRunningRequest_RenewsClaimUntilItCompletes()
+    public async Task LongRunningRequest_RetainsClaimUntilItCompletes()
     {
         var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -111,7 +111,7 @@ public sealed class IdempotencyMiddlewareTests : IAsyncLifetime
             started.TrySetResult();
             await release.Task;
             context.Response.StatusCode = StatusCodes.Status201Created;
-        }, TimeSpan.FromMilliseconds(300));
+        });
         var key = Guid.NewGuid().ToString("D");
         var firstContext = CreateContext(key, "{\"plate\":\"IDEM-0004\"}");
 
@@ -127,16 +127,62 @@ public sealed class IdempotencyMiddlewareTests : IAsyncLifetime
         Assert.Equal(StatusCodes.Status201Created, firstContext.Response.StatusCode);
     }
 
-    private RedisIdempotencyMiddleware CreateMiddleware(
-        RequestDelegate next,
-        TimeSpan? claimTtl = null)
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task DownstreamFailure_RetainsUnknownOutcomeWithoutRepeatingEffect()
+    {
+        var effects = 0;
+        var middleware = CreateMiddleware(_ =>
+        {
+            Interlocked.Increment(ref effects);
+            throw new InvalidOperationException("Failure after a possible commit.");
+        });
+        var key = Guid.NewGuid().ToString("D");
+
+        var first = await ExecuteAsync(middleware, key, "{\"plate\":\"IDEM-0005\"}");
+        var replay = await ExecuteAsync(middleware, key, "{\"plate\":\"IDEM-0005\"}");
+
+        Assert.Equal(1, effects);
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, first.Response.StatusCode);
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, replay.Response.StatusCode);
+        Assert.Equal("true", replay.Response.Headers["Idempotency-Replayed"]);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ReusingKeyWithReorderedQueryValues_ReturnsUnprocessableEntity()
+    {
+        var effects = 0;
+        var middleware = CreateMiddleware(context =>
+        {
+            Interlocked.Increment(ref effects);
+            context.Response.StatusCode = StatusCodes.Status200OK;
+            return Task.CompletedTask;
+        });
+        var key = Guid.NewGuid().ToString("D");
+
+        await ExecuteAsync(
+            middleware,
+            key,
+            string.Empty,
+            "?rentalId=A&rentalId=B");
+        var mismatch = await ExecuteAsync(
+            middleware,
+            key,
+            string.Empty,
+            "?rentalId=B&rentalId=A");
+
+        Assert.Equal(1, effects);
+        Assert.Equal(StatusCodes.Status422UnprocessableEntity, mismatch.Response.StatusCode);
+    }
+
+    private RedisIdempotencyMiddleware CreateMiddleware(RequestDelegate next)
         => new(
             next,
             new Lazy<IConnectionMultiplexer>(() => _connection),
             new IdempotencyOptions
             {
                 ServiceName = "idempotency-tests",
-                ClaimTtl = claimTtl ?? TimeSpan.FromMinutes(1),
                 ResponseTtl = TimeSpan.FromHours(1)
             },
             NullLogger<RedisIdempotencyMiddleware>.Instance);
@@ -144,18 +190,20 @@ public sealed class IdempotencyMiddlewareTests : IAsyncLifetime
     private static async Task<HttpContext> ExecuteAsync(
         RedisIdempotencyMiddleware middleware,
         string key,
-        string body)
+        string body,
+        string? query = null)
     {
-        var context = CreateContext(key, body);
+        var context = CreateContext(key, body, query);
         await middleware.InvokeAsync(context);
         return context;
     }
 
-    private static HttpContext CreateContext(string key, string body)
+    private static HttpContext CreateContext(string key, string body, string? query = null)
     {
         var context = new DefaultHttpContext();
         context.Request.Method = HttpMethods.Post;
         context.Request.Path = "/api/rentals";
+        context.Request.QueryString = new QueryString(query ?? string.Empty);
         context.Request.ContentType = "application/json";
         context.Request.Headers[IdempotencyOptions.HeaderName] = key;
         context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));

--- a/RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs
+++ b/RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs
@@ -1,0 +1,175 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProjectY.Shared.Idempotency;
+using StackExchange.Redis;
+using System.Text;
+using Testcontainers.Redis;
+
+namespace RiderManagerTests.Integration.Redis;
+
+public sealed class IdempotencyMiddlewareTests : IAsyncLifetime
+{
+    private readonly RedisContainer _redis = new RedisBuilder("redis:7.4-alpine").Build();
+    private IConnectionMultiplexer _connection = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _redis.StartAsync();
+        _connection = await ConnectionMultiplexer.ConnectAsync(_redis.GetConnectionString());
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _connection.DisposeAsync();
+        await _redis.DisposeAsync();
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ReplayingCreateWithSameKey_ReturnsOriginalResponseAndOneEffect()
+    {
+        var effects = 0;
+        var middleware = CreateMiddleware(async context =>
+        {
+            Interlocked.Increment(ref effects);
+            context.Response.StatusCode = StatusCodes.Status201Created;
+            context.Response.Headers.Location = "/api/rentals/rental-1";
+            await context.Response.WriteAsync("created-rental-1");
+        });
+        var key = Guid.NewGuid().ToString("D");
+
+        var first = await ExecuteAsync(middleware, key, "{\"plate\":\"IDEM-0001\"}");
+        var replay = await ExecuteAsync(middleware, key, "{\"plate\":\"IDEM-0001\"}");
+
+        Assert.Equal(1, effects);
+        Assert.Equal(StatusCodes.Status201Created, first.Response.StatusCode);
+        Assert.Equal(first.Response.StatusCode, replay.Response.StatusCode);
+        Assert.Equal(await ReadBodyAsync(first), await ReadBodyAsync(replay));
+        Assert.Equal("/api/rentals/rental-1", replay.Response.Headers.Location);
+        Assert.Equal("true", replay.Response.Headers["Idempotency-Replayed"]);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ReusingKeyWithDifferentBody_ReturnsUnprocessableEntity()
+    {
+        var effects = 0;
+        var middleware = CreateMiddleware(context =>
+        {
+            Interlocked.Increment(ref effects);
+            context.Response.StatusCode = StatusCodes.Status201Created;
+            return Task.CompletedTask;
+        });
+        var key = Guid.NewGuid().ToString("D");
+
+        await ExecuteAsync(middleware, key, "{\"plate\":\"IDEM-0002\"}");
+        var mismatch = await ExecuteAsync(middleware, key, "{\"plate\":\"DIFFERENT\"}");
+
+        Assert.Equal(1, effects);
+        Assert.Equal(StatusCodes.Status422UnprocessableEntity, mismatch.Response.StatusCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ConcurrentRequestWithSameKey_ReturnsConflictUntilFirstCompletes()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var effects = 0;
+        var middleware = CreateMiddleware(async context =>
+        {
+            Interlocked.Increment(ref effects);
+            started.TrySetResult();
+            await release.Task;
+            context.Response.StatusCode = StatusCodes.Status201Created;
+        });
+        var key = Guid.NewGuid().ToString("D");
+        var firstContext = CreateContext(key, "{\"plate\":\"IDEM-0003\"}");
+
+        var first = middleware.InvokeAsync(firstContext);
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var concurrent = await ExecuteAsync(middleware, key, "{\"plate\":\"IDEM-0003\"}");
+        release.TrySetResult();
+        await first;
+
+        Assert.Equal(1, effects);
+        Assert.Equal(StatusCodes.Status409Conflict, concurrent.Response.StatusCode);
+        Assert.Equal("1", concurrent.Response.Headers.RetryAfter);
+        Assert.Equal(StatusCodes.Status201Created, firstContext.Response.StatusCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task LongRunningRequest_RenewsClaimUntilItCompletes()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var effects = 0;
+        var middleware = CreateMiddleware(async context =>
+        {
+            Interlocked.Increment(ref effects);
+            started.TrySetResult();
+            await release.Task;
+            context.Response.StatusCode = StatusCodes.Status201Created;
+        }, TimeSpan.FromMilliseconds(300));
+        var key = Guid.NewGuid().ToString("D");
+        var firstContext = CreateContext(key, "{\"plate\":\"IDEM-0004\"}");
+
+        var first = middleware.InvokeAsync(firstContext);
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Task.Delay(TimeSpan.FromMilliseconds(700));
+        var concurrent = await ExecuteAsync(middleware, key, "{\"plate\":\"IDEM-0004\"}");
+        release.TrySetResult();
+        await first;
+
+        Assert.Equal(1, effects);
+        Assert.Equal(StatusCodes.Status409Conflict, concurrent.Response.StatusCode);
+        Assert.Equal(StatusCodes.Status201Created, firstContext.Response.StatusCode);
+    }
+
+    private RedisIdempotencyMiddleware CreateMiddleware(
+        RequestDelegate next,
+        TimeSpan? claimTtl = null)
+        => new(
+            next,
+            new Lazy<IConnectionMultiplexer>(() => _connection),
+            new IdempotencyOptions
+            {
+                ServiceName = "idempotency-tests",
+                ClaimTtl = claimTtl ?? TimeSpan.FromMinutes(1),
+                ResponseTtl = TimeSpan.FromHours(1)
+            },
+            NullLogger<RedisIdempotencyMiddleware>.Instance);
+
+    private static async Task<HttpContext> ExecuteAsync(
+        RedisIdempotencyMiddleware middleware,
+        string key,
+        string body)
+    {
+        var context = CreateContext(key, body);
+        await middleware.InvokeAsync(context);
+        return context;
+    }
+
+    private static HttpContext CreateContext(string key, string body)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Method = HttpMethods.Post;
+        context.Request.Path = "/api/rentals";
+        context.Request.ContentType = "application/json";
+        context.Request.Headers[IdempotencyOptions.HeaderName] = key;
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    private static async Task<string> ReadBodyAsync(HttpContext context)
+    {
+        context.Response.Body.Position = 0;
+        using var reader = new StreamReader(
+            context.Response.Body,
+            Encoding.UTF8,
+            leaveOpen: true);
+        return await reader.ReadToEndAsync();
+    }
+}

--- a/RiderManager/RiderManagerTests/RiderManagerTests.csproj
+++ b/RiderManager/RiderManagerTests/RiderManagerTests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0.2" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.14.0" />
+    <PackageReference Include="Testcontainers.Redis" Version="4.14.0" />
     <PackageReference Include="xunit" Version="2.7.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
       <PrivateAssets>all</PrivateAssets>

--- a/RiderManager/RiderManagerTests/Unit/Idempotency/IdempotencyMiddlewareBypassTests.cs
+++ b/RiderManager/RiderManagerTests/Unit/Idempotency/IdempotencyMiddlewareBypassTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProjectY.Shared.Idempotency;
+using StackExchange.Redis;
+
+namespace RiderManagerTests.Unit.Idempotency;
+
+public sealed class IdempotencyMiddlewareBypassTests
+{
+    [Fact]
+    public async Task StateChangingRequestWithoutKey_DoesNotResolveRedis()
+    {
+        var executed = false;
+        var middleware = CreateWithoutRedis(_ =>
+        {
+            executed = true;
+            return Task.CompletedTask;
+        });
+        var context = new DefaultHttpContext();
+        context.Request.Method = HttpMethods.Post;
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(executed);
+    }
+
+    [Fact]
+    public async Task SafeRequestWithKey_DoesNotResolveRedis()
+    {
+        var executed = false;
+        var middleware = CreateWithoutRedis(_ =>
+        {
+            executed = true;
+            return Task.CompletedTask;
+        });
+        var context = new DefaultHttpContext();
+        context.Request.Method = HttpMethods.Get;
+        context.Request.Headers[IdempotencyOptions.HeaderName] = "ignored-on-safe-method";
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(executed);
+    }
+
+    private static RedisIdempotencyMiddleware CreateWithoutRedis(RequestDelegate next)
+        => new(
+            next,
+            new Lazy<IConnectionMultiplexer>(() =>
+                throw new InvalidOperationException("Redis should not be resolved.")),
+            new IdempotencyOptions(),
+            NullLogger<RedisIdempotencyMiddleware>.Instance);
+}

--- a/Shared/Idempotency/IdempotencyKeyOperationFilter.cs
+++ b/Shared/Idempotency/IdempotencyKeyOperationFilter.cs
@@ -1,0 +1,34 @@
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace ProjectY.Shared.Idempotency;
+
+public sealed class IdempotencyKeyOperationFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        var method = context.ApiDescription.HttpMethod;
+        if (method is not ("POST" or "PUT" or "PATCH" or "DELETE"))
+        {
+            return;
+        }
+
+        operation.Parameters ??= [];
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = IdempotencyOptions.HeaderName,
+            In = ParameterLocation.Header,
+            Required = false,
+            Description = "Makes a state-changing request replay-safe for 24 hours. Reusing the key with a different request returns 422.",
+            Schema = new OpenApiSchema { Type = "string", MaxLength = 200 }
+        });
+        operation.Responses.TryAdd("409", new OpenApiResponse
+        {
+            Description = "Another request with this idempotency key is still running."
+        });
+        operation.Responses.TryAdd("422", new OpenApiResponse
+        {
+            Description = "The idempotency key was already used with a different request."
+        });
+    }
+}

--- a/Shared/Idempotency/IdempotencyOptions.cs
+++ b/Shared/Idempotency/IdempotencyOptions.cs
@@ -6,7 +6,6 @@ public sealed class IdempotencyOptions
 
     public string ServiceName { get; set; } = "projecty";
     public string RedisConnectionString { get; set; } = "redis:6379";
-    public TimeSpan ClaimTtl { get; set; } = TimeSpan.FromMinutes(1);
     public TimeSpan ResponseTtl { get; set; } = TimeSpan.FromHours(24);
     public int MaximumKeyLength { get; set; } = 200;
 }

--- a/Shared/Idempotency/IdempotencyOptions.cs
+++ b/Shared/Idempotency/IdempotencyOptions.cs
@@ -1,0 +1,12 @@
+namespace ProjectY.Shared.Idempotency;
+
+public sealed class IdempotencyOptions
+{
+    public const string HeaderName = "Idempotency-Key";
+
+    public string ServiceName { get; set; } = "projecty";
+    public string RedisConnectionString { get; set; } = "redis:6379";
+    public TimeSpan ClaimTtl { get; set; } = TimeSpan.FromMinutes(1);
+    public TimeSpan ResponseTtl { get; set; } = TimeSpan.FromHours(24);
+    public int MaximumKeyLength { get; set; } = 200;
+}

--- a/Shared/Idempotency/IdempotencyServiceCollectionExtensions.cs
+++ b/Shared/Idempotency/IdempotencyServiceCollectionExtensions.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
+
+namespace ProjectY.Shared.Idempotency;
+
+public static class IdempotencyServiceCollectionExtensions
+{
+    public static IServiceCollection AddProjectYIdempotency(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string serviceName)
+    {
+        var options = configuration.GetSection("Idempotency").Get<IdempotencyOptions>()
+            ?? new IdempotencyOptions();
+        options.ServiceName = serviceName;
+        options.RedisConnectionString = configuration["Redis:ConnectionString"]
+            ?? options.RedisConnectionString;
+        if (options.ClaimTtl <= TimeSpan.Zero || options.ResponseTtl <= options.ClaimTtl)
+        {
+            throw new InvalidOperationException(
+                "Idempotency:ClaimTtl must be positive and shorter than Idempotency:ResponseTtl.");
+        }
+
+        if (options.MaximumKeyLength <= 0)
+        {
+            throw new InvalidOperationException("Idempotency:MaximumKeyLength must be positive.");
+        }
+
+        services.AddSingleton(options);
+        services.AddSingleton(_ => new Lazy<IConnectionMultiplexer>(() =>
+        {
+            var redisOptions = ConfigurationOptions.Parse(options.RedisConnectionString);
+            redisOptions.AbortOnConnectFail = false;
+            return ConnectionMultiplexer.Connect(redisOptions);
+        }, LazyThreadSafetyMode.ExecutionAndPublication));
+        return services;
+    }
+
+    public static IApplicationBuilder UseProjectYIdempotency(this IApplicationBuilder app)
+        => app.UseMiddleware<RedisIdempotencyMiddleware>();
+}

--- a/Shared/Idempotency/IdempotencyServiceCollectionExtensions.cs
+++ b/Shared/Idempotency/IdempotencyServiceCollectionExtensions.cs
@@ -17,10 +17,9 @@ public static class IdempotencyServiceCollectionExtensions
         options.ServiceName = serviceName;
         options.RedisConnectionString = configuration["Redis:ConnectionString"]
             ?? options.RedisConnectionString;
-        if (options.ClaimTtl <= TimeSpan.Zero || options.ResponseTtl <= options.ClaimTtl)
+        if (options.ResponseTtl <= TimeSpan.Zero)
         {
-            throw new InvalidOperationException(
-                "Idempotency:ClaimTtl must be positive and shorter than Idempotency:ResponseTtl.");
+            throw new InvalidOperationException("Idempotency:ResponseTtl must be positive.");
         }
 
         if (options.MaximumKeyLength <= 0)

--- a/Shared/Idempotency/RedisIdempotencyMiddleware.cs
+++ b/Shared/Idempotency/RedisIdempotencyMiddleware.cs
@@ -1,0 +1,517 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using StackExchange.Redis;
+using System.Globalization;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace ProjectY.Shared.Idempotency;
+
+public sealed class RedisIdempotencyMiddleware
+{
+    private const string PendingState = "pending";
+    private const string CompletedState = "completed";
+    private const string ReplayHeader = "Idempotency-Replayed";
+    private const string CompleteScript = """
+        if redis.call('GET', KEYS[1]) == ARGV[1] then
+            redis.call('SET', KEYS[1], ARGV[2], 'PX', ARGV[3])
+            return 1
+        end
+        return 0
+        """;
+    private const string ReleaseScript = """
+        if redis.call('GET', KEYS[1]) == ARGV[1] then
+            return redis.call('DEL', KEYS[1])
+        end
+        return 0
+        """;
+    private const string ExtendScript = """
+        if redis.call('GET', KEYS[1]) == ARGV[1] then
+            return redis.call('PEXPIRE', KEYS[1], ARGV[2])
+        end
+        return 0
+        """;
+
+    private static readonly HashSet<string> HopByHopHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Connection",
+        "Keep-Alive",
+        "Proxy-Authenticate",
+        "Proxy-Authorization",
+        "TE",
+        "Trailer",
+        "Transfer-Encoding",
+        "Upgrade"
+    };
+
+    private readonly RequestDelegate _next;
+    private readonly Lazy<IConnectionMultiplexer> _redis;
+    private readonly IdempotencyOptions _options;
+    private readonly ILogger<RedisIdempotencyMiddleware> _logger;
+
+    public RedisIdempotencyMiddleware(
+        RequestDelegate next,
+        Lazy<IConnectionMultiplexer> redis,
+        IdempotencyOptions options,
+        ILogger<RedisIdempotencyMiddleware> logger)
+    {
+        _next = next;
+        _redis = redis;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!IsStateChanging(context.Request.Method)
+            || !context.Request.Headers.TryGetValue(IdempotencyOptions.HeaderName, out var header))
+        {
+            await _next(context);
+            return;
+        }
+
+        if (!TryReadKey(header, out var idempotencyKey))
+        {
+            await WriteProblemAsync(
+                context,
+                StatusCodes.Status400BadRequest,
+                "Invalid Idempotency-Key",
+                $"{IdempotencyOptions.HeaderName} must contain one non-empty value with at most {_options.MaximumKeyLength} characters.");
+            return;
+        }
+
+        string fingerprint;
+        try
+        {
+            fingerprint = await CreateFingerprintAsync(context);
+        }
+        catch (IOException exception)
+        {
+            _logger.LogWarning(exception, "Could not read request body for idempotency fingerprinting.");
+            await WriteProblemAsync(
+                context,
+                StatusCodes.Status400BadRequest,
+                "Unreadable request body",
+                "The request body could not be fingerprinted.");
+            return;
+        }
+
+        var caller = context.User.FindFirstValue(ClaimTypes.NameIdentifier) ?? "anonymous";
+        var redisKey = CreateRedisKey(idempotencyKey, caller);
+        var pending = new IdempotencyRecord
+        {
+            State = PendingState,
+            Fingerprint = fingerprint,
+            OwnerToken = Guid.NewGuid().ToString("D")
+        };
+        var pendingJson = JsonSerializer.Serialize(pending);
+
+        try
+        {
+            var database = _redis.Value.GetDatabase();
+            var claimed = await TryClaimAsync(database, redisKey, pendingJson);
+            if (!claimed)
+            {
+                var existing = await ReadExistingAsync(database, redisKey);
+                if (existing is null)
+                {
+                    claimed = await TryClaimAsync(database, redisKey, pendingJson);
+                }
+
+                if (!claimed)
+                {
+                    existing ??= await ReadExistingAsync(database, redisKey);
+                    await HandleExistingAsync(context, existing, fingerprint);
+                    return;
+                }
+            }
+
+            await ExecuteClaimedRequestAsync(context, database, redisKey, pending, pendingJson);
+        }
+        catch (IdempotencyOutcomeUnknownException exception)
+        {
+            await WriteOutcomeUnknownAsync(context, exception);
+            return;
+        }
+        catch (RedisException exception)
+        {
+            await WriteRedisUnavailableAsync(context, exception);
+            return;
+        }
+        catch (TimeoutException exception)
+        {
+            await WriteRedisUnavailableAsync(context, exception);
+            return;
+        }
+
+    }
+
+    private async Task ExecuteClaimedRequestAsync(
+        HttpContext context,
+        IDatabase database,
+        RedisKey redisKey,
+        IdempotencyRecord pending,
+        string pendingJson)
+    {
+        var originalBody = context.Response.Body;
+        await using var responseBuffer = new MemoryStream();
+        context.Response.Body = responseBuffer;
+        var handlerCompleted = false;
+        using var renewalCancellation = new CancellationTokenSource();
+        var renewal = RenewClaimUntilCancelledAsync(
+            database,
+            redisKey,
+            pendingJson,
+            renewalCancellation.Token);
+
+        try
+        {
+            await _next(context);
+            handlerCompleted = true;
+            await StopRenewalAsync(renewalCancellation, renewal);
+
+            var completed = new IdempotencyRecord
+            {
+                State = CompletedState,
+                Fingerprint = pending.Fingerprint,
+                OwnerToken = pending.OwnerToken,
+                StatusCode = context.Response.StatusCode,
+                Headers = CaptureHeaders(context.Response.Headers),
+                Body = responseBuffer.ToArray()
+            };
+            var completedJson = JsonSerializer.Serialize(completed);
+            var stored = (long)await database.ScriptEvaluateAsync(
+                CompleteScript,
+                [redisKey],
+                [pendingJson, completedJson, ToMilliseconds(_options.ResponseTtl)]) == 1;
+            if (!stored)
+            {
+                throw new InvalidOperationException("The idempotency claim was lost before the response could be stored.");
+            }
+
+            context.Response.Body = originalBody;
+            responseBuffer.Position = 0;
+            await responseBuffer.CopyToAsync(originalBody, context.RequestAborted);
+        }
+        catch (Exception exception)
+        {
+            await StopRenewalAsync(renewalCancellation, renewal, suppressFailure: true);
+            context.Response.Body = originalBody;
+            if (handlerCompleted)
+            {
+                await TryExtendClaimAsync(database, redisKey, pendingJson);
+                throw new IdempotencyOutcomeUnknownException(
+                    "The endpoint completed, but its idempotent response could not be persisted.",
+                    exception);
+            }
+
+            await TryReleaseClaimAsync(database, redisKey, pendingJson);
+            throw;
+        }
+    }
+
+    private async Task RenewClaimUntilCancelledAsync(
+        IDatabase database,
+        RedisKey key,
+        string pendingJson,
+        CancellationToken cancellationToken)
+    {
+        var interval = TimeSpan.FromMilliseconds(
+            Math.Max(100, _options.ClaimTtl.TotalMilliseconds / 3));
+
+        try
+        {
+            while (true)
+            {
+                await Task.Delay(interval, cancellationToken);
+                var renewed = (long)await database.ScriptEvaluateAsync(
+                    ExtendScript,
+                    [key],
+                    [pendingJson, ToMilliseconds(_options.ClaimTtl)]) == 1;
+                if (!renewed)
+                {
+                    throw new IdempotencyOutcomeUnknownException(
+                        "The idempotency claim was lost while the endpoint was executing.");
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private static async Task StopRenewalAsync(
+        CancellationTokenSource cancellation,
+        Task renewal,
+        bool suppressFailure = false)
+    {
+        cancellation.Cancel();
+        if (suppressFailure)
+        {
+            try
+            {
+                await renewal;
+            }
+            catch
+            {
+            }
+
+            return;
+        }
+
+        await renewal;
+    }
+
+    private async Task HandleExistingAsync(
+        HttpContext context,
+        IdempotencyRecord? existing,
+        string fingerprint)
+    {
+        if (existing is null)
+        {
+            await WriteProblemAsync(
+                context,
+                StatusCodes.Status503ServiceUnavailable,
+                "Idempotency state unavailable",
+                "The idempotency claim changed while the request was being evaluated.");
+            return;
+        }
+
+        if (existing.State is not (PendingState or CompletedState))
+        {
+            await WriteProblemAsync(
+                context,
+                StatusCodes.Status503ServiceUnavailable,
+                "Invalid idempotency state",
+                "The stored idempotency response is invalid.");
+            return;
+        }
+
+        if (!CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(existing.Fingerprint),
+                Encoding.UTF8.GetBytes(fingerprint)))
+        {
+            await WriteProblemAsync(
+                context,
+                StatusCodes.Status422UnprocessableEntity,
+                "Idempotency key reused with a different request",
+                "Use a new Idempotency-Key when the method, route, query, caller, content type, or body changes.");
+            return;
+        }
+
+        if (existing.State == PendingState)
+        {
+            context.Response.Headers.RetryAfter = "1";
+            await WriteProblemAsync(
+                context,
+                StatusCodes.Status409Conflict,
+                "Request already in progress",
+                "Another request with the same Idempotency-Key is still executing.");
+            return;
+        }
+
+        if (existing.StatusCode is null || existing.Body is null)
+        {
+            await WriteProblemAsync(
+                context,
+                StatusCodes.Status503ServiceUnavailable,
+                "Invalid idempotency state",
+                "The stored idempotency response is incomplete.");
+            return;
+        }
+
+        context.Response.StatusCode = existing.StatusCode.Value;
+        foreach (var (name, values) in existing.Headers)
+        {
+            if (!HopByHopHeaders.Contains(name))
+            {
+                context.Response.Headers[name] = new StringValues(values);
+            }
+        }
+
+        context.Response.Headers[ReplayHeader] = "true";
+        context.Response.ContentLength = existing.Body.Length;
+        await context.Response.Body.WriteAsync(existing.Body, context.RequestAborted);
+    }
+
+    private async Task<bool> TryClaimAsync(IDatabase database, RedisKey key, string pendingJson)
+        => await database.StringSetAsync(
+            key,
+            pendingJson,
+            _options.ClaimTtl,
+            When.NotExists);
+
+    private static async Task<IdempotencyRecord?> ReadExistingAsync(IDatabase database, RedisKey key)
+    {
+        var value = await database.StringGetAsync(key);
+        if (!value.HasValue)
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<IdempotencyRecord>((string)value!);
+        }
+        catch (JsonException)
+        {
+            return new IdempotencyRecord
+            {
+                State = "invalid",
+                Fingerprint = string.Empty,
+                OwnerToken = string.Empty
+            };
+        }
+    }
+
+    private async Task TryReleaseClaimAsync(IDatabase database, RedisKey key, string pendingJson)
+    {
+        try
+        {
+            await database.ScriptEvaluateAsync(ReleaseScript, [key], [pendingJson]);
+        }
+        catch (Exception exception) when (exception is RedisException or TimeoutException)
+        {
+            _logger.LogError(exception, "Could not release failed idempotency claim {RedisKey}.", key);
+        }
+    }
+
+    private async Task TryExtendClaimAsync(IDatabase database, RedisKey key, string pendingJson)
+    {
+        try
+        {
+            await database.ScriptEvaluateAsync(
+                ExtendScript,
+                [key],
+                [pendingJson, ToMilliseconds(_options.ResponseTtl)]);
+        }
+        catch (Exception exception) when (exception is RedisException or TimeoutException)
+        {
+            _logger.LogCritical(exception, "Could not preserve completed idempotency claim {RedisKey}.", key);
+        }
+    }
+
+    private async Task WriteRedisUnavailableAsync(HttpContext context, Exception exception)
+    {
+        _logger.LogError(exception, "Redis is unavailable for an idempotent write request.");
+        context.Response.Clear();
+        context.Response.Headers.RetryAfter = "1";
+        await WriteProblemAsync(
+            context,
+            StatusCodes.Status503ServiceUnavailable,
+            "Idempotency service unavailable",
+            "The request was not executed because its idempotency guarantee could not be established.");
+    }
+
+    private async Task WriteOutcomeUnknownAsync(HttpContext context, Exception exception)
+    {
+        _logger.LogCritical(exception, "An executed write could not be recorded by the idempotency service.");
+        context.Response.Clear();
+        await WriteProblemAsync(
+            context,
+            StatusCodes.Status503ServiceUnavailable,
+            "Idempotency outcome unavailable",
+            "The request may have completed, but its response could not be recorded. Retry with the same Idempotency-Key after the service recovers.");
+    }
+
+    private bool TryReadKey(StringValues header, out string key)
+    {
+        key = header.Count == 1 ? header[0]?.Trim() ?? string.Empty : string.Empty;
+        return key.Length is > 0 && key.Length <= _options.MaximumKeyLength;
+    }
+
+    private string CreateRedisKey(string idempotencyKey, string caller)
+    {
+        var keyHash = Convert.ToHexStringLower(SHA256.HashData(
+            Encoding.UTF8.GetBytes(caller + "\n" + idempotencyKey)));
+        return $"idempotency:{_options.ServiceName}:{keyHash}";
+    }
+
+    private static async Task<string> CreateFingerprintAsync(HttpContext context)
+    {
+        context.Request.EnableBuffering();
+        await using var body = new MemoryStream();
+        await context.Request.Body.CopyToAsync(body, context.RequestAborted);
+        context.Request.Body.Position = 0;
+
+        var query = JsonSerializer.Serialize(context.Request.Query
+            .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+            .Select(pair => new
+            {
+                pair.Key,
+                Values = pair.Value.OrderBy(value => value, StringComparer.Ordinal).ToArray()
+            }));
+        var caller = context.User.FindFirstValue(ClaimTypes.NameIdentifier) ?? "anonymous";
+        var prefix = string.Join('\n',
+            context.Request.Method.ToUpperInvariant(),
+            context.Request.PathBase + context.Request.Path,
+            query,
+            caller,
+            context.Request.ContentType ?? string.Empty) + "\n";
+
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        hash.AppendData(Encoding.UTF8.GetBytes(prefix));
+        hash.AppendData(body.GetBuffer().AsSpan(0, checked((int)body.Length)));
+        return Convert.ToHexStringLower(hash.GetHashAndReset());
+    }
+
+    private static Dictionary<string, string[]> CaptureHeaders(IHeaderDictionary headers)
+        => headers
+            .Where(header => !HopByHopHeaders.Contains(header.Key))
+            .ToDictionary(
+                header => header.Key,
+                header => header.Value.Select(value => value ?? string.Empty).ToArray(),
+                StringComparer.OrdinalIgnoreCase);
+
+    private static bool IsStateChanging(string method)
+        => HttpMethods.IsPost(method)
+            || HttpMethods.IsPut(method)
+            || HttpMethods.IsPatch(method)
+            || HttpMethods.IsDelete(method);
+
+    private static long ToMilliseconds(TimeSpan value)
+        => checked((long)value.TotalMilliseconds);
+
+    private static Task WriteProblemAsync(
+        HttpContext context,
+        int status,
+        string title,
+        string detail)
+    {
+        context.Response.StatusCode = status;
+        context.Response.ContentType = "application/problem+json";
+        return context.Response.WriteAsJsonAsync(new
+        {
+            type = "https://httpstatuses.com/" + status.ToString(CultureInfo.InvariantCulture),
+            title,
+            status,
+            detail
+        });
+    }
+
+    private sealed class IdempotencyRecord
+    {
+        public required string State { get; init; }
+        public required string Fingerprint { get; init; }
+        public required string OwnerToken { get; init; }
+        public int? StatusCode { get; init; }
+        public Dictionary<string, string[]> Headers { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+        public byte[]? Body { get; init; }
+    }
+
+    private sealed class IdempotencyOutcomeUnknownException : Exception
+    {
+        public IdempotencyOutcomeUnknownException(string message)
+            : base(message)
+        {
+        }
+
+        public IdempotencyOutcomeUnknownException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/Shared/Idempotency/RedisIdempotencyMiddleware.cs
+++ b/Shared/Idempotency/RedisIdempotencyMiddleware.cs
@@ -14,17 +14,12 @@ public sealed class RedisIdempotencyMiddleware
 {
     private const string PendingState = "pending";
     private const string CompletedState = "completed";
+    private const string UnknownState = "unknown";
     private const string ReplayHeader = "Idempotency-Replayed";
     private const string CompleteScript = """
         if redis.call('GET', KEYS[1]) == ARGV[1] then
             redis.call('SET', KEYS[1], ARGV[2], 'PX', ARGV[3])
             return 1
-        end
-        return 0
-        """;
-    private const string ReleaseScript = """
-        if redis.call('GET', KEYS[1]) == ARGV[1] then
-            return redis.call('DEL', KEYS[1])
         end
         return 0
         """;
@@ -109,9 +104,10 @@ public sealed class RedisIdempotencyMiddleware
         };
         var pendingJson = JsonSerializer.Serialize(pending);
 
+        IDatabase database;
         try
         {
-            var database = _redis.Value.GetDatabase();
+            database = _redis.Value.GetDatabase();
             var claimed = await TryClaimAsync(database, redisKey, pendingJson);
             if (!claimed)
             {
@@ -129,12 +125,6 @@ public sealed class RedisIdempotencyMiddleware
                 }
             }
 
-            await ExecuteClaimedRequestAsync(context, database, redisKey, pending, pendingJson);
-        }
-        catch (IdempotencyOutcomeUnknownException exception)
-        {
-            await WriteOutcomeUnknownAsync(context, exception);
-            return;
         }
         catch (RedisException exception)
         {
@@ -147,6 +137,14 @@ public sealed class RedisIdempotencyMiddleware
             return;
         }
 
+        try
+        {
+            await ExecuteClaimedRequestAsync(context, database, redisKey, pending, pendingJson);
+        }
+        catch (IdempotencyOutcomeUnknownException exception)
+        {
+            await WriteOutcomeUnknownAsync(context, exception);
+        }
     }
 
     private async Task ExecuteClaimedRequestAsync(
@@ -159,110 +157,58 @@ public sealed class RedisIdempotencyMiddleware
         var originalBody = context.Response.Body;
         await using var responseBuffer = new MemoryStream();
         context.Response.Body = responseBuffer;
-        var handlerCompleted = false;
-        using var renewalCancellation = new CancellationTokenSource();
-        var renewal = RenewClaimUntilCancelledAsync(
-            database,
-            redisKey,
-            pendingJson,
-            renewalCancellation.Token);
 
         try
         {
             await _next(context);
-            handlerCompleted = true;
-            await StopRenewalAsync(renewalCancellation, renewal);
-
-            var completed = new IdempotencyRecord
-            {
-                State = CompletedState,
-                Fingerprint = pending.Fingerprint,
-                OwnerToken = pending.OwnerToken,
-                StatusCode = context.Response.StatusCode,
-                Headers = CaptureHeaders(context.Response.Headers),
-                Body = responseBuffer.ToArray()
-            };
-            var completedJson = JsonSerializer.Serialize(completed);
-            var stored = (long)await database.ScriptEvaluateAsync(
-                CompleteScript,
-                [redisKey],
-                [pendingJson, completedJson, ToMilliseconds(_options.ResponseTtl)]) == 1;
-            if (!stored)
-            {
-                throw new InvalidOperationException("The idempotency claim was lost before the response could be stored.");
-            }
-
-            context.Response.Body = originalBody;
-            responseBuffer.Position = 0;
-            await responseBuffer.CopyToAsync(originalBody, context.RequestAborted);
         }
         catch (Exception exception)
         {
-            await StopRenewalAsync(renewalCancellation, renewal, suppressFailure: true);
             context.Response.Body = originalBody;
-            if (handlerCompleted)
-            {
-                await TryExtendClaimAsync(database, redisKey, pendingJson);
-                throw new IdempotencyOutcomeUnknownException(
-                    "The endpoint completed, but its idempotent response could not be persisted.",
-                    exception);
-            }
-
-            await TryReleaseClaimAsync(database, redisKey, pendingJson);
-            throw;
+            await TryStoreUnknownOutcomeAsync(database, redisKey, pending, pendingJson);
+            throw new IdempotencyOutcomeUnknownException(
+                "The endpoint failed after execution began, so its outcome is unknown.",
+                exception);
         }
-    }
 
-    private async Task RenewClaimUntilCancelledAsync(
-        IDatabase database,
-        RedisKey key,
-        string pendingJson,
-        CancellationToken cancellationToken)
-    {
-        var interval = TimeSpan.FromMilliseconds(
-            Math.Max(100, _options.ClaimTtl.TotalMilliseconds / 3));
-
+        var completed = new IdempotencyRecord
+        {
+            State = CompletedState,
+            Fingerprint = pending.Fingerprint,
+            OwnerToken = pending.OwnerToken,
+            StatusCode = context.Response.StatusCode,
+            Headers = CaptureHeaders(context.Response.Headers),
+            Body = responseBuffer.ToArray()
+        };
+        var completedJson = JsonSerializer.Serialize(completed);
+        bool stored;
         try
         {
-            while (true)
-            {
-                await Task.Delay(interval, cancellationToken);
-                var renewed = (long)await database.ScriptEvaluateAsync(
-                    ExtendScript,
-                    [key],
-                    [pendingJson, ToMilliseconds(_options.ClaimTtl)]) == 1;
-                if (!renewed)
-                {
-                    throw new IdempotencyOutcomeUnknownException(
-                        "The idempotency claim was lost while the endpoint was executing.");
-                }
-            }
+            stored = (long)await database.ScriptEvaluateAsync(
+                CompleteScript,
+                [redisKey],
+                [pendingJson, completedJson, ToMilliseconds(_options.ResponseTtl)]) == 1;
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (Exception exception) when (exception is RedisException or TimeoutException)
         {
+            context.Response.Body = originalBody;
+            await TryExtendClaimAsync(database, redisKey, pendingJson);
+            throw new IdempotencyOutcomeUnknownException(
+                "The endpoint completed, but its idempotent response could not be persisted.",
+                exception);
         }
-    }
 
-    private static async Task StopRenewalAsync(
-        CancellationTokenSource cancellation,
-        Task renewal,
-        bool suppressFailure = false)
-    {
-        cancellation.Cancel();
-        if (suppressFailure)
+        if (!stored)
         {
-            try
-            {
-                await renewal;
-            }
-            catch
-            {
-            }
-
-            return;
+            context.Response.Body = originalBody;
+            await TryExtendClaimAsync(database, redisKey, pendingJson);
+            throw new IdempotencyOutcomeUnknownException(
+                "The idempotency claim was lost before the response could be stored.");
         }
 
-        await renewal;
+        context.Response.Body = originalBody;
+        responseBuffer.Position = 0;
+        await responseBuffer.CopyToAsync(originalBody, context.RequestAborted);
     }
 
     private async Task HandleExistingAsync(
@@ -280,7 +226,7 @@ public sealed class RedisIdempotencyMiddleware
             return;
         }
 
-        if (existing.State is not (PendingState or CompletedState))
+        if (existing.State is not (PendingState or CompletedState or UnknownState))
         {
             await WriteProblemAsync(
                 context,
@@ -313,6 +259,13 @@ public sealed class RedisIdempotencyMiddleware
             return;
         }
 
+        if (existing.State == UnknownState)
+        {
+            context.Response.Headers[ReplayHeader] = "true";
+            await WriteUnknownOutcomeProblemAsync(context);
+            return;
+        }
+
         if (existing.StatusCode is null || existing.Body is null)
         {
             await WriteProblemAsync(
@@ -341,7 +294,7 @@ public sealed class RedisIdempotencyMiddleware
         => await database.StringSetAsync(
             key,
             pendingJson,
-            _options.ClaimTtl,
+            _options.ResponseTtl,
             When.NotExists);
 
     private static async Task<IdempotencyRecord?> ReadExistingAsync(IDatabase database, RedisKey key)
@@ -367,15 +320,34 @@ public sealed class RedisIdempotencyMiddleware
         }
     }
 
-    private async Task TryReleaseClaimAsync(IDatabase database, RedisKey key, string pendingJson)
+    private async Task TryStoreUnknownOutcomeAsync(
+        IDatabase database,
+        RedisKey key,
+        IdempotencyRecord pending,
+        string pendingJson)
     {
+        var unknownJson = JsonSerializer.Serialize(new IdempotencyRecord
+        {
+            State = UnknownState,
+            Fingerprint = pending.Fingerprint,
+            OwnerToken = pending.OwnerToken
+        });
+
         try
         {
-            await database.ScriptEvaluateAsync(ReleaseScript, [key], [pendingJson]);
+            var stored = (long)await database.ScriptEvaluateAsync(
+                CompleteScript,
+                [key],
+                [pendingJson, unknownJson, ToMilliseconds(_options.ResponseTtl)]) == 1;
+            if (!stored)
+            {
+                await TryExtendClaimAsync(database, key, pendingJson);
+            }
         }
         catch (Exception exception) when (exception is RedisException or TimeoutException)
         {
-            _logger.LogError(exception, "Could not release failed idempotency claim {RedisKey}.", key);
+            _logger.LogCritical(exception, "Could not store unknown idempotency outcome {RedisKey}.", key);
+            await TryExtendClaimAsync(database, key, pendingJson);
         }
     }
 
@@ -410,12 +382,15 @@ public sealed class RedisIdempotencyMiddleware
     {
         _logger.LogCritical(exception, "An executed write could not be recorded by the idempotency service.");
         context.Response.Clear();
-        await WriteProblemAsync(
+        await WriteUnknownOutcomeProblemAsync(context);
+    }
+
+    private static Task WriteUnknownOutcomeProblemAsync(HttpContext context)
+        => WriteProblemAsync(
             context,
             StatusCodes.Status503ServiceUnavailable,
             "Idempotency outcome unavailable",
-            "The request may have completed, but its response could not be recorded. Retry with the same Idempotency-Key after the service recovers.");
-    }
+            "The request may have completed. Reconcile its outcome before creating a new request; retrying this Idempotency-Key will not execute it again.");
 
     private bool TryReadKey(StringValues header, out string key)
     {
@@ -442,7 +417,7 @@ public sealed class RedisIdempotencyMiddleware
             .Select(pair => new
             {
                 pair.Key,
-                Values = pair.Value.OrderBy(value => value, StringComparer.Ordinal).ToArray()
+                Values = pair.Value.ToArray()
             }));
         var caller = context.User.FindFirstValue(ClaimTypes.NameIdentifier) ?? "anonymous";
         var prefix = string.Join('\n',

--- a/deploy/base/compose.yaml
+++ b/deploy/base/compose.yaml
@@ -46,6 +46,7 @@ services:
 
   redis:
     image: redis:7.4-alpine
+    command: ["redis-server", "--appendonly", "yes", "--appendfsync", "always"]
     volumes:
       - redis-data:/data
     networks: [projecty]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ x-auth-gate-environment: &auth-gate-environment
   RabbitMQ__UserName: "${AUTH_GATE_RABBITMQ_USER:?Set AUTH_GATE_RABBITMQ_USER in .env}"
   RabbitMQ__Password: "${AUTH_GATE_RABBITMQ_PASSWORD:?Set AUTH_GATE_RABBITMQ_PASSWORD in .env}"
   Messaging__SigningKey: "${RIDER_EVENTS_SIGNING_KEY:?Set RIDER_EVENTS_SIGNING_KEY in .env}"
+  Redis__ConnectionString: "redis:6379"
   Jwt__SigningKeys__AuthGate: "${AUTH_GATE_JWT_SIGNING_KEY:?Set AUTH_GATE_JWT_SIGNING_KEY in .env}"
   Jwt__SigningKeys__MotoHub: "${MOTO_HUB_JWT_SIGNING_KEY:?Set MOTO_HUB_JWT_SIGNING_KEY in .env}"
   Jwt__SigningKeys__RiderManager: "${RIDER_MANAGER_JWT_SIGNING_KEY:?Set RIDER_MANAGER_JWT_SIGNING_KEY in .env}"
@@ -20,6 +21,7 @@ x-rider-manager-environment: &rider-manager-environment
   RabbitMQ__UserName: "${RIDER_MANAGER_RABBITMQ_USER:?Set RIDER_MANAGER_RABBITMQ_USER in .env}"
   RabbitMQ__Password: "${RIDER_MANAGER_RABBITMQ_PASSWORD:?Set RIDER_MANAGER_RABBITMQ_PASSWORD in .env}"
   Messaging__SigningKey: "${RIDER_EVENTS_SIGNING_KEY:?Set RIDER_EVENTS_SIGNING_KEY in .env}"
+  Redis__ConnectionString: "redis:6379"
   MinIO__AccessKey: "${MINIO_USER:?Set MINIO_USER in .env}"
   MinIO__SecretKey: "${MINIO_PASSWORD:?Set MINIO_PASSWORD in .env}"
   Jwt__SigningKey: "${RIDER_MANAGER_JWT_SIGNING_KEY:?Set RIDER_MANAGER_JWT_SIGNING_KEY in .env}"
@@ -32,6 +34,7 @@ x-moto-hub-environment: &moto-hub-environment
   ConnectionStrings__Postgresql: "Host=postgres;Port=5432;Database=${MOTO_HUB_POSTGRES_DB:?Set MOTO_HUB_POSTGRES_DB in .env};Username=${POSTGRES_USER:?Set POSTGRES_USER in .env};Password=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}"
   RabbitMQ__UserName: "${MOTO_HUB_RABBITMQ_USER:?Set MOTO_HUB_RABBITMQ_USER in .env}"
   RabbitMQ__Password: "${MOTO_HUB_RABBITMQ_PASSWORD:?Set MOTO_HUB_RABBITMQ_PASSWORD in .env}"
+  Redis__ConnectionString: "redis:6379"
   Jwt__SigningKey: "${MOTO_HUB_JWT_SIGNING_KEY:?Set MOTO_HUB_JWT_SIGNING_KEY in .env}"
   MotoHubApiKey: "${MOTO_HUB_API_KEY:?Set MOTO_HUB_API_KEY in .env}"
   RentalOperationsSettings__ApiKey: "${RENTAL_OPERATIONS_API_KEY:?Set RENTAL_OPERATIONS_API_KEY in .env}"
@@ -96,6 +99,22 @@ services:
       timeout: 5s
       retries: 12
       start_period: 10s
+
+  redis:
+    image: redis:7.4-alpine
+    container_name: redis
+    command: ["redis-server", "--appendonly", "yes"]
+    ports:
+      - "6379:6379"
+    networks:
+      - elk
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
 
   pgadmin:
     image: dpage/pgadmin4:9.13
@@ -196,6 +215,8 @@ services:
         condition: service_completed_successfully
       rabbitmq:
         condition: service_healthy
+      redis:
+        condition: service_healthy
   
   rider-manager-migrations:
     image: projecty/rider-manager:dev
@@ -232,6 +253,8 @@ services:
       rider-manager-migrations:
         condition: service_completed_successfully
       rabbitmq:
+        condition: service_healthy
+      redis:
         condition: service_healthy
 
   moto-hub-migrations:
@@ -270,6 +293,8 @@ services:
         condition: service_completed_successfully
       rabbitmq:
         condition: service_healthy
+      redis:
+        condition: service_healthy
   
   rental-operations:
     build:
@@ -289,6 +314,7 @@ services:
       MongoDbSettings__DatabaseName: "${MONGO_DB:?Set MONGO_DB in .env}"
       RabbitMQ__UserName: "${RENTAL_OPERATIONS_RABBITMQ_USER:?Set RENTAL_OPERATIONS_RABBITMQ_USER in .env}"
       RabbitMQ__Password: "${RENTAL_OPERATIONS_RABBITMQ_PASSWORD:?Set RENTAL_OPERATIONS_RABBITMQ_PASSWORD in .env}"
+      Redis__ConnectionString: "redis:6379"
       Jwt__SigningKey: "${RENTAL_OPERATIONS_JWT_SIGNING_KEY:?Set RENTAL_OPERATIONS_JWT_SIGNING_KEY in .env}"
       RentalOperationsApiKey: "${RENTAL_OPERATIONS_API_KEY:?Set RENTAL_OPERATIONS_API_KEY in .env}"
       RiderManagerSettings__ApiKey: "${RIDER_MANAGER_API_KEY:?Set RIDER_MANAGER_API_KEY in .env}"
@@ -304,6 +330,8 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
+      redis:
+        condition: service_healthy
 
 networks:
   elk:
@@ -311,6 +339,7 @@ networks:
 
 volumes:
   postgres-data:
+  redis-data:
   mongo-data:
   rabbitmq-data:
   minio-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
   redis:
     image: redis:7.4-alpine
     container_name: redis
-    command: ["redis-server", "--appendonly", "yes"]
+    command: ["redis-server", "--appendonly", "yes", "--appendfsync", "always"]
     ports:
       - "6379:6379"
     networks:

--- a/docs/api/idempotency.md
+++ b/docs/api/idempotency.md
@@ -1,0 +1,46 @@
+# Idempotency-Key semantics
+
+All `POST`, `PUT`, `PATCH`, and `DELETE` endpoints in the four baseline APIs
+accept the optional `Idempotency-Key` request header. Clients should generate a
+new opaque key for each intended state change and reuse that key only when
+retrying the same request after a timeout or connection failure.
+
+The guarantee is scoped to one service and authenticated caller, and lasts 24 hours. Redis stores the
+key, a SHA-256 request fingerprint, and the complete HTTP response. The
+fingerprint covers the method, path, canonical query string, authenticated user
+identifier, content type, and raw request body. Keys are hashed before they are
+used in Redis keys.
+
+| Situation | Result |
+|---|---|
+| Header omitted | The request executes normally without replay protection. |
+| New key | Redis claims the key and the request executes once. |
+| Same key and fingerprint after completion | The stored status, headers, and body are replayed with `Idempotency-Replayed: true`. |
+| Same key with a different fingerprint | `422 Unprocessable Entity`; the new request does not execute. |
+| Same key while the first request is running | `409 Conflict` with `Retry-After: 1`; the second request does not execute. |
+| Invalid or multiple key values | `400 Bad Request`. |
+| Redis unavailable before the claim is acquired | `503 Service Unavailable`; the request does not execute. |
+| Redis fails after the endpoint completes | `503 Service Unavailable` reports an unknown outcome; retry the same key after recovery. |
+
+A claim is leased for one minute and renewed while the request is running. Successful responses remain replayable for
+24 hours. Both durations and the maximum key length are configurable through
+the `Idempotency` configuration section. The baseline Compose stack stores
+Redis data in an append-only, persistent volume.
+
+Example against RentalOperations:
+
+```http
+POST /api/Rental/create HTTP/1.1
+Authorization: Bearer <token>
+Content-Type: application/json
+Idempotency-Key: rental-request-001
+
+{
+  "motocycleLicencePlate": "ABC1D23",
+  "startDate": "2026-09-01T00:00:00Z",
+  "predictedEndDate": "2026-09-08T00:00:00Z"
+}
+```
+
+The Swagger document for each service also exposes this header on every
+state-changing operation and documents the `409` and `422` responses.

--- a/docs/api/idempotency.md
+++ b/docs/api/idempotency.md
@@ -20,11 +20,13 @@ used in Redis keys.
 | Same key while the first request is running | `409 Conflict` with `Retry-After: 1`; the second request does not execute. |
 | Invalid or multiple key values | `400 Bad Request`. |
 | Redis unavailable before the claim is acquired | `503 Service Unavailable`; the request does not execute. |
-| Redis fails after the endpoint completes | `503 Service Unavailable` reports an unknown outcome; retry the same key after recovery. |
+| Endpoint execution throws after a possible side effect | `503 Service Unavailable`; the unknown outcome is retained and the same key never executes again. |
+| Redis fails after the endpoint completes | `503 Service Unavailable` reports an unknown outcome; the pending claim is retained. |
 
-A claim is leased for one minute and renewed while the request is running. Successful responses remain replayable for
-24 hours. Both durations and the maximum key length are configurable through
-the `Idempotency` configuration section. The baseline Compose stack stores
+Pending claims and successful responses remain protected for 24 hours. Using
+the full retention TTL for in-flight work prevents a second replica from
+claiming a long-running or ambiguously failed request. The duration and maximum
+key length are configurable through the `Idempotency` configuration section. The baseline Compose stack stores
 Redis data in an append-only, persistent volume.
 
 Example against RentalOperations:

--- a/docs/api/idempotency.md
+++ b/docs/api/idempotency.md
@@ -26,8 +26,9 @@ used in Redis keys.
 Pending claims and successful responses remain protected for 24 hours. Using
 the full retention TTL for in-flight work prevents a second replica from
 claiming a long-running or ambiguously failed request. The duration and maximum
-key length are configurable through the `Idempotency` configuration section. The baseline Compose stack stores
-Redis data in an append-only, persistent volume.
+key length are configurable through the `Idempotency` configuration section.
+The Compose stacks store Redis data in an append-only, persistent volume and
+fsync every idempotency write before Redis acknowledges it.
 
 Example against RentalOperations:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,6 +32,7 @@ starting.
 | Logstash | `5000` |
 | Kibana | `5601` |
 | PostgreSQL | `5432` |
+| Redis | `6379` |
 | pgAdmin | `5050` |
 | MongoDB | `27017` |
 | MinIO | `9000`, `9001` |


### PR DESCRIPTION
Closes #55. Implements Redis-backed Idempotency-Key handling across all state-changing endpoints, including request fingerprinting, response replay, mismatch and concurrency protection, renewable claims, persistent Compose Redis, Swagger documentation, and integration tests. Validation: all four solutions build; 95 non-integration tests pass; dotnet format is clean.