### PR TITLE
M12: soft-delete motorcycles and serialize retirement

### DIFF
--- a/MotoHub/MotoHub/Controllers/MotorcycleController.cs
+++ b/MotoHub/MotoHub/Controllers/MotorcycleController.cs
@@ -92,10 +92,20 @@ namespace MotoHub.Controllers
             }
             else
             {
-
-                return BadRequest(result.Message);
+                return result.StatusCode is { } statusCode
+                    ? StatusCode(statusCode, result.Message)
+                    : BadRequest(result.Message);
             }
 
+        }
+
+        [ServiceFilter(typeof(AdminAuthorizationFilter))]
+        [HttpPost("historical-references")]
+        public async Task<IActionResult> EnsureHistoricalReferences(
+            [FromBody] HistoricalMotorcycleReferencesRequest request)
+        {
+            await _motorcycleService.EnsureHistoricalReferencesAsync(request.LicensePlates);
+            return NoContent();
         }
     }
 }

--- a/MotoHub/MotoHub/CrossCutting/IRentalOperationService.cs
+++ b/MotoHub/MotoHub/CrossCutting/IRentalOperationService.cs
@@ -3,5 +3,6 @@
     public interface IRentalOperationService
     {
         Task<bool> GetRentalsByMotorcycleLicencePlateAsync(string licensePlate);
+        Task<bool> TryRetireMotorcycleAsync(string licensePlate);
     }
 }

--- a/MotoHub/MotoHub/CrossCutting/RentalOperationService.cs
+++ b/MotoHub/MotoHub/CrossCutting/RentalOperationService.cs
@@ -36,5 +36,34 @@ namespace MotoHub.CrossCutting
                 throw new Exception($"Unable to obtain motorcycle data: {e.Message}", e);
             }
         }
+
+        public async Task<bool> TryRetireMotorcycleAsync(string licensePlate)
+        {
+            try
+            {
+                var response = await _httpClient.PostAsync(
+                    $"api/Rental/motorcycle-retirements/{Uri.EscapeDataString(licensePlate)}",
+                    content: null);
+                if (response.IsSuccessStatusCode)
+                {
+                    return true;
+                }
+
+                if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+                {
+                    return false;
+                }
+
+                var errorContent = await response.Content.ReadAsStringAsync();
+                throw new HttpRequestException(
+                    $"Request failed with status {response.StatusCode}: {errorContent}");
+            }
+            catch (HttpRequestException exception)
+            {
+                throw new Exception(
+                    $"Unable to reserve motorcycle retirement: {exception.Message}",
+                    exception);
+            }
+        }
     }
 }

--- a/MotoHub/MotoHub/DTOs/HistoricalMotorcycleReferencesRequest.cs
+++ b/MotoHub/MotoHub/DTOs/HistoricalMotorcycleReferencesRequest.cs
@@ -1,0 +1,6 @@
+namespace MotoHub.DTOs;
+
+public sealed class HistoricalMotorcycleReferencesRequest
+{
+    public required IReadOnlyCollection<string> LicensePlates { get; init; }
+}

--- a/MotoHub/MotoHub/DTOs/MotoDTO.cs
+++ b/MotoHub/MotoHub/DTOs/MotoDTO.cs
@@ -5,5 +5,7 @@
         public int Year { get; set; }
         public string? Model { get; set; }
         public required string LicensePlate { get; set; }
+        public DateTime? RetiredAtUtc { get; set; }
+        public string? RetirementReason { get; set; }
     }
 }

--- a/MotoHub/MotoHub/Data/IApplicationDbContext.cs
+++ b/MotoHub/MotoHub/Data/IApplicationDbContext.cs
@@ -8,6 +8,7 @@ namespace MotoHub.Data
     {
         DbSet<Motorcycle> Motorcycles { get; set; }
         int SaveChanges();
+        Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
         EntityEntry<TEntity> Entry<TEntity>(TEntity entity) where TEntity : class;
     }
 }

--- a/MotoHub/MotoHub/Entities/OperationResult.cs
+++ b/MotoHub/MotoHub/Entities/OperationResult.cs
@@ -4,9 +4,11 @@
     {
         public bool Success { get; set; }
         public string Message { get; set; } = string.Empty;
+        public int? StatusCode { get; set; }
 
-        public static OperationResult Ok(string message = null) => new OperationResult { Success = true, Message = message };
-        public static OperationResult Fail(string message) => new OperationResult { Success = false, Message = message };
+        public static OperationResult Ok(string? message = null) => new() { Success = true, Message = message ?? string.Empty };
+        public static OperationResult Fail(string message, int? statusCode = null) =>
+            new() { Success = false, Message = message, StatusCode = statusCode };
     }
 
 }

--- a/MotoHub/MotoHub/Mapping/MappingProfile.cs
+++ b/MotoHub/MotoHub/Mapping/MappingProfile.cs
@@ -8,7 +8,9 @@ namespace MotoHub.Mapping
     {
         public MappingProfile()
         {
-            CreateMap<MotorcycleDTO, Motorcycle>();
+            CreateMap<MotorcycleDTO, Motorcycle>()
+                .ForMember(motorcycle => motorcycle.RetiredAtUtc, options => options.Ignore())
+                .ForMember(motorcycle => motorcycle.RetirementReason, options => options.Ignore());
             CreateMap<Motorcycle, MotorcycleDTO>();
         }
     }

--- a/MotoHub/MotoHub/Migrations/20260901115807_AddMotorcycleRetirement.Designer.cs
+++ b/MotoHub/MotoHub/Migrations/20260901115807_AddMotorcycleRetirement.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MotoHub.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MotoHub.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260901115807_AddMotorcycleRetirement")]
+    partial class AddMotorcycleRetirement
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MotoHub/MotoHub/Migrations/20260901115807_AddMotorcycleRetirement.cs
+++ b/MotoHub/MotoHub/Migrations/20260901115807_AddMotorcycleRetirement.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MotoHub.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMotorcycleRetirement : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "RetiredAtUtc",
+                table: "Motorcycles",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RetirementReason",
+                table: "Motorcycles",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RetiredAtUtc",
+                table: "Motorcycles");
+
+            migrationBuilder.DropColumn(
+                name: "RetirementReason",
+                table: "Motorcycles");
+        }
+    }
+}

--- a/MotoHub/MotoHub/Models/Moto.cs
+++ b/MotoHub/MotoHub/Models/Moto.cs
@@ -7,5 +7,7 @@
         public string? Model { get; set; }
         public required string LicensePlate { get; set; }
         public DateTime RegistrationDate { get; set; }
+        public DateTime? RetiredAtUtc { get; set; }
+        public string? RetirementReason { get; set; }
     }
 }

--- a/MotoHub/MotoHub/Models/MotorcycleRetirementReasons.cs
+++ b/MotoHub/MotoHub/Models/MotorcycleRetirementReasons.cs
@@ -1,0 +1,7 @@
+namespace MotoHub.Models;
+
+public static class MotorcycleRetirementReasons
+{
+    public const string RequestedByAdministrator = "RequestedByAdministrator";
+    public const string LegacyOrphanBackfill = "LegacyOrphanBackfill";
+}

--- a/MotoHub/MotoHub/Repositories/IMotorcycleRepository.cs
+++ b/MotoHub/MotoHub/Repositories/IMotorcycleRepository.cs
@@ -8,7 +8,8 @@ namespace MotoHub.Repositories
         Motorcycle? GetById(string id);
         void Add(Motorcycle motorcycle);
         void Update(Motorcycle motorcycle);
-        void Delete(string id);
+        Task<bool> RetireAsync(string id, DateTime retiredAtUtc, string reason);
+        Task EnsureHistoricalReferenceAsync(string licensePlate, DateTime retiredAtUtc);
         bool LicensePlateExists(string licensePlate);
         Task<Motorcycle?> GetByLicensePlateAsync(string licensePlate);
     }

--- a/MotoHub/MotoHub/Repositories/MotorcycleRepository.cs
+++ b/MotoHub/MotoHub/Repositories/MotorcycleRepository.cs
@@ -15,7 +15,9 @@ namespace MotoHub.Repositories
 
         public IEnumerable<Motorcycle> GetAll()
         {
-            return _context.Motorcycles.ToList();
+            return _context.Motorcycles
+                .Where(motorcycle => motorcycle.RetiredAtUtc == null)
+                .ToList();
         }
 
         public Motorcycle? GetById(string id)
