### PR TITLE
test: document and prove consistency guarantees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Validate legacy Compose model
-        run: docker compose --file docker-compose.yml config --quiet --no-interpolate
+      - name: Validate Compose models
+        run: |
+          docker compose --file docker-compose.yml config --quiet --no-interpolate
+          docker compose --file deploy/overlays/selfhost/compose.yaml config --quiet --no-interpolate
 
       - name: Detect relevant paths
         id: filter

--- a/MotoHub/MotoHubTests/Integration/PostgreSql/OutboxRelayTests.cs
+++ b/MotoHub/MotoHubTests/Integration/PostgreSql/OutboxRelayTests.cs
@@ -28,7 +28,7 @@ public sealed class OutboxRelayTests : IAsyncLifetime
     [Fact]
     [Trait("Category", "Integration")]
     [Trait("Guarantee", "ADR-0009#transactional-outbox")]
-    public async Task CommittedMessages_SurviveRelayRestartAndDrainInAggregateOrderAfterBrokerRecovery()
+    public async Task CommittedSequencedMessages_SurviveRelayRestartAndDrainAfterBrokerRecovery()
     {
         var transport = new RecoverableOutboxTransport { IsAvailable = false };
 

--- a/MotoHub/MotoHubTests/Integration/PostgreSql/OutboxRelayTests.cs
+++ b/MotoHub/MotoHubTests/Integration/PostgreSql/OutboxRelayTests.cs
@@ -1,7 +1,14 @@
+using AutoMapper;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MotoHub.Configurations;
+using MotoHub.CrossCutting;
 using MotoHub.Data;
 using MotoHub.Models;
+using MotoHub.Repositories;
+using MotoHub.Services;
+using MotoHub.Services.RabbitMQ;
 using ProjectY.Shared.Messaging;
 using Testcontainers.PostgreSql;
 
@@ -20,65 +27,53 @@ public sealed class OutboxRelayTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#transactional-outbox")]
     public async Task CommittedMessages_SurviveRelayRestartAndDrainInAggregateOrderAfterBrokerRecovery()
     {
-        var services = new ServiceCollection();
-        services.AddLogging();
-        services.AddDbContext<ApplicationDbContext>(options =>
-            options.UseNpgsql(_database.GetConnectionString()));
         var transport = new RecoverableOutboxTransport { IsAvailable = false };
-        services.AddSingleton<IOutboxTransport>(transport);
-        services.AddSingleton(new OutboxRelayOptions
-        {
-            ServiceName = "moto-hub-test",
-            HostName = "unused",
-            VirtualHost = "unused",
-            UserName = "unused",
-            Password = "unused",
-            PollInterval = TimeSpan.FromMilliseconds(10)
-        });
-        services.AddSingleton<OutboxRelay<ApplicationDbContext>>();
-        await using var provider = services.BuildServiceProvider();
 
-        await using (var scope = provider.CreateAsyncScope())
+        await using (var firstProcess = CreateRelayProvider(transport))
         {
-            var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            await context.Database.MigrateAsync();
-            context.Motorcycles.Add(new Motorcycle
+            await using (var scope = firstProcess.CreateAsyncScope())
             {
-                Id = "motorcycle-1",
-                LicensePlate = "OUT-0001",
-                Model = "Outbox proof",
-                Year = 2026,
-                RegistrationDate = DateTime.UtcNow
-            });
-            context.OutboxMessages.AddRange(
-                Message(sequence: 1, eventType: "motorcycle.second.v1"),
-                Message(sequence: 0, eventType: "motorcycle.first.v1"));
-            await context.SaveChangesAsync();
-        }
+                var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                await context.Database.MigrateAsync();
+                context.Motorcycles.Add(new Motorcycle
+                {
+                    Id = "motorcycle-1",
+                    LicensePlate = "OUT-0001",
+                    Model = "Outbox proof",
+                    Year = 2026,
+                    RegistrationDate = DateTime.UtcNow
+                });
+                context.OutboxMessages.AddRange(
+                    Message(sequence: 1, eventType: "motorcycle.second.v1"),
+                    Message(sequence: 0, eventType: "motorcycle.first.v1"));
+                await context.SaveChangesAsync();
+            }
 
-        var relayAfterCommit = provider.GetRequiredService<OutboxRelay<ApplicationDbContext>>();
-        Assert.Equal(0, await relayAfterCommit.DispatchOnceAsync());
+            var relayBeforeRestart = firstProcess.GetRequiredService<OutboxRelay<ApplicationDbContext>>();
+            Assert.Equal(0, await relayBeforeRestart.DispatchOnceAsync());
 
-        await using (var scope = provider.CreateAsyncScope())
-        {
-            var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            Assert.Equal(1, await context.Motorcycles.CountAsync());
-            Assert.Equal(2, await context.OutboxMessages.CountAsync(message => message.PublishedAtUtc == null));
-            var failed = await context.OutboxMessages.SingleAsync(message => message.AggregateSequence == 0);
+            await using var verificationScope = firstProcess.CreateAsyncScope();
+            var verificationContext = verificationScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            Assert.Equal(1, await verificationContext.Motorcycles.CountAsync());
+            Assert.Equal(2, await verificationContext.OutboxMessages.CountAsync(message => message.PublishedAtUtc == null));
+            var failed = await verificationContext.OutboxMessages.SingleAsync(message => message.AggregateSequence == 0);
             Assert.Equal(1, failed.PublishAttempts);
             failed.NextAttemptAtUtc = DateTime.UtcNow.AddSeconds(-1);
-            await context.SaveChangesAsync();
+            await verificationContext.SaveChangesAsync();
         }
 
         transport.IsAvailable = true;
-        Assert.Equal(2, await relayAfterCommit.DispatchOnceAsync());
+        await using var restartedProcess = CreateRelayProvider(transport);
+        var relayAfterRestart = restartedProcess.GetRequiredService<OutboxRelay<ApplicationDbContext>>();
+        Assert.Equal(2, await relayAfterRestart.DispatchOnceAsync());
 
         Assert.Equal(
             ["motorcycle.first.v1", "motorcycle.second.v1"],
             transport.Published.Select(message => message.EventType));
-        await using (var scope = provider.CreateAsyncScope())
+        await using (var scope = restartedProcess.CreateAsyncScope())
         {
             var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
             Assert.Equal(2, await context.OutboxMessages.CountAsync(message => message.PublishedAtUtc != null));
@@ -87,26 +82,59 @@ public sealed class OutboxRelayTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#transactional-outbox")]
+    public async Task DomainMutationAndOutboxInsert_RollBackTogetherWhenSaveFails()
+    {
+        await using (var seed = CreateContext())
+        {
+            await seed.Database.MigrateAsync();
+            seed.Motorcycles.Add(new Motorcycle
+            {
+                Id = "motorcycle-atomic",
+                LicensePlate = "ATM-0001",
+                Model = "Atomic outbox proof",
+                Year = 2026,
+                RegistrationDate = DateTime.UtcNow
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        await using (var context = CreateContext())
+        {
+            var publisher = new MessagingPublisherService(
+                context,
+                new RabbitMQOptions
+                {
+                    HostName = "unused",
+                    VirtualHost = "unused",
+                    UserName = "unused",
+                    Password = "unused",
+                    LicenceUpdateQueueName = new string('q', 201)
+                });
+            var service = new MotorcycleService(
+                new MotorcycleRepository(context),
+                Mock.Of<IMapper>(),
+                publisher,
+                Mock.Of<IRentalOperationService>());
+
+            await Assert.ThrowsAsync<DbUpdateException>(() =>
+                service.UpdateMotorcycleAsync("ATM-0001", "ATM-0002"));
+        }
+
+        await using var verification = CreateContext();
+        Assert.Equal(
+            "ATM-0001",
+            (await verification.Motorcycles.SingleAsync()).LicensePlate);
+        Assert.Empty(await verification.OutboxMessages.ToListAsync());
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#leased-outbox-relay")]
     public async Task ConcurrentRelays_ClaimOnlyOneHeadMessagePerAggregate()
     {
-        var services = new ServiceCollection();
-        services.AddLogging();
-        services.AddDbContext<ApplicationDbContext>(options =>
-            options.UseNpgsql(_database.GetConnectionString()));
         var transport = new BlockingOutboxTransport();
-        services.AddSingleton<IOutboxTransport>(transport);
-        services.AddSingleton(new OutboxRelayOptions
-        {
-            ServiceName = "moto-hub-test",
-            HostName = "unused",
-            VirtualHost = "unused",
-            UserName = "unused",
-            Password = "unused",
-            BatchSize = 1,
-            ClaimLeaseDuration = TimeSpan.FromMinutes(1)
-        });
-        services.AddTransient<OutboxRelay<ApplicationDbContext>>();
-        await using var provider = services.BuildServiceProvider();
+        await using var provider = CreateRelayProvider(transport, batchSize: 1);
 
         await using (var scope = provider.CreateAsyncScope())
         {
@@ -143,6 +171,33 @@ public sealed class OutboxRelayTests : IAsyncLifetime
         Destination = "motorcycle-events",
         Payload = "{}"
     };
+
+    private ApplicationDbContext CreateContext()
+        => new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(_database.GetConnectionString())
+            .Options);
+
+    private ServiceProvider CreateRelayProvider(IOutboxTransport transport, int batchSize = 100)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<ApplicationDbContext>(options =>
+            options.UseNpgsql(_database.GetConnectionString()));
+        services.AddSingleton(transport);
+        services.AddSingleton(new OutboxRelayOptions
+        {
+            ServiceName = "moto-hub-test",
+            HostName = "unused",
+            VirtualHost = "unused",
+            UserName = "unused",
+            Password = "unused",
+            BatchSize = batchSize,
+            PollInterval = TimeSpan.FromMilliseconds(10),
+            ClaimLeaseDuration = TimeSpan.FromMinutes(1)
+        });
+        services.AddTransient<OutboxRelay<ApplicationDbContext>>();
+        return services.BuildServiceProvider();
+    }
 }
 
 internal sealed class RecoverableOutboxTransport : IOutboxTransport

--- a/RentalOperations/RentalOperationsTests/Integration/MongoDb/ActiveRentalApiTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/MongoDb/ActiveRentalApiTests.cs
@@ -56,6 +56,7 @@ public sealed class ActiveRentalApiTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#database-serialized-rental-claim")]
     public async Task ConcurrentCreateRequestsForSameMotorcycle_OneSucceedsAndOneReturnsConflict()
     {
         using var client = CreateAuthenticatedClient();

--- a/RentalOperations/RentalOperationsTests/Integration/MongoDb/InboxProcessorTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/MongoDb/InboxProcessorTests.cs
@@ -30,6 +30,7 @@ public sealed class InboxProcessorTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#mongo-inbox-convergence")]
     public async Task SameMessageDeliveredTwice_ExecutesHandlerOnce()
     {
         var processor = new MongoInboxProcessor(_context, _options, TimeProvider.System);
@@ -47,6 +48,7 @@ public sealed class InboxProcessorTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#mongo-inbox-convergence")]
     public async Task CrashAfterIdempotentEffect_RedeliveryConvergesAndCompletesInbox()
     {
         var processor = new MongoInboxProcessor(_context, _options, TimeProvider.System);
@@ -89,6 +91,7 @@ public sealed class InboxProcessorTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#retention-boundaries")]
     public async Task Initializer_SchedulesRetentionWithTtlIndex()
     {
         var messages = _context.Database.GetCollection<InboxMessage>("InboxMessages");

--- a/RentalOperations/RentalOperationsTests/Integration/PostgreSql/ActiveRentalConstraintTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/PostgreSql/ActiveRentalConstraintTests.cs
@@ -14,6 +14,7 @@ public sealed class ActiveRentalConstraintTests
 
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#database-serialized-rental-claim")]
     public async Task ConcurrentClaimsForSameMotorcycle_OneIsRejectedByDatabaseConstraint()
     {
         await _database.ResetAsync();

--- a/RiderManager/RiderManagerTests/Integration/PostgreSql/InboxProcessorTests.cs
+++ b/RiderManager/RiderManagerTests/Integration/PostgreSql/InboxProcessorTests.cs
@@ -35,6 +35,7 @@ public sealed class InboxProcessorTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#transactional-inbox")]
     public async Task SameMessageProcessedConcurrently_ProducesOneDatabaseEffect()
     {
         var messageId = Guid.NewGuid().ToString("D");
@@ -52,6 +53,7 @@ public sealed class InboxProcessorTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#transactional-inbox")]
     public async Task ImageRedelivery_UsesInboxAndCallsIdempotentUploadOnce()
     {
         var manager = new Mock<IRiderManager>();
@@ -83,6 +85,7 @@ public sealed class InboxProcessorTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#retention-boundaries")]
     public async Task RetentionSweep_DeletesOnlyExpiredInboxRows()
     {
         await using (var seed = new ApplicationDbContext(_options))

--- a/RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs
+++ b/RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs
@@ -26,6 +26,7 @@ public sealed class IdempotencyMiddlewareTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#http-idempotency")]
     public async Task ReplayingCreateWithSameKey_ReturnsOriginalResponseAndOneEffect()
     {
         var effects = 0;
@@ -51,6 +52,7 @@ public sealed class IdempotencyMiddlewareTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#http-idempotency")]
     public async Task ReusingKeyWithDifferentBody_ReturnsUnprocessableEntity()
     {
         var effects = 0;
@@ -71,6 +73,7 @@ public sealed class IdempotencyMiddlewareTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#http-idempotency")]
     public async Task ConcurrentRequestWithSameKey_ReturnsConflictUntilFirstCompletes()
     {
         var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -100,6 +103,7 @@ public sealed class IdempotencyMiddlewareTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#http-idempotency")]
     public async Task LongRunningRequest_RetainsClaimUntilItCompletes()
     {
         var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -129,6 +133,7 @@ public sealed class IdempotencyMiddlewareTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#http-idempotency")]
     public async Task DownstreamFailure_RetainsUnknownOutcomeWithoutRepeatingEffect()
     {
         var effects = 0;
@@ -150,6 +155,7 @@ public sealed class IdempotencyMiddlewareTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Guarantee", "ADR-0009#http-idempotency")]
     public async Task ReusingKeyWithReorderedQueryValues_ReturnsUnprocessableEntity()
     {
         var effects = 0;

--- a/deploy/overlays/selfhost/compose.override.yaml
+++ b/deploy/overlays/selfhost/compose.override.yaml
@@ -29,7 +29,7 @@ services:
 
   redis:
     <<: *restart
-    command: ["redis-server", "--appendonly", "yes", "--maxmemory", "256mb", "--maxmemory-policy", "allkeys-lru"]
+    command: ["redis-server", "--appendonly", "yes", "--appendfsync", "always", "--maxmemory", "256mb", "--maxmemory-policy", "noeviction"]
     ports:
       - "6379:6379"
 

--- a/docs/adr/0003-observability-and-fault-tolerance.md
+++ b/docs/adr/0003-observability-and-fault-tolerance.md
@@ -36,9 +36,10 @@ Fault tolerance, per layer:
 
 - **Edge:** per-upstream timeout, circuit breaker, bulkhead that refuses rather
   than queues, retry with full jitter on idempotent requests only.
-- **Domain:** outbox and inbox in the same transaction as the aggregate change,
-  giving an exactly-once *effect* without any broker promising exactly-once
-  delivery.
+- **Domain:** outbox and inbox boundaries provide an exactly-once *effect*
+  without any broker promising exactly-once delivery. The precise boundaries,
+  including the weaker MongoDB convergence case, are defined by
+  [ADR 0009](0009-exactly-once-effect.md).
 - **Messaging:** durable queues, persistent messages, publisher confirms, and a
   real dead-letter exchange with backoff via TTL in the broker rather than
   `sleep` in the consumer.

--- a/docs/adr/0009-exactly-once-effect.md
+++ b/docs/adr/0009-exactly-once-effect.md
@@ -118,8 +118,11 @@ Once downstream execution starts, an exception is retained as an `unknown`
 outcome rather than releasing the key. That chooses duplicate prevention over
 automatic retry when the database may already have committed. Redis uses AOF
 with `appendfsync always` in both Compose stacks so a claim is fsynced before it
-is acknowledged. This is not atomic with a service database: loss or corruption
-of the Redis volume can still remove request history.
+is acknowledged. The memory-limited self-hosted overlay uses `noeviction`:
+when Redis is full, protected writes fail closed instead of silently evicting
+idempotency history before its TTL. This trades write availability for the
+stated duplicate-prevention guarantee. Redis is still not atomic with a service
+database: loss or corruption of the Redis volume can remove request history.
 
 <a id="retention-boundaries"></a>
 ## Retention boundaries

--- a/docs/adr/0009-exactly-once-effect.md
+++ b/docs/adr/0009-exactly-once-effect.md
@@ -72,8 +72,15 @@ ambiguous and can cause a duplicate publish.
 Each relay atomically claims one eligible aggregate head with `FOR UPDATE SKIP
 LOCKED`, records an owner token and lease, and publishes outside the database
 transaction. Another replica skips that row. Rows from the same aggregate are
-released in `AggregateSequence` order; no ordering is promised between
-different aggregates.
+selected by `AggregateSequence`, `OccurredAtUtc`, and `Id`, and only one head
+can be owned at a time.
+
+The relay preserves causal order only when the producer persists a strictly
+monotonic `AggregateSequence` in the same write. AuthGate image chunks do this
+inside one registration transaction. MotoHub licence-plate updates currently
+write sequence `0` for every separate update, so their timestamp and identifier
+are tie-breakers, not a causal clock. Ordering between those updates is
+deliberately not promised, nor is ordering between different aggregates.
 
 A publish failure clears the claim and schedules a bounded backoff. A process
 crash leaves the claim until its lease expires. A confirm followed by a crash
@@ -140,8 +147,8 @@ HTTP key as permanent evidence.
 The domain commit succeeds and the outbox row remains pending. The API does not
 wait for RabbitMQ, so downstream views can be stale until the relay recovers.
 Backlog age and attempt count, not API status, expose this degradation. Ordering
-within one aggregate is preserved because later rows cannot pass its pending
-head.
+for already-sequenced rows is preserved because later rows cannot pass their
+pending head; the relay does not invent a missing producer sequence.
 
 ### Broker partition and ambiguous confirms
 
@@ -158,7 +165,9 @@ early. Claim tokens prevent a former owner from marking a row complete after it
 loses ownership, but they cannot retract an external publish already made.
 Production nodes therefore require synchronized clocks and lease durations
 larger than expected skew and publish latency. Duplicate delivery remains an
-expected outcome and must reach an inbox-protected handler.
+expected outcome and must reach an inbox-protected handler. Same-sequence
+MotoHub updates can also be observed out of causal order when their timestamps
+come from skewed writers.
 
 ### Partition during the unique-index race
 
@@ -188,7 +197,11 @@ acknowledge conflicting writes outside its configured consistency model.
   RabbitMQ.** Each guarantee ends at its named authority.
 - **Not exactly-once execution.** Handlers and middleware can run more than
   once; the durable effect is what is deduplicated.
-- **Not global event ordering.** Ordering is per aggregate only.
+- **Not global event ordering.** A producer sequence can order one aggregate;
+  nothing orders different aggregates.
+- **Not causal ordering for MotoHub licence updates.** Those events do not yet
+  carry a durable monotonic aggregate sequence; relay tie-breakers are not a
+  substitute for one.
 - **Not arbitrary MongoDB effect safety.** The current Mongo inbox requires an
   idempotent effect after a crash window.
 - **Not permanent deduplication.** HTTP and inbox records expire.
@@ -210,7 +223,7 @@ only where the test must deterministically stop or observe a publish.
 | [Database rental claim](#database-serialized-rental-claim) | [`ConcurrentCreateRequestsForSameMotorcycle_OneSucceedsAndOneReturnsConflict`](../../RentalOperations/RentalOperationsTests/Integration/MongoDb/ActiveRentalApiTests.cs) | The production Mongo partial unique index is removed |
 | [Database rental claim](#database-serialized-rental-claim) | [`ConcurrentClaimsForSameMotorcycle_OneIsRejectedByDatabaseConstraint`](../../RentalOperations/RentalOperationsTests/Integration/PostgreSql/ActiveRentalConstraintTests.cs) | The relational partial unique index is removed |
 | [Transactional outbox](#transactional-outbox) | [`DomainMutationAndOutboxInsert_RollBackTogetherWhenSaveFails`](../../MotoHub/MotoHubTests/Integration/PostgreSql/OutboxRelayTests.cs) | The outbox is no longer part of the aggregate save |
-| [Transactional outbox](#transactional-outbox) | [`CommittedMessages_SurviveRelayRestartAndDrainInAggregateOrderAfterBrokerRecovery`](../../MotoHub/MotoHubTests/Integration/PostgreSql/OutboxRelayTests.cs) | The committed event row or retry behavior is removed |
+| [Transactional outbox](#transactional-outbox) | [`CommittedSequencedMessages_SurviveRelayRestartAndDrainAfterBrokerRecovery`](../../MotoHub/MotoHubTests/Integration/PostgreSql/OutboxRelayTests.cs) | The committed event row or retry behavior is removed |
 | [Leased relay](#leased-outbox-relay) | [`ConcurrentRelays_ClaimOnlyOneHeadMessagePerAggregate`](../../MotoHub/MotoHubTests/Integration/PostgreSql/OutboxRelayTests.cs) | Atomic claims or aggregate-head ordering is removed |
 | [PostgreSQL inbox](#transactional-inbox) | [`SameMessageProcessedConcurrently_ProducesOneDatabaseEffect`](../../RiderManager/RiderManagerTests/Integration/PostgreSql/InboxProcessorTests.cs) | The inbox conflict gate or shared transaction is removed |
 | [PostgreSQL inbox](#transactional-inbox) | [`ImageRedelivery_UsesInboxAndCallsIdempotentUploadOnce`](../../RiderManager/RiderManagerTests/Integration/PostgreSql/InboxProcessorTests.cs) | Completed image messages are handled again |

--- a/docs/adr/0009-exactly-once-effect.md
+++ b/docs/adr/0009-exactly-once-effect.md
@@ -1,0 +1,271 @@
+# ADR 0009 — Exactly-once effect is a layered, bounded guarantee
+
+- **Status:** Accepted
+- **Date:** 2026-09-01
+- **Deciders:** ProjectY maintainers
+
+## Context
+
+The phrase "exactly once" is dangerously compact. A request crosses an HTTP
+server, a primary database, an outbox relay, RabbitMQ, and a consumer database.
+None of those components can make one atomic commit across every boundary, and
+RabbitMQ deliberately provides at-least-once delivery. Calling the whole path
+"exactly once" would hide the failure modes that matter most.
+
+This record refines the domain guarantee sketched in
+[ADR 0003](0003-observability-and-fault-tolerance.md). It documents the
+baseline .NET services implemented in this repository; it does not claim that
+the future services named in `deploy/base/compose.yaml` already provide the
+same behavior.
+
+## Decision
+
+ProjectY promises an **exactly-once effect only inside a named idempotency
+boundary**. It means that retries or redeliveries carrying the same stable
+identity produce at most one durable domain transition inside that boundary.
+It does not mean exactly-once transport, one global transaction, or one
+execution of application code.
+
+The guarantee is assembled from independent layers. Each layer has its own
+identity, durability boundary, expiry, and failure response.
+
+| Layer | Stable identity | Authority | Guarantee |
+|---|---|---|---|
+| Rental claim | Motorcycle licence plate while status is `Active` | MongoDB partial unique index | At most one active rental per motorcycle |
+| Producer write | EF Core database transaction | PostgreSQL | Aggregate mutation and outbox rows commit or roll back together |
+| Relay | Outbox row and claim token | PostgreSQL | A committed row remains retryable; concurrent relays do not own the same row |
+| Rider consumer | `(MessageId, ConsumerName)` | PostgreSQL inbox transaction | Inbox record and relational domain effect commit once |
+| Rental consumer | `(MessageId, ConsumerName)` | MongoDB inbox document | One active handler lease; completed messages are suppressed |
+| HTTP retry | Service, authenticated caller, and `Idempotency-Key` | Redis AOF | Same fingerprint replays; a different fingerprint is rejected for 24 hours |
+
+<a id="database-serialized-rental-claim"></a>
+## Database-serialized rental claim
+
+RentalOperations relies on MongoDB's partial unique index over
+`MotorcycleLicencePlate` for documents whose status is `Active`. The
+application may perform an advisory read for a friendly error, but correctness
+comes from the index. Two genuinely parallel inserts can both pass an earlier
+read; MongoDB serializes the writes and accepts only one. The losing API request
+returns `409 Conflict`.
+
+The relational `rental_claims` Testcontainer is a portability proof of the same
+invariant using a PostgreSQL partial unique index. It is not a claim that the
+current RentalOperations service stores rentals in PostgreSQL.
+
+<a id="transactional-outbox"></a>
+## Transactional outbox
+
+AuthGate and MotoHub add domain changes and `OutboxMessages` to the same EF Core
+`DbContext` and commit them in one PostgreSQL transaction. A failed outbox
+insert rolls back the domain mutation. A successful domain commit therefore
+leaves a durable event row even when RabbitMQ is unavailable or the process
+stops before the relay runs.
+
+This boundary ends at PostgreSQL. Publishing and marking `PublishedAtUtc`
+cannot be one transaction with RabbitMQ. Publisher confirms prove that the
+broker accepted a message, but a connection loss around the confirm is
+ambiguous and can cause a duplicate publish.
+
+<a id="leased-outbox-relay"></a>
+## Leased outbox relay and ordering
+
+Each relay atomically claims one eligible aggregate head with `FOR UPDATE SKIP
+LOCKED`, records an owner token and lease, and publishes outside the database
+transaction. Another replica skips that row. Rows from the same aggregate are
+released in `AggregateSequence` order; no ordering is promised between
+different aggregates.
+
+A publish failure clears the claim and schedules a bounded backoff. A process
+crash leaves the claim until its lease expires. A confirm followed by a crash
+before `PublishedAtUtc` is stored causes a later republish; consumer inboxes are
+what make that duplicate harmless.
+
+<a id="transactional-inbox"></a>
+## PostgreSQL transactional inbox
+
+RiderManager inserts `(MessageId, ConsumerName)` with `ON CONFLICT DO NOTHING`,
+runs the handler, and commits the inbox row and EF Core domain changes in one
+transaction. Concurrent deliveries race at the database; one commits and the
+other reports that it did no work. This is the strongest consumer boundary in
+the baseline and is the precise case meant by "exactly-once effect."
+
+The guarantee covers effects written through that same PostgreSQL transaction.
+Calls to object storage, HTTP APIs, email, or another database are outside it
+and must be independently idempotent.
+
+<a id="mongo-inbox-convergence"></a>
+## MongoDB inbox convergence
+
+RentalOperations atomically leases an inbox document and suppresses a completed
+message, but its handler effect and inbox completion are not a general MongoDB
+multi-document transaction. A crash can therefore happen after the effect and
+before completion. Redelivery is safe only where the handler itself is
+idempotent, such as setting every matching rental from an old plate to a new
+plate. The test proves convergence for that operation; it does not generalize
+the PostgreSQL transactional-inbox promise to arbitrary MongoDB effects.
+
+<a id="http-idempotency"></a>
+## HTTP idempotency
+
+For `POST`, `PUT`, `PATCH`, and `DELETE`, clients may provide an
+`Idempotency-Key`. Redis atomically claims the service/caller/key tuple for the
+full 24-hour retention period. The fingerprint includes method, path, ordered
+query values, caller, content type, and raw body. A completed response is
+replayed; a different fingerprint returns `422`; concurrent ownership returns
+`409`.
+
+Once downstream execution starts, an exception is retained as an `unknown`
+outcome rather than releasing the key. That chooses duplicate prevention over
+automatic retry when the database may already have committed. Redis uses AOF
+with `appendfsync always` in both Compose stacks so a claim is fsynced before it
+is acknowledged. This is not atomic with a service database: loss or corruption
+of the Redis volume can still remove request history.
+
+<a id="retention-boundaries"></a>
+## Retention boundaries
+
+Idempotency records live for 24 hours and inbox records are retained for seven
+days by the configured cleanup mechanisms. After retention expires, an old key
+or message identity may execute again. Producers must not redeliver messages
+beyond the consumer retention horizon, and clients must not treat an expired
+HTTP key as permanent evidence.
+
+## Failure modes
+
+### Outbox relay lag
+
+The domain commit succeeds and the outbox row remains pending. The API does not
+wait for RabbitMQ, so downstream views can be stale until the relay recovers.
+Backlog age and attempt count, not API status, expose this degradation. Ordering
+within one aggregate is preserved because later rows cannot pass its pending
+head.
+
+### Broker partition and ambiguous confirms
+
+Before a confirm, the row remains pending and is retried. If RabbitMQ accepted
+the message but the confirm was lost, retry can publish it twice. Durable queues
+and persistent messages protect accepted messages across broker restart; inbox
+deduplication protects domain effects from duplicate delivery.
+
+### Clock skew
+
+Outbox and Mongo inbox leases use application-node UTC timestamps. A fast owner
+clock can hold a claim longer than intended; a fast contender can reclaim it
+early. Claim tokens prevent a former owner from marking a row complete after it
+loses ownership, but they cannot retract an external publish already made.
+Production nodes therefore require synchronized clocks and lease durations
+larger than expected skew and publish latency. Duplicate delivery remains an
+expected outcome and must reach an inbox-protected handler.
+
+### Partition during the unique-index race
+
+The primary database is the authority. A writer that cannot reach it cannot
+claim a rental and fails. If a commit succeeded but its acknowledgement was
+lost, the client sees an ambiguous result; retrying cannot create a second
+active rental because the unique index still arbitrates the write. During a
+database topology event, this guarantee assumes MongoDB itself does not
+acknowledge conflicting writes outside its configured consistency model.
+
+### Process crash by phase
+
+| Crash point | Observable result |
+|---|---|
+| Before database commit | Neither domain mutation nor outbox row exists |
+| After commit, before publish | Domain state exists; pending outbox row publishes after recovery |
+| After broker accept, before `PublishedAtUtc` | Message may be published again; inbox suppresses the duplicate effect |
+| During PostgreSQL inbox handler | Inbox and relational effect roll back together |
+| After Mongo effect, before inbox completion | Redelivery occurs; only an idempotent handler is safe |
+| After HTTP effect, before response persistence | Redis retains `unknown`; the same key never executes again during retention |
+
+## What is deliberately not promised
+
+- **Not exactly-once delivery.** RabbitMQ may redeliver and the relay may
+  republish.
+- **Not one transaction across Redis, PostgreSQL, MongoDB, MinIO, and
+  RabbitMQ.** Each guarantee ends at its named authority.
+- **Not exactly-once execution.** Handlers and middleware can run more than
+  once; the durable effect is what is deduplicated.
+- **Not global event ordering.** Ordering is per aggregate only.
+- **Not arbitrary MongoDB effect safety.** The current Mongo inbox requires an
+  idempotent effect after a crash window.
+- **Not permanent deduplication.** HTTP and inbox records expire.
+- **Not protection for requests without `Idempotency-Key`.** Those requests
+  intentionally bypass Redis.
+- **Not recovery from loss of the authority itself.** Losing the primary
+  database, inbox table, or Redis AOF volume loses the corresponding evidence.
+- **Not immediate propagation.** A healthy primary write can coexist with a
+  delayed outbox and stale downstream reads.
+
+## Executable proof matrix
+
+Every proof carries a `Guarantee` trait that points back to the paragraph above.
+All database and Redis proofs use real Testcontainers; the transport is replaced
+only where the test must deterministically stop or observe a publish.
+
+| Paragraph | Executable proof | Fails when |
+|---|---|---|
+| [Database rental claim](#database-serialized-rental-claim) | [`ConcurrentCreateRequestsForSameMotorcycle_OneSucceedsAndOneReturnsConflict`](../../RentalOperations/RentalOperationsTests/Integration/MongoDb/ActiveRentalApiTests.cs) | The production Mongo partial unique index is removed |
+| [Database rental claim](#database-serialized-rental-claim) | [`ConcurrentClaimsForSameMotorcycle_OneIsRejectedByDatabaseConstraint`](../../RentalOperations/RentalOperationsTests/Integration/PostgreSql/ActiveRentalConstraintTests.cs) | The relational partial unique index is removed |
+| [Transactional outbox](#transactional-outbox) | [`DomainMutationAndOutboxInsert_RollBackTogetherWhenSaveFails`](../../MotoHub/MotoHubTests/Integration/PostgreSql/OutboxRelayTests.cs) | The outbox is no longer part of the aggregate save |
+| [Transactional outbox](#transactional-outbox) | [`CommittedMessages_SurviveRelayRestartAndDrainInAggregateOrderAfterBrokerRecovery`](../../MotoHub/MotoHubTests/Integration/PostgreSql/OutboxRelayTests.cs) | The committed event row or retry behavior is removed |
+| [Leased relay](#leased-outbox-relay) | [`ConcurrentRelays_ClaimOnlyOneHeadMessagePerAggregate`](../../MotoHub/MotoHubTests/Integration/PostgreSql/OutboxRelayTests.cs) | Atomic claims or aggregate-head ordering is removed |
+| [PostgreSQL inbox](#transactional-inbox) | [`SameMessageProcessedConcurrently_ProducesOneDatabaseEffect`](../../RiderManager/RiderManagerTests/Integration/PostgreSql/InboxProcessorTests.cs) | The inbox conflict gate or shared transaction is removed |
+| [PostgreSQL inbox](#transactional-inbox) | [`ImageRedelivery_UsesInboxAndCallsIdempotentUploadOnce`](../../RiderManager/RiderManagerTests/Integration/PostgreSql/InboxProcessorTests.cs) | Completed image messages are handled again |
+| [Mongo inbox](#mongo-inbox-convergence) | [`SameMessageDeliveredTwice_ExecutesHandlerOnce`](../../RentalOperations/RentalOperationsTests/Integration/MongoDb/InboxProcessorTests.cs) | Completed Mongo inbox messages are claimable |
+| [Mongo inbox](#mongo-inbox-convergence) | [`CrashAfterIdempotentEffect_RedeliveryConvergesAndCompletesInbox`](../../RentalOperations/RentalOperationsTests/Integration/MongoDb/InboxProcessorTests.cs) | A crash cannot be reclaimed or the handler is not idempotent |
+| [HTTP idempotency](#http-idempotency) | [`ReplayingCreateWithSameKey_ReturnsOriginalResponseAndOneEffect`](../../RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs) | Completed responses are not stored |
+| [HTTP idempotency](#http-idempotency) | [`ReusingKeyWithDifferentBody_ReturnsUnprocessableEntity`](../../RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs) | Body fingerprints are ignored |
+| [HTTP idempotency](#http-idempotency) | [`ConcurrentRequestWithSameKey_ReturnsConflictUntilFirstCompletes`](../../RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs) | Atomic Redis claiming is removed |
+| [HTTP idempotency](#http-idempotency) | [`LongRunningRequest_RetainsClaimUntilItCompletes`](../../RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs) | Pending claims expire on a short execution lease |
+| [HTTP idempotency](#http-idempotency) | [`DownstreamFailure_RetainsUnknownOutcomeWithoutRepeatingEffect`](../../RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs) | Ambiguous failures release their claim |
+| [HTTP idempotency](#http-idempotency) | [`ReusingKeyWithReorderedQueryValues_ReturnsUnprocessableEntity`](../../RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs) | Repeated query-value order is discarded |
+| [Retention](#retention-boundaries) | [`RetentionSweep_DeletesOnlyExpiredInboxRows`](../../RiderManager/RiderManagerTests/Integration/PostgreSql/InboxProcessorTests.cs) | PostgreSQL retention deletes current evidence |
+| [Retention](#retention-boundaries) | [`Initializer_SchedulesRetentionWithTtlIndex`](../../RentalOperations/RentalOperationsTests/Integration/MongoDb/InboxProcessorTests.cs) | MongoDB inbox TTL is missing or misconfigured |
+
+Run the proof suite from the repository root:
+
+```powershell
+dotnet test RentalOperations/RentalOperationsTests/RentalOperationsTests.csproj --filter "Category=Integration&Guarantee~ADR-0009"
+dotnet test MotoHub/MotoHubTests/MotoHubTests.csproj --filter "Category=Integration&Guarantee~ADR-0009"
+dotnet test RiderManager/RiderManagerTests/RiderManagerTests.csproj --filter "Category=Integration&Guarantee~ADR-0009"
+```
+
+## Alternatives considered
+
+- **Distributed transactions across every dependency.** RabbitMQ, Redis,
+  PostgreSQL, MongoDB, and object storage do not share a practical transaction
+  coordinator here. The operational cost would still not remove ambiguous
+  network outcomes.
+- **Broker deduplication as the only defense.** It does not cover republish
+  after an ambiguous confirm, consumer crashes, or domain-specific identities.
+- **An application mutex around rental creation.** It protects one process,
+  disappears on restart, and fails with two replicas. The database constraint
+  is the authority all replicas share.
+- **Infinite inbox and idempotency retention.** It converts correctness state
+  into unbounded storage. Bounded retention is explicit, monitored, and part of
+  the producer/client contract.
+
+## What was explicitly rejected
+
+The project does not use the phrase "exactly-once delivery." It does not hide
+the MongoDB crash window behind the stronger PostgreSQL inbox guarantee, and it
+does not claim that an HTTP idempotency record commits atomically with a domain
+database. Precision is preferred over a broader but false guarantee.
+
+## Consequences
+
+- Every new consumer must name its message identity and effect boundary.
+- External side effects require their own idempotency key or reconciliation
+  process.
+- Clock synchronization and retention horizons are correctness inputs, not
+  tuning details.
+- Relay backlog, expired leases, inbox conflicts, and unknown HTTP outcomes
+  need operational visibility.
+- The integration suite is slower because it starts real PostgreSQL, MongoDB,
+  and Redis containers; that cost is accepted because mocks cannot prove these
+  database races.
+
+## Follow-up
+
+- [Epic 5 — Transactional core and distributed consistency](https://github.com/iVega123/ProjectY/issues/6)
+- [Task 56 — Write the guarantees and prove them](https://github.com/iVega123/ProjectY/issues/56)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,7 @@ is what separates a decision from a preference.
 | [0006](0006-secret-loading-and-jwt-boundaries.md) | Secret loading and JWT trust boundaries | How finding C3 was closed |
 | [0007](0007-authenticated-queue-boundary.md) | Authenticate domain-writing queue messages | How finding C5 was closed |
 | [0008](0008-single-trust-boundary.md) | One trust boundary, at the edge | Why domain services stop parsing tokens, and what is traded for it |
+| [0009](0009-exactly-once-effect.md) | Exactly-once effect is layered and bounded | Which layer provides each guarantee, how it fails, and what is deliberately not promised |
 
 ## Reading order
 
@@ -27,6 +28,8 @@ to that trail but was written later, after review showed the trust-boundary
 decision was implied everywhere and recorded nowhere; read it after 0001.
 Records 0006 and 0007 are remediation decisions taken while closing individual
 findings, and read on their own. Numbers are never reused or reassigned.
+ADR 0009 is the executable consistency contract and refines the shorter
+outbox/inbox statement in ADR 0003.
 
 The full findings list, with remediation status and the commit that closed each
 one, lives in


### PR DESCRIPTION
Closes #56. Adds ADR 0009 defining the exact boundaries of exactly-once effects, failure modes, clock-skew and partition behavior, and guarantees deliberately not promised. Links 17 Testcontainers proofs back to their ADR paragraphs, adds a negative transactional-outbox rollback proof, and makes the relay-recovery test instantiate a new relay process. Local validation: affected solutions build, 95 non-integration tests pass, all 17 ADR proofs are discoverable, and dotnet format is clean. The Testcontainers proofs run in CI because Docker is unavailable locally.