@@ -35,15 +37,48 @@ namespace MotoHub.Repositories
             _context.SaveChanges();
         }
 
-        public void Delete(string id)
+        public async Task<bool> RetireAsync(string id, DateTime retiredAtUtc, string reason)
         {
-            var motorcycle = _context.Motorcycles.Find(id);
-            if (motorcycle == null)
+            var motorcycle = await _context.Motorcycles
+                .FirstOrDefaultAsync(candidate => candidate.Id == id && candidate.RetiredAtUtc == null);
+            if (motorcycle is null)
+            {
+                return false;
+            }
+
+            motorcycle.RetiredAtUtc = retiredAtUtc;
+            motorcycle.RetirementReason = reason;
+            await _context.SaveChangesAsync();
+            return true;
+        }
+
+        public async Task EnsureHistoricalReferenceAsync(string licensePlate, DateTime retiredAtUtc)
+        {
+            if (await _context.Motorcycles.AnyAsync(motorcycle => motorcycle.LicensePlate == licensePlate))
             {
                 return;
             }
-            _context.Motorcycles.Remove(motorcycle);
-            _context.SaveChanges();
+
+            var placeholder = new Motorcycle
+            {
+                LicensePlate = licensePlate,
+                Model = "Legacy motorcycle (metadata unavailable)",
+                Year = 0,
+                RegistrationDate = retiredAtUtc,
+                RetiredAtUtc = retiredAtUtc,
+                RetirementReason = MotorcycleRetirementReasons.LegacyOrphanBackfill
+            };
+
+            _context.Motorcycles.Add(placeholder);
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateException)
+                when (_context.Motorcycles.Any(motorcycle => motorcycle.LicensePlate == licensePlate))
+            {
+                _context.Entry(placeholder).State = EntityState.Detached;
+            }
         }
 
         public bool LicensePlateExists(string licensePlate)

--- a/MotoHub/MotoHub/Services/IMotorcycleService.cs
+++ b/MotoHub/MotoHub/Services/IMotorcycleService.cs
@@ -6,10 +6,11 @@ namespace MotoHub.Services
     public interface IMotorcycleService
     {
         IEnumerable<MotorcycleDTO> GetAllMotorcycles();
-        Task<MotorcycleDTO> GetMotorcycleByLicensePlateAsync(string licensePlate);
+        Task<MotorcycleDTO?> GetMotorcycleByLicensePlateAsync(string licensePlate);
         void CreateMotorcycle(MotorcycleDTO motorcycleDto);
         Task UpdateMotorcycleAsync(string licensePlate, string newLicencePlate);
         Task<OperationResult> DeleteMotorcycle(string licensePlate);
+        Task EnsureHistoricalReferencesAsync(IEnumerable<string> licensePlates);
         bool LicensePlateExists(string licensePlate);
     }
 }

--- a/MotoHub/MotoHub/Services/MotorcycleService.cs
+++ b/MotoHub/MotoHub/Services/MotorcycleService.cs
@@ -33,7 +33,7 @@ namespace MotoHub.Services
             return _mapper.Map<IEnumerable<MotorcycleDTO>>(motorcycles);
         }
 
-        public async Task<MotorcycleDTO> GetMotorcycleByLicensePlateAsync(string licensePlate)
+        public async Task<MotorcycleDTO?> GetMotorcycleByLicensePlateAsync(string licensePlate)
         {
             var motorcycle = await _repository.GetByLicensePlateAsync(licensePlate);
             return _mapper.Map<MotorcycleDTO>(motorcycle);
@@ -49,6 +49,11 @@ namespace MotoHub.Services
         {
             var existingMotorcycle = await _repository.GetByLicensePlateAsync(licensePlate);
             if (existingMotorcycle == null)
+            {
+                return;
+            }
+
+            if (existingMotorcycle.RetiredAtUtc is not null)
             {
                 return;
             }
@@ -72,18 +77,43 @@ namespace MotoHub.Services
             if (existingMotorcycle == null)
                 return OperationResult.Fail($"Motorcycle with plate {licensePlate} not found.");
 
-            var isRented = await _rentalOperationService.GetRentalsByMotorcycleLicencePlateAsync(licensePlate);
-            if (isRented)
-                return OperationResult.Fail("Motorcycle is currently rented and cannot be deleted.");
+            if (existingMotorcycle.RetiredAtUtc is not null)
+                return OperationResult.Ok("Motorcycle was already retired.");
 
             try
             {
-                _repository.Delete(existingMotorcycle.Id);
-                return OperationResult.Ok("Motorcycle successfully deleted.");
+                var retirementReserved = await _rentalOperationService.TryRetireMotorcycleAsync(licensePlate);
+                if (!retirementReserved)
+                    return OperationResult.Fail(
+                        "Motorcycle has an active rental and cannot be retired.",
+                        StatusCodes.Status409Conflict);
+
+                var retired = await _repository.RetireAsync(
+                    existingMotorcycle.Id,
+                    DateTime.UtcNow,
+                    MotorcycleRetirementReasons.RequestedByAdministrator);
+                return retired
+                    ? OperationResult.Ok("Motorcycle successfully retired.")
+                    : OperationResult.Ok("Motorcycle was already retired.");
             }
             catch (Exception ex)
             {
-                return OperationResult.Fail("Failed to delete the motorcycle due to an unexpected error." + ex.Message);
+                // The RentalOperations retirement marker is intentionally retained on an
+                // ambiguous failure. A retry can finish the soft delete without allowing a
+                // rental to slip through the cross-service commit window.
+                return OperationResult.Fail("Failed to retire the motorcycle due to an unexpected error. " + ex.Message);
+            }
+        }
+
+        public async Task EnsureHistoricalReferencesAsync(IEnumerable<string> licensePlates)
+        {
+            var retiredAtUtc = DateTime.UtcNow;
+            foreach (var licensePlate in licensePlates
+                         .Where(plate => !string.IsNullOrWhiteSpace(plate))
+                         .Select(plate => plate.Trim())
+                         .Distinct(StringComparer.Ordinal))
+            {
+                await _repository.EnsureHistoricalReferenceAsync(licensePlate, retiredAtUtc);
             }
         }
 

--- a/MotoHub/MotoHubTests/Integration/CustomWebApplicationFactory.cs
+++ b/MotoHub/MotoHubTests/Integration/CustomWebApplicationFactory.cs
@@ -36,6 +36,8 @@ namespace MotoHubTests.Integration
                 var mockService = new Mock<IRentalOperationService>();
                 mockService.Setup(service => service.GetRentalsByMotorcycleLicencePlateAsync("mock"))
                            .ReturnsAsync(true);
+                mockService.Setup(service => service.TryRetireMotorcycleAsync(It.IsAny<string>()))
+                           .ReturnsAsync(true);
 
                 services.AddSingleton<IRentalOperationService>(mockService.Object);
 

--- a/MotoHub/MotoHubTests/Integration/IntegrationTests.cs
+++ b/MotoHub/MotoHubTests/Integration/IntegrationTests.cs
@@ -76,7 +76,7 @@ namespace MotoHubTests.Integration
         {
             // Arrange
             var client = _factory.CreateClient();
-            var motorcycle = new MotorcycleDTO { LicensePlate = "ABC123", Model = "Honda", Year = 2020 };
+            var motorcycle = new MotorcycleDTO { LicensePlate = $"CREATE-{Guid.NewGuid():N}", Model = "Honda", Year = 2020 };
 
             var token = GenerateJwtToken();
 
@@ -97,9 +97,14 @@ namespace MotoHubTests.Integration
         {
             // Arrange
             var client = _factory.CreateClient();
-            var licensePlate = "ABC123";
+            var licensePlate = $"GET-{Guid.NewGuid():N}";
             var token = GenerateJwtToken();
             client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+            var createResponse = await client.PostAsJsonAsync(
+                "/api/motorcycles",
+                new MotorcycleDTO { LicensePlate = licensePlate, Model = "Honda", Year = 2020 });
+            createResponse.EnsureSuccessStatusCode();
 
             // Act
             var response = await client.GetAsync($"/api/motorcycles/{licensePlate}");
@@ -174,10 +179,15 @@ namespace MotoHubTests.Integration
         {
             // Arrange
             var client = _factory.CreateClient();
-            var licensePlate = "ABC123";
+            var licensePlate = $"DELETE-{Guid.NewGuid():N}";
 
             var token = GenerateJwtToken();
             client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+            var createResponse = await client.PostAsJsonAsync(
+                "/api/motorcycles",
+                new MotorcycleDTO { LicensePlate = licensePlate, Model = "Honda", Year = 2020 });
+            createResponse.EnsureSuccessStatusCode();
 
             // Act
             var response = await client.DeleteAsync($"/api/motorcycles/{licensePlate}");

--- a/MotoHub/MotoHubTests/Integration/IntegrationTests.cs
+++ b/MotoHub/MotoHubTests/Integration/IntegrationTests.cs
@@ -93,6 +93,33 @@ namespace MotoHubTests.Integration
         }
 
         [Fact]
+        public async Task Create_IgnoresClientSuppliedRetirementMetadata()
+        {
+            using var client = _factory.CreateClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                "Bearer",
+                GenerateJwtToken());
+            var licensePlate = $"ACTIVE-{Guid.NewGuid():N}";
+            var response = await client.PostAsJsonAsync("/api/motorcycles", new MotorcycleDTO
+            {
+                LicensePlate = licensePlate,
+                Model = "Must remain active",
+                Year = 2026,
+                RetiredAtUtc = DateTime.UtcNow,
+                RetirementReason = "client-controlled"
+            });
+            response.EnsureSuccessStatusCode();
+
+            using var scope = _factory.Services.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var motorcycle = await context.Motorcycles.SingleAsync(candidate =>
+                candidate.LicensePlate == licensePlate);
+
+            Assert.Null(motorcycle.RetiredAtUtc);
+            Assert.Null(motorcycle.RetirementReason);
+        }
+
+        [Fact]
         public async Task GetByLicensePlate_ExistingPlate_ReturnsOk()
         {
             // Arrange

--- a/MotoHub/MotoHubTests/Integration/PostgreSql/MigrationTests.cs
+++ b/MotoHub/MotoHubTests/Integration/PostgreSql/MigrationTests.cs
@@ -36,7 +36,7 @@ public sealed class MigrationTests : IAsyncLifetime
         await context.SaveChangesAsync();
 
         Assert.Empty(await context.Database.GetPendingMigrationsAsync());
-        Assert.Equal(3, (await context.Database.GetAppliedMigrationsAsync()).Count());
+        Assert.Equal(4, (await context.Database.GetAppliedMigrationsAsync()).Count());
         Assert.Equal(1, await context.Motorcycles.CountAsync());
     }
 }

--- a/MotoHub/MotoHubTests/Integration/PostgreSql/MotorcycleRetirementTests.cs
+++ b/MotoHub/MotoHubTests/Integration/PostgreSql/MotorcycleRetirementTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.EntityFrameworkCore;
+using MotoHub.Data;
+using MotoHub.Models;
+using MotoHub.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace MotoHubTests.Integration.PostgreSql;
+
+public sealed class MotorcycleRetirementTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _database = new PostgreSqlBuilder("postgres:17.11-alpine3.24")
+        .WithDatabase("moto_hub_retirement")
+        .WithUsername("projecty")
+        .Build();
+
+    public Task InitializeAsync() => _database.StartAsync();
+
+    public Task DisposeAsync() => _database.DisposeAsync().AsTask();
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task RetiredMotorcycle_DisappearsFromListingButRemainsResolvable()
+    {
+        await using var context = await CreateContextAsync();
+        var motorcycle = new Motorcycle
+        {
+            LicensePlate = "RET-0001",
+            Model = "Historical model",
+            Year = 2025,
+            RegistrationDate = DateTime.UtcNow
+        };
+        context.Motorcycles.Add(motorcycle);
+        await context.SaveChangesAsync();
+        var repository = new MotorcycleRepository(context);
+
+        var retiredAtUtc = DateTime.UtcNow;
+        Assert.True(await repository.RetireAsync(
+            motorcycle.Id,
+            retiredAtUtc,
+            MotorcycleRetirementReasons.RequestedByAdministrator));
+
+        Assert.Empty(repository.GetAll());
+        var historical = await repository.GetByLicensePlateAsync(motorcycle.LicensePlate);
+        Assert.NotNull(historical);
+        Assert.Equal(retiredAtUtc, historical.RetiredAtUtc);
+        Assert.Equal(MotorcycleRetirementReasons.RequestedByAdministrator, historical.RetirementReason);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task MissingLegacyReference_IsBackfilledAsRetiredPlaceholderOnce()
+    {
+        await using var context = await CreateContextAsync();
+        var repository = new MotorcycleRepository(context);
+        var migratedAtUtc = DateTime.UtcNow;
+
+        await repository.EnsureHistoricalReferenceAsync("OLD-0001", migratedAtUtc);
+        await repository.EnsureHistoricalReferenceAsync("OLD-0001", migratedAtUtc.AddMinutes(1));
+
+        var historical = await context.Motorcycles.SingleAsync();
+        Assert.Equal("OLD-0001", historical.LicensePlate);
+        Assert.Equal(migratedAtUtc, historical.RetiredAtUtc);
+        Assert.Equal(MotorcycleRetirementReasons.LegacyOrphanBackfill, historical.RetirementReason);
+        Assert.Empty(repository.GetAll());
+    }
+
+    private async Task<ApplicationDbContext> CreateContextAsync()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(_database.GetConnectionString())
+            .Options;
+        var context = new ApplicationDbContext(options);
+        await context.Database.MigrateAsync();
+        return context;
+    }
+}

--- a/MotoHub/MotoHubTests/Unit/Services/MotorcycleServicesTests.cs
+++ b/MotoHub/MotoHubTests/Unit/Services/MotorcycleServicesTests.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using MotoHub.CrossCutting;
@@ -148,7 +149,7 @@ namespace MotoHubTests.Unit.Services
         }
 
         [Fact]
-        public void DeleteMotorcycle_ExistingMotorcycle_DeletesMotorcycle()
+        public async Task DeleteMotorcycle_ExistingMotorcycle_RetiresMotorcycle()
         {
             // Arrange
             var existingLicensePlate = "ABC123";
@@ -159,14 +160,58 @@ namespace MotoHubTests.Unit.Services
             var mockCrossCutting = new Mock<IRentalOperationService>();
             mockRepository.Setup(repo => repo.GetByLicensePlateAsync(existingLicensePlate))
                           .ReturnsAsync(existingMotorcycle);
+            mockCrossCutting.Setup(service => service.TryRetireMotorcycleAsync(existingLicensePlate))
+                .ReturnsAsync(true);
+            mockRepository.Setup(repo => repo.RetireAsync(
+                    existingMotorcycle.Id,
+                    It.IsAny<DateTime>(),
+                    MotorcycleRetirementReasons.RequestedByAdministrator))
+                .ReturnsAsync(true);
 
             var service = new MotorcycleService(mockRepository.Object, Mock.Of<IMapper>(), mockMessagingPublish.Object, mockCrossCutting.Object);
 
             // Act
-            service.DeleteMotorcycle(existingLicensePlate);
+            var result = await service.DeleteMotorcycle(existingLicensePlate);
 
             // Assert
-            mockRepository.Verify(repo => repo.Delete(existingMotorcycle.Id), Times.Once);
+            Assert.True(result.Success);
+            mockRepository.Verify(repo => repo.RetireAsync(
+                existingMotorcycle.Id,
+                It.IsAny<DateTime>(),
+                MotorcycleRetirementReasons.RequestedByAdministrator), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteMotorcycle_WhenRentalClaimWins_ReturnsConflictWithoutRetiring()
+        {
+            const string licensePlate = "BUSY-0001";
+            var motorcycle = new Motorcycle
+            {
+                Id = Guid.NewGuid().ToString(),
+                LicensePlate = licensePlate,
+                Model = "Busy",
+                Year = 2026
+            };
+            var repository = new Mock<IMotorcycleRepository>();
+            repository.Setup(candidate => candidate.GetByLicensePlateAsync(licensePlate))
+                .ReturnsAsync(motorcycle);
+            var rentalOperations = new Mock<IRentalOperationService>();
+            rentalOperations.Setup(service => service.TryRetireMotorcycleAsync(licensePlate))
+                .ReturnsAsync(false);
+            var service = new MotorcycleService(
+                repository.Object,
+                Mock.Of<IMapper>(),
+                Mock.Of<IMessagingPublisherService>(),
+                rentalOperations.Object);
+
+            var result = await service.DeleteMotorcycle(licensePlate);
+
+            Assert.False(result.Success);
+            Assert.Equal(StatusCodes.Status409Conflict, result.StatusCode);
+            repository.Verify(candidate => candidate.RetireAsync(
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<string>()), Times.Never);
         }
 
         [Fact]
@@ -234,7 +279,7 @@ namespace MotoHubTests.Unit.Services
         }
 
         [Fact]
-        public void DeleteMotorcycle_NonExistingMotorcycle_DoesNotDelete()
+        public async Task DeleteMotorcycle_NonExistingMotorcycle_DoesNotRetire()
         {
             // Arrange
             var nonExistingLicensePlate = "XYZ789";
@@ -248,10 +293,13 @@ namespace MotoHubTests.Unit.Services
             var service = new MotorcycleService(mockRepository.Object, Mock.Of<IMapper>(), mockMessagingPublish.Object, mockCrossCutting.Object);
 
             // Act
-            service.DeleteMotorcycle(nonExistingLicensePlate);
+            await service.DeleteMotorcycle(nonExistingLicensePlate);
 
             // Assert
-            mockRepository.Verify(repo => repo.Delete(It.IsAny<string>()), Times.Never);
+            mockRepository.Verify(repo => repo.RetireAsync(
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<string>()), Times.Never);
         }
     }
 }

--- a/RentalOperations/RentalOperations/Controllers/RentalController.cs
+++ b/RentalOperations/RentalOperations/Controllers/RentalController.cs
@@ -43,6 +43,15 @@ namespace RentalOperations.Controllers
                     Detail = ex.Message
                 });
             }
+            catch (MotorcycleRetiredException ex)
+            {
+                return Conflict(new ProblemDetails
+                {
+                    Status = StatusCodes.Status409Conflict,
+                    Title = "Motorcycle retired",
+                    Detail = ex.Message
+                });
+            }
             catch (Exception ex)
             {
                 return BadRequest(ex.Message);
@@ -130,6 +139,21 @@ namespace RentalOperations.Controllers
             {
                 return BadRequest($"Error checking rental status: {ex.Message}");
             }
+        }
+
+        [ServiceFilter(typeof(AuthorizationFilter))]
+        [HttpPost("motorcycle-retirements/{licencePlate}")]
+        public async Task<IActionResult> TryRetireMotorcycle(string licencePlate)
+        {
+            var acquired = await _rentalService.TryRetireMotorcycleAsync(licencePlate);
+            return acquired
+                ? NoContent()
+                : Conflict(new ProblemDetails
+                {
+                    Status = StatusCodes.Status409Conflict,
+                    Title = "Active rental conflict",
+                    Detail = $"Motorcycle {licencePlate} has an active rental."
+                });
         }
     }
 }

--- a/RentalOperations/RentalOperations/Controllers/RentalController.cs
+++ b/RentalOperations/RentalOperations/Controllers/RentalController.cs
@@ -141,7 +141,7 @@ namespace RentalOperations.Controllers
             }
         }
 
-        [ServiceFilter(typeof(AuthorizationFilter))]
+        [ServiceFilter(typeof(AdminAuthorizationFilter))]
         [HttpPost("motorcycle-retirements/{licencePlate}")]
         public async Task<IActionResult> TryRetireMotorcycle(string licencePlate)
         {

--- a/RentalOperations/RentalOperations/CrossCutting/Model/Motorcycle.cs
+++ b/RentalOperations/RentalOperations/CrossCutting/Model/Motorcycle.cs
@@ -5,5 +5,7 @@
         public int year { get; set; }
         public string model { get; set; } = string.Empty;
         public string licensePlate { get; set; } = string.Empty;
+        public DateTime? retiredAtUtc { get; set; }
+        public string? retirementReason { get; set; }
     }
 }

--- a/RentalOperations/RentalOperations/CrossCutting/Services/IMotorcycleService.cs
+++ b/RentalOperations/RentalOperations/CrossCutting/Services/IMotorcycleService.cs
@@ -5,5 +5,6 @@ namespace RentalOperations.CrossCutting.Services
     public interface IMotorcycleService
     {
         Task<Motorcycle> GetMotorcycleByIdAsync(string motorcycleId);
+        Task EnsureHistoricalReferencesAsync(IEnumerable<string> licensePlates);
     }
 }

--- a/RentalOperations/RentalOperations/CrossCutting/Services/MotorcycleService.cs
+++ b/RentalOperations/RentalOperations/CrossCutting/Services/MotorcycleService.cs
@@ -37,5 +37,18 @@ namespace RentalOperations.CrossCutting.Services
                 throw new Exception($"Unable to obtain motorcycle data: {e.Message}", e);
             }
         }
+
+        public async Task EnsureHistoricalReferencesAsync(IEnumerable<string> licensePlates)
+        {
+            var response = await _httpClient.PostAsJsonAsync(
+                "api/Motorcycles/historical-references",
+                new { LicensePlates = licensePlates });
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorContent = await response.Content.ReadAsStringAsync();
+                throw new HttpRequestException(
+                    $"Historical motorcycle reconciliation failed with status {response.StatusCode}: {errorContent}");
+            }
+        }
     }
 }

--- a/RentalOperations/RentalOperations/Data/MongoRentalIndexInitializer.cs
+++ b/RentalOperations/RentalOperations/Data/MongoRentalIndexInitializer.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Hosting;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using RentalOperations.CrossCutting.Services;
 using RentalOperations.Model;
 
 namespace RentalOperations.Data;
@@ -10,12 +11,16 @@ public sealed class MongoRentalIndexInitializer : IHostedService
     public const string ActiveRentalIndexName = "ux_rentals_one_active_per_motorcycle";
     public const string LegacyDuplicateQuarantineMessage =
         "Quarantined during active-rental index migration: duplicate open rental; review required.";
+    public const string RetiredMotorcycleQuarantineMessage =
+        "Quarantined during motorcycle-reference migration: motorcycle was already retired.";
 
     private readonly MongoDbContext _context;
+    private readonly IServiceScopeFactory _scopeFactory;
 
-    public MongoRentalIndexInitializer(MongoDbContext context)
+    public MongoRentalIndexInitializer(MongoDbContext context, IServiceScopeFactory scopeFactory)
     {
         _context = context;
+        _scopeFactory = scopeFactory;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -36,6 +41,8 @@ public sealed class MongoRentalIndexInitializer : IHostedService
             });
 
         await rentals.Indexes.CreateOneAsync(index, cancellationToken: cancellationToken);
+        await ReconcileMotorcycleClaimsAsync(cancellationToken);
+        await EnsureHistoricalMotorcycleReferencesAsync(cancellationToken);
     }
 
     private async Task ClassifyLegacyRentalsAsync(CancellationToken cancellationToken)
@@ -94,6 +101,118 @@ public sealed class MongoRentalIndexInitializer : IHostedService
 
             await rentals.UpdateManyAsync(filter, update, cancellationToken: cancellationToken);
         }
+    }
+
+    private async Task ReconcileMotorcycleClaimsAsync(CancellationToken cancellationToken)
+    {
+        var rentals = _context.Database.GetCollection<Rental>("Rentals");
+        var claims = _context.Database.GetCollection<MotorcycleClaim>("MotorcycleClaims");
+        await RemoveStaleRentalClaimsAsync(rentals, claims, cancellationToken);
+        var activeRentals = await rentals
+            .Find(rental => rental.Status == RentalStatus.Active)
+            .ToListAsync(cancellationToken);
+
+        foreach (var rental in activeRentals)
+        {
+            var rentalId = rental._id!.Value.ToString();
+            try
+            {
+                await claims.InsertOneAsync(new MotorcycleClaim
+                {
+                    MotorcycleLicencePlate = rental.MotorcycleLicencePlate,
+                    Kind = MotorcycleClaimKind.ActiveRental,
+                    RentalId = rentalId,
+                    CreatedAtUtc = DateTime.UtcNow
+                }, cancellationToken: cancellationToken);
+            }
+            catch (MongoWriteException exception)
+                when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+            {
+                var existing = await claims
+                    .Find(claim => claim.MotorcycleLicencePlate == rental.MotorcycleLicencePlate)
+                    .FirstOrDefaultAsync(cancellationToken);
+                if (existing?.Kind == MotorcycleClaimKind.Retired)
+                {
+                    await rentals.UpdateOneAsync(
+                        candidate => candidate._id == rental._id &&
+                                     candidate.Status == RentalStatus.Active,
+                        Builders<Rental>.Update
+                            .Set(candidate => candidate.Status, RentalStatus.Quarantined)
+                            .Set(candidate => candidate.StatusMessage, RetiredMotorcycleQuarantineMessage),
+                        cancellationToken: cancellationToken);
+                }
+                else if (existing?.Kind == MotorcycleClaimKind.ActiveRental &&
+                         existing.RentalId != rentalId)
+                {
+                    var claimedRentalIsActive = ObjectId.TryParse(existing.RentalId, out var claimedRentalId) &&
+                        await rentals.Find(candidate =>
+                                candidate._id == claimedRentalId &&
+                                candidate.Status == RentalStatus.Active)
+                            .AnyAsync(cancellationToken);
+                    if (!claimedRentalIsActive)
+                    {
+                        await claims.ReplaceOneAsync(
+                            claim => claim.MotorcycleLicencePlate == rental.MotorcycleLicencePlate &&
+                                     claim.Kind == MotorcycleClaimKind.ActiveRental &&
+                                     claim.RentalId == existing.RentalId,
+                            new MotorcycleClaim
+                            {
+                                MotorcycleLicencePlate = rental.MotorcycleLicencePlate,
+                                Kind = MotorcycleClaimKind.ActiveRental,
+                                RentalId = rentalId,
+                                CreatedAtUtc = DateTime.UtcNow
+                            },
+                            cancellationToken: cancellationToken);
+                    }
+                }
+            }
+        }
+    }
+
+    private static async Task RemoveStaleRentalClaimsAsync(
+        IMongoCollection<Rental> rentals,
+        IMongoCollection<MotorcycleClaim> claims,
+        CancellationToken cancellationToken)
+    {
+        var staleBeforeUtc = DateTime.UtcNow.AddMinutes(-5);
+        var staleCandidates = await claims.Find(claim =>
+                claim.Kind == MotorcycleClaimKind.ActiveRental &&
+                claim.CreatedAtUtc < staleBeforeUtc)
+            .ToListAsync(cancellationToken);
+
+        foreach (var claim in staleCandidates)
+        {
+            var hasActiveRental = ObjectId.TryParse(claim.RentalId, out var rentalId) &&
+                await rentals.Find(rental =>
+                        rental._id == rentalId &&
+                        rental.Status == RentalStatus.Active)
+                    .AnyAsync(cancellationToken);
+            if (!hasActiveRental)
+            {
+                await claims.DeleteOneAsync(candidate =>
+                    candidate.MotorcycleLicencePlate == claim.MotorcycleLicencePlate &&
+                    candidate.Kind == MotorcycleClaimKind.ActiveRental &&
+                    candidate.RentalId == claim.RentalId &&
+                    candidate.CreatedAtUtc == claim.CreatedAtUtc,
+                    cancellationToken);
+            }
+        }
+    }
+
+    private async Task EnsureHistoricalMotorcycleReferencesAsync(CancellationToken cancellationToken)
+    {
+        var rentals = _context.Database.GetCollection<Rental>("Rentals");
+        var licensePlates = await rentals
+            .Distinct<string>("MotorcycleLicencePlate", FilterDefinition<Rental>.Empty)
+            .ToListAsync(cancellationToken);
+        if (licensePlates.Count == 0)
+        {
+            return;
+        }
+
+        using var scope = _scopeFactory.CreateScope();
+        var motorcycleService = scope.ServiceProvider.GetRequiredService<IMotorcycleService>();
+        await motorcycleService.EnsureHistoricalReferencesAsync(licensePlates);
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/RentalOperations/RentalOperations/Domain/MotorcycleClaimResult.cs
+++ b/RentalOperations/RentalOperations/Domain/MotorcycleClaimResult.cs
@@ -1,0 +1,8 @@
+namespace RentalOperations.Domain;
+
+public enum MotorcycleClaimResult
+{
+    Acquired,
+    ActiveRental,
+    Retired
+}

--- a/RentalOperations/RentalOperations/Domain/MotorcycleRetiredException.cs
+++ b/RentalOperations/RentalOperations/Domain/MotorcycleRetiredException.cs
@@ -1,0 +1,9 @@
+namespace RentalOperations.Domain;
+
+public sealed class MotorcycleRetiredException : InvalidOperationException
+{
+    public MotorcycleRetiredException(string licencePlate)
+        : base($"Motorcycle {licencePlate} is retired and cannot be rented.")
+    {
+    }
+}

--- a/RentalOperations/RentalOperations/Model/MotorcycleClaim.cs
+++ b/RentalOperations/RentalOperations/Model/MotorcycleClaim.cs
@@ -1,0 +1,26 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace RentalOperations.Model;
+
+public sealed class MotorcycleClaim
+{
+    [BsonId]
+    public required string MotorcycleLicencePlate { get; init; }
+
+    [BsonElement("kind")]
+    [BsonRepresentation(MongoDB.Bson.BsonType.String)]
+    public MotorcycleClaimKind Kind { get; init; }
+
+    [BsonElement("rentalId")]
+    [BsonIgnoreIfNull]
+    public string? RentalId { get; init; }
+
+    [BsonElement("createdAtUtc")]
+    public DateTime CreatedAtUtc { get; init; }
+}
+
+public enum MotorcycleClaimKind
+{
+    ActiveRental,
+    Retired
+}

--- a/RentalOperations/RentalOperations/Repository/IRentalRepository.cs
+++ b/RentalOperations/RentalOperations/Repository/IRentalRepository.cs
@@ -1,4 +1,5 @@
-﻿using RentalOperations.Model;
+using RentalOperations.Domain;
+using RentalOperations.Model;
 
 namespace RentalOperations.Repository
 {
@@ -11,6 +12,9 @@ namespace RentalOperations.Repository
         Task<bool> IsMotorcycleCurrentlyRentedAsync(string licencePlate);
         Task UpdateRentalAsync(Rental rental);
         Task UpdateLicensePlateForAllRentalsAsync(string oldLicensePlate, string newLicensePlate);
+        Task<MotorcycleClaimResult> TryClaimRentalAsync(string licencePlate, string rentalId);
+        Task<MotorcycleClaimResult> TryClaimRetirementAsync(string licencePlate);
+        Task ReleaseRentalClaimAsync(string licencePlate, string rentalId);
         Task DeleteRentalAsync(string id);
     }
 }

--- a/RentalOperations/RentalOperations/Repository/RentalRepository.cs
+++ b/RentalOperations/RentalOperations/Repository/RentalRepository.cs
@@ -9,10 +9,12 @@ namespace RentalOperations.Repository
     public class RentalRepository : IRentalRepository
     {
         private readonly IMongoCollection<Rental> _rentals;
+        private readonly IMongoCollection<MotorcycleClaim> _motorcycleClaims;
 
         public RentalRepository(MongoDbContext context)
         {
             _rentals = context.Database.GetCollection<Rental>("Rentals");
+            _motorcycleClaims = context.Database.GetCollection<MotorcycleClaim>("MotorcycleClaims");
         }
 
         public async Task<Rental> CreateRentalAsync(Rental rental)
@@ -70,12 +72,89 @@ namespace RentalOperations.Repository
 
         public async Task UpdateLicensePlateForAllRentalsAsync(string oldLicensePlate, string newLicensePlate)
         {
+            var activeClaim = await _motorcycleClaims
+                .Find(claim => claim.MotorcycleLicencePlate == oldLicensePlate &&
+                               claim.Kind == MotorcycleClaimKind.ActiveRental)
+                .FirstOrDefaultAsync();
+            if (activeClaim is not null)
+            {
+                var claimResult = await TryClaimRentalAsync(newLicensePlate, activeClaim.RentalId!);
+                if (claimResult != MotorcycleClaimResult.Acquired)
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot move the active rental claim to licence plate {newLicensePlate}.");
+                }
+            }
+
             var filter = Builders<Rental>.Filter.Eq(r => r.MotorcycleLicencePlate, oldLicensePlate);
             var update = Builders<Rental>.Update.Set(r => r.MotorcycleLicencePlate, newLicensePlate);
 
             var updateResult = await _rentals.UpdateManyAsync(filter, update);
+            if (activeClaim is not null)
+            {
+                await ReleaseRentalClaimAsync(oldLicensePlate, activeClaim.RentalId!);
+            }
 
             Console.WriteLine($"{updateResult.ModifiedCount} rentals updated.");
+        }
+
+        public Task<MotorcycleClaimResult> TryClaimRentalAsync(string licencePlate, string rentalId) =>
+            TryAcquireClaimAsync(new MotorcycleClaim
+            {
+                MotorcycleLicencePlate = licencePlate,
+                Kind = MotorcycleClaimKind.ActiveRental,
+                RentalId = rentalId,
+                CreatedAtUtc = DateTime.UtcNow
+            });
+
+        public Task<MotorcycleClaimResult> TryClaimRetirementAsync(string licencePlate) =>
+            TryAcquireClaimAsync(new MotorcycleClaim
+            {
+                MotorcycleLicencePlate = licencePlate,
+                Kind = MotorcycleClaimKind.Retired,
+                CreatedAtUtc = DateTime.UtcNow
+            });
+
+        public async Task ReleaseRentalClaimAsync(string licencePlate, string rentalId)
+        {
+            await _motorcycleClaims.DeleteOneAsync(claim =>
+                claim.MotorcycleLicencePlate == licencePlate &&
+                claim.Kind == MotorcycleClaimKind.ActiveRental &&
+                claim.RentalId == rentalId);
+        }
+
+        private async Task<MotorcycleClaimResult> TryAcquireClaimAsync(MotorcycleClaim claim)
+        {
+            for (var attempt = 0; attempt < 3; attempt++)
+            {
+                try
+                {
+                    await _motorcycleClaims.InsertOneAsync(claim);
+                    return MotorcycleClaimResult.Acquired;
+                }
+                catch (MongoWriteException exception)
+                    when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+                {
+                    var existing = await _motorcycleClaims
+                        .Find(candidate => candidate.MotorcycleLicencePlate == claim.MotorcycleLicencePlate)
+                        .FirstOrDefaultAsync();
+
+                    if (existing?.Kind == MotorcycleClaimKind.Retired)
+                    {
+                        return MotorcycleClaimResult.Retired;
+                    }
+
+                    if (existing?.Kind == MotorcycleClaimKind.ActiveRental)
+                    {
+                        return existing.RentalId == claim.RentalId
+                            ? MotorcycleClaimResult.Acquired
+                            : MotorcycleClaimResult.ActiveRental;
+                    }
+                }
+            }
+
+            throw new InvalidOperationException(
+                $"Motorcycle claim for {claim.MotorcycleLicencePlate} changed too quickly to resolve.");
         }
     }
 }

--- a/RentalOperations/RentalOperations/Services/IRentalService.cs
+++ b/RentalOperations/RentalOperations/Services/IRentalService.cs
@@ -10,6 +10,7 @@ namespace RentalOperations.Services
         Task<List<ResponseRentalDTO>> GetRentalsByUserIdAsync(string userId);
         Task UpdateMotorcycleLicensePlateAsync(string oldLicensePlate, string newLicensePlate);
         Task<bool> IsMotorcycleCurrentlyRentedAsync(string licencePlate);
+        Task<bool> TryRetireMotorcycleAsync(string licencePlate);
     }
 }
 

--- a/RentalOperations/RentalOperations/Services/RentalService.cs
+++ b/RentalOperations/RentalOperations/Services/RentalService.cs
@@ -58,6 +58,10 @@ namespace RentalOperations.Services
             {
                 throw new ArgumentException("Motorcycle does not exist.");
             }
+            if (motorcycle.retiredAtUtc is not null)
+            {
+                throw new MotorcycleRetiredException(createDto.MotocycleLicencePlate);
+            }
 
             var rentalDomain = RentalDomain.Create(createDto, userId);
             var rental = new Rental
@@ -70,6 +74,22 @@ namespace RentalOperations.Services
                 InitCost = rentalDomain.TotalCost
             };
 
+            var rentalId = rental._id!.Value.ToString();
+            var claimResult = await _repository.TryClaimRentalAsync(
+                rental.MotorcycleLicencePlate,
+                rentalId);
+            if (claimResult == MotorcycleClaimResult.Retired)
+            {
+                throw new MotorcycleRetiredException(rental.MotorcycleLicencePlate);
+            }
+            if (claimResult == MotorcycleClaimResult.ActiveRental)
+            {
+                throw new ActiveRentalConflictException(rental.MotorcycleLicencePlate);
+            }
+
+            // The claim is deliberately retained if MongoDB reports an ambiguous
+            // insert failure. Startup reconciliation can repair a stale claim; releasing
+            // it here could let retirement win after the rental was actually committed.
             await _repository.CreateRentalAsync(rental);
         }
 
@@ -84,7 +104,12 @@ namespace RentalOperations.Services
                 throw new UnauthorizedAccessException("The rental belongs to another rider.");
 
             if (rental.Status == RentalStatus.Completed)
+            {
+                await _repository.ReleaseRentalClaimAsync(
+                    rental.MotorcycleLicencePlate,
+                    rental._id!.Value.ToString());
                 return _mapper.Map<ResponseRentalDTO>(rental);
+            }
 
             var response = _mapper.Map<ResponseRentalDTO>(rental);
             response.ActualEndDate = actualEndDate;
@@ -118,6 +143,9 @@ namespace RentalOperations.Services
             rental.StatusMessage = response.StatusMessage;
             rental.Status = RentalStatus.Completed;
             await _repository.UpdateRentalAsync(rental);
+            await _repository.ReleaseRentalClaimAsync(
+                rental.MotorcycleLicencePlate,
+                rental._id!.Value.ToString());
             return response;
         }
 
@@ -136,6 +164,12 @@ namespace RentalOperations.Services
         public async Task<bool> IsMotorcycleCurrentlyRentedAsync(string licencePlate)
         {
             return await _repository.IsMotorcycleCurrentlyRentedAsync(licencePlate);
+        }
+
+        public async Task<bool> TryRetireMotorcycleAsync(string licencePlate)
+        {
+            var result = await _repository.TryClaimRetirementAsync(licencePlate);
+            return result is MotorcycleClaimResult.Acquired or MotorcycleClaimResult.Retired;
         }
 
         private decimal DetermineDailyRate(int days)

--- a/RentalOperations/RentalOperationsTests/Integration/InMemoryRentalRepository.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/InMemoryRentalRepository.cs
@@ -1,4 +1,5 @@
 using MongoDB.Bson;
+using RentalOperations.Domain;
 using RentalOperations.Model;
 using RentalOperations.Repository;
 using System.Collections.Concurrent;
@@ -8,6 +9,7 @@ namespace RentalOperationsTests.Integration;
 public sealed class InMemoryRentalRepository : IRentalRepository
 {
     private readonly ConcurrentDictionary<ObjectId, Rental> _rentals = new();
+    private readonly ConcurrentDictionary<string, (MotorcycleClaimKind Kind, string? RentalId)> _claims = new();
 
     public InMemoryRentalRepository()
     {
@@ -91,6 +93,42 @@ public sealed class InMemoryRentalRepository : IRentalRepository
     public Task DeleteRentalAsync(string id)
     {
         _rentals.TryRemove(ObjectId.Parse(id), out _);
+        return Task.CompletedTask;
+    }
+
+    public Task<MotorcycleClaimResult> TryClaimRentalAsync(string licencePlate, string rentalId)
+    {
+        if (_claims.TryAdd(licencePlate, (MotorcycleClaimKind.ActiveRental, rentalId)))
+        {
+            return Task.FromResult(MotorcycleClaimResult.Acquired);
+        }
+
+        var existing = _claims[licencePlate];
+        return Task.FromResult(existing.Kind == MotorcycleClaimKind.Retired
+            ? MotorcycleClaimResult.Retired
+            : existing.RentalId == rentalId
+                ? MotorcycleClaimResult.Acquired
+                : MotorcycleClaimResult.ActiveRental);
+    }
+
+    public Task<MotorcycleClaimResult> TryClaimRetirementAsync(string licencePlate)
+    {
+        if (_claims.TryAdd(licencePlate, (MotorcycleClaimKind.Retired, null)))
+        {
+            return Task.FromResult(MotorcycleClaimResult.Acquired);
+        }
+
+        return Task.FromResult(_claims[licencePlate].Kind == MotorcycleClaimKind.Retired
+            ? MotorcycleClaimResult.Retired
+            : MotorcycleClaimResult.ActiveRental);
+    }
+
+    public Task ReleaseRentalClaimAsync(string licencePlate, string rentalId)
+    {
+        _claims.TryRemove(
+            new KeyValuePair<string, (MotorcycleClaimKind Kind, string? RentalId)>(
+                licencePlate,
+                (MotorcycleClaimKind.ActiveRental, rentalId)));
         return Task.CompletedTask;
     }
 

--- a/RentalOperations/RentalOperationsTests/Integration/MongoDb/ActiveRentalApiTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/MongoDb/ActiveRentalApiTests.cs
@@ -124,6 +124,7 @@ public sealed class ActiveRentalApiTests : IAsyncLifetime
         Assert.Equal(1, await rentals.CountDocumentsAsync(
             rental => rental.MotorcycleLicencePlate == request.MotocycleLicencePlate &&
                       rental.Status == RentalStatus.Active));
+        Assert.Contains("LEGACY-0001", _factory!.MotorcycleService.HistoricalReferences);
     }
 
     private HttpClient CreateAuthenticatedClient()
@@ -175,6 +176,7 @@ internal sealed class MongoRentalApiFactory : WebApplicationFactory<Program>
     public const string JwtKey = "test-only-key-with-at-least-32-bytes";
     private readonly string _connectionString;
     private readonly string _databaseName;
+    public StubMotorcycleService MotorcycleService { get; } = new();
 
     public MongoRentalApiFactory(string connectionString, string databaseName)
     {
@@ -211,7 +213,7 @@ internal sealed class MongoRentalApiFactory : WebApplicationFactory<Program>
                 provider.GetRequiredService<RentalRepository>(),
                 provider.GetRequiredService<ConcurrentCreateGate>()));
             services.AddSingleton<IRiderManagerService, StubRiderManagerService>();
-            services.AddSingleton<IMotorcycleService, StubMotorcycleService>();
+            services.AddSingleton<IMotorcycleService>(MotorcycleService);
             services.AddHostedService<MongoRentalIndexInitializer>();
 
             services.PostConfigure<JwtBearerOptions>(
@@ -261,7 +263,6 @@ internal sealed class SynchronizingRentalRepository : IRentalRepository
 
     public async Task<Rental> CreateRentalAsync(Rental rental)
     {
-        await _gate.WaitAsync();
         return await _repository.CreateRentalAsync(rental);
     }
 
@@ -282,6 +283,24 @@ internal sealed class SynchronizingRentalRepository : IRentalRepository
         _repository.UpdateLicensePlateForAllRentalsAsync(oldLicensePlate, newLicensePlate);
 
     public Task DeleteRentalAsync(string id) => _repository.DeleteRentalAsync(id);
+
+    public Task<RentalOperations.Domain.MotorcycleClaimResult> TryClaimRentalAsync(
+        string licencePlate,
+        string rentalId) => TryClaimRentalAfterGateAsync(licencePlate, rentalId);
+
+    private async Task<RentalOperations.Domain.MotorcycleClaimResult> TryClaimRentalAfterGateAsync(
+        string licencePlate,
+        string rentalId)
+    {
+        await _gate.WaitAsync();
+        return await _repository.TryClaimRentalAsync(licencePlate, rentalId);
+    }
+
+    public Task<RentalOperations.Domain.MotorcycleClaimResult> TryClaimRetirementAsync(
+        string licencePlate) => _repository.TryClaimRetirementAsync(licencePlate);
+
+    public Task ReleaseRentalClaimAsync(string licencePlate, string rentalId) =>
+        _repository.ReleaseRentalClaimAsync(licencePlate, rentalId);
 }
 
 internal sealed class StubRiderManagerService : IRiderManagerService
@@ -296,10 +315,22 @@ internal sealed class StubRiderManagerService : IRiderManagerService
 
 internal sealed class StubMotorcycleService : IMotorcycleService
 {
+    public System.Collections.Concurrent.ConcurrentBag<string> HistoricalReferences { get; } = new();
+
     public Task<Motorcycle> GetMotorcycleByIdAsync(string motorcycleId) => Task.FromResult(new Motorcycle
     {
         licensePlate = motorcycleId,
         model = "Concurrency test",
         year = 2026
     });
+
+    public Task EnsureHistoricalReferencesAsync(IEnumerable<string> licensePlates)
+    {
+        foreach (var licensePlate in licensePlates)
+        {
+            HistoricalReferences.Add(licensePlate);
+        }
+
+        return Task.CompletedTask;
+    }
 }

--- a/RentalOperations/RentalOperationsTests/Integration/MongoDb/ActiveRentalApiTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/MongoDb/ActiveRentalApiTests.cs
@@ -127,6 +127,23 @@ public sealed class ActiveRentalApiTests : IAsyncLifetime
         Assert.Contains("LEGACY-0001", _factory!.MotorcycleService.HistoricalReferences);
     }
 
+    [Fact]
+    public async Task RiderCannotCreatePermanentMotorcycleRetirementClaim()
+    {
+        using var client = CreateAuthenticatedClient();
+
+        var response = await client.PostAsync(
+            "/api/Rental/motorcycle-retirements/ADMIN-ONLY-0001",
+            content: null);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        var claims = new MongoClient(_database.GetConnectionString())
+            .GetDatabase(DatabaseName)
+            .GetCollection<MotorcycleClaim>("MotorcycleClaims");
+        Assert.Equal(0, await claims.CountDocumentsAsync(claim =>
+            claim.MotorcycleLicencePlate == "ADMIN-ONLY-0001"));
+    }
+
     private HttpClient CreateAuthenticatedClient()
     {
         var factory = _factory ?? throw new InvalidOperationException("The test database has not started.");

--- a/RentalOperations/RentalOperationsTests/Integration/MongoDb/MotorcycleClaimConcurrencyTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/MongoDb/MotorcycleClaimConcurrencyTests.cs
@@ -1,0 +1,49 @@
+using MongoDB.Driver;
+using RentalOperations.Data;
+using RentalOperations.Domain;
+using RentalOperations.Model;
+using RentalOperations.Repository;
+using Testcontainers.MongoDb;
+
+namespace RentalOperationsTests.Integration.MongoDb;
+
+public sealed class MotorcycleClaimConcurrencyTests : IAsyncLifetime
+{
+    private const string DatabaseName = "motorcycle_claim_race_tests";
+    private readonly MongoDbContainer _database = new MongoDbBuilder("mongo:8.0").Build();
+
+    public Task InitializeAsync() => _database.StartAsync();
+
+    public Task DisposeAsync() => _database.DisposeAsync().AsTask();
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ConcurrentRentalAndRetirement_ExactlyOneClaimWinsCleanly()
+    {
+        var context = new MongoDbContext(_database.GetConnectionString(), DatabaseName);
+        var repository = new RentalRepository(context);
+        const string licensePlate = "RACE-RET-0001";
+        var rentalId = MongoDB.Bson.ObjectId.GenerateNewId().ToString();
+        using var ready = new CountdownEvent(2);
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        async Task<MotorcycleClaimResult> CompeteAsync(Func<Task<MotorcycleClaimResult>> attempt)
+        {
+            ready.Signal();
+            await start.Task;
+            return await attempt();
+        }
+
+        var rentalAttempt = CompeteAsync(() => repository.TryClaimRentalAsync(licensePlate, rentalId));
+        var retirementAttempt = CompeteAsync(() => repository.TryClaimRetirementAsync(licensePlate));
+        Assert.True(ready.Wait(TimeSpan.FromSeconds(10)));
+        start.SetResult();
+
+        var results = await Task.WhenAll(rentalAttempt, retirementAttempt);
+
+        Assert.Single(results, result => result == MotorcycleClaimResult.Acquired);
+        Assert.Single(results, result => result is MotorcycleClaimResult.ActiveRental or MotorcycleClaimResult.Retired);
+        var claims = context.Database.GetCollection<MotorcycleClaim>("MotorcycleClaims");
+        Assert.Equal(1, await claims.CountDocumentsAsync(FilterDefinition<MotorcycleClaim>.Empty));
+    }
+}

--- a/RentalOperations/RentalOperationsTests/RentalOperationsTests.csproj
+++ b/RentalOperations/RentalOperationsTests/RentalOperationsTests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Npgsql" Version="10.0.3" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.14.0" />
     <PackageReference Include="Testcontainers.MongoDb" Version="4.14.0" />

--- a/RentalOperations/RentalOperationsTests/Unit/Services/RentalServiceTests.cs
+++ b/RentalOperations/RentalOperationsTests/Unit/Services/RentalServiceTests.cs
@@ -1,0 +1,69 @@
+using AutoMapper;
+using Moq;
+using RentalOperations.CrossCutting.Model;
+using RentalOperations.CrossCutting.Services;
+using RentalOperations.Domain;
+using RentalOperations.DTOs;
+using RentalOperations.Repository;
+using RentalOperations.Services;
+
+namespace RentalOperationsTests.Unit.Services;
+
+public sealed class RentalServiceTests
+{
+    [Fact]
+    public async Task CreateRental_WhenRetirementClaimWins_RejectsWithoutInsertingRental()
+    {
+        var repository = new Mock<IRentalRepository>();
+        repository.Setup(candidate => candidate.GetRentalsByMotorcycleIdAsync("RET-0001"))
+            .ReturnsAsync([]);
+        repository.Setup(candidate => candidate.TryClaimRentalAsync("RET-0001", It.IsAny<string>()))
+            .ReturnsAsync(MotorcycleClaimResult.Retired);
+        var riders = new Mock<IRiderManagerService>();
+        riders.Setup(service => service.GetRiderByIdAsync("rider-1"))
+            .ReturnsAsync(new Rider
+            {
+                Id = "rider-1",
+                UserId = "rider-1",
+                CNHType = "A"
+            });
+        var motorcycles = new Mock<IMotorcycleService>();
+        motorcycles.Setup(service => service.GetMotorcycleByIdAsync("RET-0001"))
+            .ReturnsAsync(new Motorcycle
+            {
+                licensePlate = "RET-0001",
+                model = "Retirement race",
+                year = 2026
+            });
+        var service = new RentalService(
+            repository.Object,
+            Mock.Of<IMapper>(),
+            riders.Object,
+            motorcycles.Object);
+        var request = new RentalCreateDto
+        {
+            MotocycleLicencePlate = "RET-0001",
+            StartDate = DateTime.UtcNow.Date.AddDays(1),
+            PredictedEndDate = DateTime.UtcNow.Date.AddDays(8)
+        };
+
+        await Assert.ThrowsAsync<MotorcycleRetiredException>(() =>
+            service.CreateRentalAsync(request, "rider-1"));
+        repository.Verify(candidate => candidate.CreateRentalAsync(It.IsAny<RentalOperations.Model.Rental>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryRetireMotorcycle_WhenActiveRentalClaimExists_ReturnsFalse()
+    {
+        var repository = new Mock<IRentalRepository>();
+        repository.Setup(candidate => candidate.TryClaimRetirementAsync("BUSY-0001"))
+            .ReturnsAsync(MotorcycleClaimResult.ActiveRental);
+        var service = new RentalService(
+            repository.Object,
+            Mock.Of<IMapper>(),
+            Mock.Of<IRiderManagerService>(),
+            Mock.Of<IMotorcycleService>());
+
+        Assert.False(await service.TryRetireMotorcycleAsync("BUSY-0001"));
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -328,6 +328,8 @@ services:
     depends_on:
       mongodb:
         condition: service_healthy
+      moto-hub:
+        condition: service_healthy
       rabbitmq:
         condition: service_healthy
       redis:

--- a/docs/adr/0010-motorcycle-retirement-protocol.md
+++ b/docs/adr/0010-motorcycle-retirement-protocol.md
@@ -1,0 +1,64 @@
+# ADR 0010 — Motorcycle retirement is serialized with rental claims
+
+- **Status:** Accepted
+- **Date:** 2026-09-01
+- **Deciders:** ProjectY maintainers
+
+## Context
+
+MotoHub and RentalOperations use different databases, so checking for a rental
+and then deleting a motorcycle cannot be one local transaction. A rental could
+previously be inserted between the check and the physical delete, leaving a
+plate that no longer resolved in MotoHub.
+
+## Decision
+
+RentalOperations is the serialization authority for a motorcycle's rentable
+state. The `MotorcycleClaims` MongoDB collection has one document per licence
+plate. Rental creation atomically inserts an `ActiveRental` claim; retirement
+atomically inserts a `Retired` claim. MongoDB's unique `_id` constraint means
+only one can win. The losing operation returns `409 Conflict`.
+
+After acquiring a retirement claim, MotoHub sets `RetiredAtUtc` and
+`RetirementReason` instead of deleting the row. Retired motorcycles are omitted
+from the collection endpoint but remain available by plate for historical
+rentals. A retirement claim is intentionally retained when the MotoHub write
+has an ambiguous failure: a retry can finish the soft delete, while releasing
+the claim could admit a rental after retirement had committed.
+
+On upgrade, the Mongo initializer creates claims for active legacy rentals. It
+removes rental claims older than five minutes only after confirming that their
+owned rental is absent or no longer active. This repairs ambiguous failed
+inserts without deleting a live rental's protection. It
+also sends every historical rental plate to MotoHub. A plate whose physical
+motorcycle row was already deleted is recreated once as a retired placeholder
+with reason `LegacyOrphanBackfill`; unavailable metadata is recorded as such.
+This deliberately preserves referential resolution instead of inventing the
+lost model and year. RentalOperations does not become ready if a non-empty
+backfill cannot reach MotoHub.
+
+## Consequences
+
+- A concurrent rental and retirement have one MongoDB arbitration point.
+- Completing a rental removes only the claim owned by that rental.
+- Licence plates are never reused after retirement, preserving historical
+  identity.
+- A failed retirement can temporarily fail closed until the delete is retried.
+- Startup reconciliation is a cross-service data migration, so Compose starts
+  MotoHub before RentalOperations.
+
+## Alternatives considered
+
+- **Check MotoHub before inserting a rental.** This remains a stale read and
+  cannot close the cross-database race.
+- **MongoDB multi-document transactions.** The supported standalone MongoDB
+  deployment does not provide a replica-set transaction boundary.
+- **Release the retirement claim on every MotoHub error.** A timeout can hide a
+  committed soft delete, so releasing would re-open the orphan race.
+- **Drop legacy orphan rentals.** Financial and rider history is more valuable
+  than incomplete motorcycle metadata, so a marked placeholder is retained.
+
+## Traceability
+
+- [Issue #97 — M12 soft-delete motorcycles](https://github.com/iVega123/ProjectY/issues/97)
+- Audit finding M12.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ is what separates a decision from a preference.
 | [0007](0007-authenticated-queue-boundary.md) | Authenticate domain-writing queue messages | How finding C5 was closed |
 | [0008](0008-single-trust-boundary.md) | One trust boundary, at the edge | Why domain services stop parsing tokens, and what is traded for it |
 | [0009](0009-exactly-once-effect.md) | Exactly-once effect is layered and bounded | Which layer provides each guarantee, how it fails, and what is deliberately not promised |
+| [0010](0010-motorcycle-retirement-protocol.md) | Serialize motorcycle retirement with rental claims | How retirement races rentals and how legacy orphan plates remain resolvable |
 
 ## Reading order
 
@@ -30,6 +31,7 @@ Records 0006 and 0007 are remediation decisions taken while closing individual
 findings, and read on their own. Numbers are never reused or reassigned.
 ADR 0009 is the executable consistency contract and refines the shorter
 outbox/inbox statement in ADR 0003.
+ADR 0010 applies that contract to the cross-database motorcycle-retirement race.
 
 The full findings list, with remediation status and the commit that closed each
 one, lives in


### PR DESCRIPTION
Closes #97

## What changed

- replaces physical motorcycle deletion with `RetiredAtUtc` and an auditable retirement reason
- hides retired motorcycles from listings while keeping lookup-by-plate available to historical rentals
- serializes rental creation and retirement through one atomic MongoDB `MotorcycleClaims` document per plate
- retains retirement claims on ambiguous MotoHub failures so retries fail closed instead of reopening the race
- backfills active-rental claims and recreates already-deleted historical plates as retired placeholders
- records the protocol and rejected alternatives in ADR 0010
- starts RentalOperations after MotoHub so a non-empty historical-reference migration can complete

## Proof

- 44 MotoHub non-container tests pass
- 15 RentalOperations non-container tests pass
- new Testcontainers proofs cover the Mongo rental/retirement race, PostgreSQL soft delete/history, migration, and legacy placeholder backfill
- full container execution is delegated to CI because Docker and the Docker CLI are unavailable in the local environment

## GitFlow

Task PR into `epic/6-transactional-consistency`; the Epic remains the only branch that will later target `master`.
