### PR TITLE
M13: paginate listings with index-backed queries

### DIFF
--- a/MotoHub/MotoHub/Controllers/MotorcycleController.cs
+++ b/MotoHub/MotoHub/Controllers/MotorcycleController.cs
@@ -23,11 +23,17 @@ namespace MotoHub.Controllers
         [Authorize]
         [ServiceFilter(typeof(AdminAuthorizationFilter))]
         [HttpGet]
-        public IActionResult GetAll()
+        public async Task<IActionResult> GetAll([FromQuery] string? cursor, [FromQuery] int? pageSize)
         {
-            _logger.LogInformation("Fetching all motorcycles.");
-            var motorcycles = _motorcycleService.GetAllMotorcycles();
-            return Ok(motorcycles);
+            _logger.LogInformation("Fetching a page of motorcycles.");
+            try
+            {
+                return Ok(await _motorcycleService.GetMotorcyclesAsync(cursor, pageSize));
+            }
+            catch (FormatException exception)
+            {
+                return BadRequest(exception.Message);
+            }
         }
 
         [ServiceFilter(typeof(AdminAuthorizationFilter))]

--- a/MotoHub/MotoHub/Data/ApplicationDbContext.cs
+++ b/MotoHub/MotoHub/Data/ApplicationDbContext.cs
@@ -18,6 +18,10 @@ namespace MotoHub.Data
             modelBuilder.Entity<Motorcycle>()
                 .HasIndex(m => m.LicensePlate)
                 .IsUnique();
+            modelBuilder.Entity<Motorcycle>()
+                .HasIndex(m => m.Id)
+                .HasDatabaseName("IX_Motorcycles_Active_Id")
+                .HasFilter("\"RetiredAtUtc\" IS NULL");
             modelBuilder.ConfigureOutbox();
         }
     }

--- a/MotoHub/MotoHub/Migrations/20260901122917_AddMotorcyclePaginationIndex.Designer.cs
+++ b/MotoHub/MotoHub/Migrations/20260901122917_AddMotorcyclePaginationIndex.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MotoHub.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MotoHub.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260901122917_AddMotorcyclePaginationIndex")]
+    partial class AddMotorcyclePaginationIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MotoHub/MotoHub/Migrations/20260901122917_AddMotorcyclePaginationIndex.cs
+++ b/MotoHub/MotoHub/Migrations/20260901122917_AddMotorcyclePaginationIndex.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MotoHub.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMotorcyclePaginationIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Motorcycles_Active_Id",
+                table: "Motorcycles",
+                column: "Id",
+                filter: "\"RetiredAtUtc\" IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Motorcycles_Active_Id",
+                table: "Motorcycles");
+        }
+    }
+}

--- a/MotoHub/MotoHub/MotoHub.csproj
+++ b/MotoHub/MotoHub/MotoHub.csproj
@@ -47,6 +47,7 @@
     <Compile Include="..\..\Shared\Messaging\OutboxRelayOptions.cs" Link="Shared\Messaging\OutboxRelayOptions.cs" />
     <Compile Include="..\..\Shared\Messaging\RabbitMqOutboxTransport.cs" Link="Shared\Messaging\RabbitMqOutboxTransport.cs" />
     <Compile Include="..\..\Shared\Idempotency\*.cs" Link="Shared\Idempotency\%(Filename)%(Extension)" />
+    <Compile Include="..\..\Shared\Pagination\*.cs" Link="Shared\Pagination\%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/MotoHub/MotoHub/Repositories/IMotorcycleRepository.cs
+++ b/MotoHub/MotoHub/Repositories/IMotorcycleRepository.cs
@@ -1,10 +1,12 @@
 ﻿using MotoHub.Models;
 
+using ProjectY.Shared.Pagination;
+
 namespace MotoHub.Repositories
 {
     public interface IMotorcycleRepository
     {
-        IEnumerable<Motorcycle> GetAll();
+        Task<CursorPage<Motorcycle>> GetPageAsync(string? cursor, int? pageSize);
         Motorcycle? GetById(string id);
         void Add(Motorcycle motorcycle);
         void Update(Motorcycle motorcycle);

--- a/MotoHub/MotoHub/Repositories/MotorcycleRepository.cs
+++ b/MotoHub/MotoHub/Repositories/MotorcycleRepository.cs
@@ -19,15 +19,17 @@ namespace MotoHub.Repositories
         {
             var size = CursorPagination.NormalizePageSize(pageSize);
             var afterId = CursorPagination.Decode(cursor);
-            var query = _context.Motorcycles
+            var source = afterId is null
+                ? _context.Motorcycles
+                : _context.Motorcycles.FromSqlInterpolated($$"""
+                    SELECT * FROM "Motorcycles"
+                    WHERE "RetiredAtUtc" IS NULL AND "Id" > {{afterId}}
+                    """);
+            var query = source
                 .AsNoTracking()
                 .Where(motorcycle => motorcycle.RetiredAtUtc == null)
                 .OrderBy(motorcycle => motorcycle.Id)
                 .AsQueryable();
-            if (afterId is not null)
-            {
-                query = query.Where(motorcycle => string.Compare(motorcycle.Id, afterId) > 0);
-            }
 
             var fetched = await query.Take(size + 1).ToListAsync();
             return CursorPagination.CreatePage(fetched, size, motorcycle => motorcycle.Id);

--- a/MotoHub/MotoHub/Repositories/MotorcycleRepository.cs
+++ b/MotoHub/MotoHub/Repositories/MotorcycleRepository.cs
@@ -2,6 +2,8 @@
 using MotoHub.Data;
 using MotoHub.Models;
 
+using ProjectY.Shared.Pagination;
+
 namespace MotoHub.Repositories
 {
     public class MotorcycleRepository : IMotorcycleRepository
@@ -13,11 +15,22 @@ namespace MotoHub.Repositories
             _context = context;
         }
 
-        public IEnumerable<Motorcycle> GetAll()
+        public async Task<CursorPage<Motorcycle>> GetPageAsync(string? cursor, int? pageSize)
         {
-            return _context.Motorcycles
+            var size = CursorPagination.NormalizePageSize(pageSize);
+            var afterId = CursorPagination.Decode(cursor);
+            var query = _context.Motorcycles
+                .AsNoTracking()
                 .Where(motorcycle => motorcycle.RetiredAtUtc == null)
-                .ToList();
+                .OrderBy(motorcycle => motorcycle.Id)
+                .AsQueryable();
+            if (afterId is not null)
+            {
+                query = query.Where(motorcycle => string.Compare(motorcycle.Id, afterId) > 0);
+            }
+
+            var fetched = await query.Take(size + 1).ToListAsync();
+            return CursorPagination.CreatePage(fetched, size, motorcycle => motorcycle.Id);
         }
 
         public Motorcycle? GetById(string id)

--- a/MotoHub/MotoHub/Services/IMotorcycleService.cs
+++ b/MotoHub/MotoHub/Services/IMotorcycleService.cs
@@ -1,11 +1,13 @@
 ﻿using MotoHub.DTOs;
 using MotoHub.Entities;
 
+using ProjectY.Shared.Pagination;
+
 namespace MotoHub.Services
 {
     public interface IMotorcycleService
     {
-        IEnumerable<MotorcycleDTO> GetAllMotorcycles();
+        Task<CursorPage<MotorcycleDTO>> GetMotorcyclesAsync(string? cursor, int? pageSize);
         Task<MotorcycleDTO?> GetMotorcycleByLicensePlateAsync(string licensePlate);
         void CreateMotorcycle(MotorcycleDTO motorcycleDto);
         Task UpdateMotorcycleAsync(string licensePlate, string newLicencePlate);

--- a/MotoHub/MotoHub/Services/MotorcycleService.cs
+++ b/MotoHub/MotoHub/Services/MotorcycleService.cs
@@ -6,6 +6,8 @@ using MotoHub.Models;
 using MotoHub.Repositories;
 using MotoHub.Services.RabbitMQ;
 
+using ProjectY.Shared.Pagination;
+
 namespace MotoHub.Services
 {
     public class MotorcycleService : IMotorcycleService
@@ -27,10 +29,12 @@ namespace MotoHub.Services
             _rentalOperationService = rentalOperationService;
         }
 
-        public IEnumerable<MotorcycleDTO> GetAllMotorcycles()
+        public async Task<CursorPage<MotorcycleDTO>> GetMotorcyclesAsync(string? cursor, int? pageSize)
         {
-            var motorcycles = _repository.GetAll();
-            return _mapper.Map<IEnumerable<MotorcycleDTO>>(motorcycles);
+            var page = await _repository.GetPageAsync(cursor, pageSize);
+            return new CursorPage<MotorcycleDTO>(
+                _mapper.Map<IReadOnlyList<MotorcycleDTO>>(page.Items),
+                page.NextCursor);
         }
 
         public async Task<MotorcycleDTO?> GetMotorcycleByLicensePlateAsync(string licensePlate)

--- a/MotoHub/MotoHubTests/Integration/PostgreSql/MigrationTests.cs
+++ b/MotoHub/MotoHubTests/Integration/PostgreSql/MigrationTests.cs
@@ -36,7 +36,7 @@ public sealed class MigrationTests : IAsyncLifetime
         await context.SaveChangesAsync();
 
         Assert.Empty(await context.Database.GetPendingMigrationsAsync());
-        Assert.Equal(4, (await context.Database.GetAppliedMigrationsAsync()).Count());
+        Assert.Equal(5, (await context.Database.GetAppliedMigrationsAsync()).Count());
         Assert.Equal(1, await context.Motorcycles.CountAsync());
     }
 }

--- a/MotoHub/MotoHubTests/Integration/PostgreSql/MotorcycleRetirementTests.cs
+++ b/MotoHub/MotoHubTests/Integration/PostgreSql/MotorcycleRetirementTests.cs
@@ -97,7 +97,7 @@ public sealed class MotorcycleRetirementTests : IAsyncLifetime
         Assert.NotNull(first.NextCursor);
         Assert.Null(second.NextCursor);
         Assert.Empty(first.Items.Select(item => item.Id).Intersect(second.Items.Select(item => item.Id)));
-        Assert.Contains(sql, command => command.Contains("WHERE \"Id\" >", StringComparison.Ordinal));
+        Assert.Contains(sql, command => command.Contains("\"Id\" > @", StringComparison.Ordinal));
         Assert.DoesNotContain(sql, command => command.Contains("CASE", StringComparison.Ordinal));
 
         context.Motorcycles.AddRange(Enumerable.Range(105, 10_000).Select(index => new Motorcycle

--- a/MotoHub/MotoHubTests/Integration/PostgreSql/MotorcycleRetirementTests.cs
+++ b/MotoHub/MotoHubTests/Integration/PostgreSql/MotorcycleRetirementTests.cs
@@ -80,9 +80,16 @@ public sealed class MotorcycleRetirementTests : IAsyncLifetime
         }));
         await context.SaveChangesAsync();
         context.ChangeTracker.Clear();
-        var repository = new MotorcycleRepository(context);
+        var sql = new List<string>();
+        var listingOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(_database.GetConnectionString())
+            .LogTo(sql.Add)
+            .Options;
+        await using var listingContext = new ApplicationDbContext(listingOptions);
+        var repository = new MotorcycleRepository(listingContext);
 
         var first = await repository.GetPageAsync(null, 1_000);
+        sql.Clear();
         var second = await repository.GetPageAsync(first.NextCursor, 1_000);
 
         Assert.Equal(100, first.Items.Count);
@@ -90,6 +97,8 @@ public sealed class MotorcycleRetirementTests : IAsyncLifetime
         Assert.NotNull(first.NextCursor);
         Assert.Null(second.NextCursor);
         Assert.Empty(first.Items.Select(item => item.Id).Intersect(second.Items.Select(item => item.Id)));
+        Assert.Contains(sql, command => command.Contains("WHERE \"Id\" >", StringComparison.Ordinal));
+        Assert.DoesNotContain(sql, command => command.Contains("CASE", StringComparison.Ordinal));
 
         context.Motorcycles.AddRange(Enumerable.Range(105, 10_000).Select(index => new Motorcycle
         {

--- a/MotoHub/MotoHubTests/Integration/PostgreSql/MotorcycleRetirementTests.cs
+++ b/MotoHub/MotoHubTests/Integration/PostgreSql/MotorcycleRetirementTests.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using MotoHub.Data;
 using MotoHub.Models;
 using MotoHub.Repositories;
+using Npgsql;
 using Testcontainers.PostgreSql;
 
 namespace MotoHubTests.Integration.PostgreSql;
@@ -39,7 +40,7 @@ public sealed class MotorcycleRetirementTests : IAsyncLifetime
             retiredAtUtc,
             MotorcycleRetirementReasons.RequestedByAdministrator));
 
-        Assert.Empty(repository.GetAll());
+        Assert.Empty((await repository.GetPageAsync(null, null)).Items);
         var historical = await repository.GetByLicensePlateAsync(motorcycle.LicensePlate);
         Assert.NotNull(historical);
         Assert.Equal(retiredAtUtc, historical.RetiredAtUtc);
@@ -61,7 +62,68 @@ public sealed class MotorcycleRetirementTests : IAsyncLifetime
         Assert.Equal("OLD-0001", historical.LicensePlate);
         Assert.Equal(migratedAtUtc, historical.RetiredAtUtc);
         Assert.Equal(MotorcycleRetirementReasons.LegacyOrphanBackfill, historical.RetirementReason);
-        Assert.Empty(repository.GetAll());
+        Assert.Empty((await repository.GetPageAsync(null, null)).Items);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Listing_IsCursorPagedBoundedAndUsesAnIndex()
+    {
+        await using var context = await CreateContextAsync();
+        context.Motorcycles.AddRange(Enumerable.Range(0, 105).Select(index => new Motorcycle
+        {
+            Id = $"motorcycle-{index:D4}",
+            LicensePlate = $"PAGE-{index:D4}",
+            Model = "Pagination proof",
+            Year = 2026,
+            RegistrationDate = DateTime.UtcNow
+        }));
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+        var repository = new MotorcycleRepository(context);
+
+        var first = await repository.GetPageAsync(null, 1_000);
+        var second = await repository.GetPageAsync(first.NextCursor, 1_000);
+
+        Assert.Equal(100, first.Items.Count);
+        Assert.Equal(5, second.Items.Count);
+        Assert.NotNull(first.NextCursor);
+        Assert.Null(second.NextCursor);
+        Assert.Empty(first.Items.Select(item => item.Id).Intersect(second.Items.Select(item => item.Id)));
+
+        context.Motorcycles.AddRange(Enumerable.Range(105, 10_000).Select(index => new Motorcycle
+        {
+            Id = $"motorcycle-{index:D5}",
+            LicensePlate = $"PLAN-{index:D5}",
+            Model = "Query plan proof",
+            Year = 2026,
+            RegistrationDate = DateTime.UtcNow
+        }));
+        await context.SaveChangesAsync();
+
+        await using var connection = new NpgsqlConnection(_database.GetConnectionString());
+        await connection.OpenAsync();
+        await using (var analyzeCommand = new NpgsqlCommand("ANALYZE \"Motorcycles\"", connection))
+        {
+            await analyzeCommand.ExecuteNonQueryAsync();
+        }
+        await using var indexCommand = new NpgsqlCommand(
+            "SELECT indexname FROM pg_indexes WHERE tablename = 'Motorcycles' AND indexname = 'IX_Motorcycles_Active_Id'",
+            connection);
+        Assert.Equal("IX_Motorcycles_Active_Id", await indexCommand.ExecuteScalarAsync());
+
+        await using var explainCommand = new NpgsqlCommand(
+            "EXPLAIN SELECT \"Id\" FROM \"Motorcycles\" WHERE \"RetiredAtUtc\" IS NULL AND \"Id\" > 'motorcycle-0000' ORDER BY \"Id\" LIMIT 101",
+            connection);
+        var plan = new List<string>();
+        await using var reader = await explainCommand.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            plan.Add(reader.GetString(0));
+        }
+
+        Assert.Contains(plan, line => line.Contains("Index", StringComparison.Ordinal));
+        Assert.DoesNotContain(plan, line => line.Contains("Seq Scan", StringComparison.Ordinal));
     }
 
     private async Task<ApplicationDbContext> CreateContextAsync()

--- a/MotoHub/MotoHubTests/Unit/Controllers/MotorcycleControllerTests.cs
+++ b/MotoHub/MotoHubTests/Unit/Controllers/MotorcycleControllerTests.cs
@@ -6,6 +6,7 @@ using MotoHub.Controllers;
 using MotoHub.DTOs;
 using MotoHub.Entities;
 using MotoHub.Services;
+using ProjectY.Shared.Pagination;
 using System.Security.Claims;
 
 namespace MotoHubTests.Unit.Controllers
@@ -13,16 +14,19 @@ namespace MotoHubTests.Unit.Controllers
     public class MotorcyclesControllerTests
     {
         [Fact]
-        public void GetAll_ReturnsOkObjectResult()
+        public async Task GetAll_ReturnsOkObjectResult()
         {
             // Arrange
             var motorcycleServiceMock = new Mock<IMotorcycleService>();
             var mockLogger = new Mock<ILogger<MotorcyclesController>>();
-            motorcycleServiceMock.Setup(service => service.GetAllMotorcycles()).Returns(new[] { new MotorcycleDTO() { LicensePlate = "test-584" } });
+            motorcycleServiceMock.Setup(service => service.GetMotorcyclesAsync(null, null))
+                .ReturnsAsync(new CursorPage<MotorcycleDTO>(
+                    [new MotorcycleDTO { LicensePlate = "test-584" }],
+                    null));
             var controller = new MotorcyclesController(motorcycleServiceMock.Object, mockLogger.Object);
 
             // Act
-            var result = controller.GetAll();
+            var result = await controller.GetAll(null, null);
 
             // Assert
             Assert.IsType<OkObjectResult>(result);
@@ -154,7 +158,7 @@ namespace MotoHubTests.Unit.Controllers
         }
 
         [Fact]
-        public void GetAll_AuthorizedUser_ReturnsOkResult()
+        public async Task GetAll_AuthorizedUser_ReturnsOkResult()
         {
             // Arrange
             var controller = new MotorcyclesController(Mock.Of<IMotorcycleService>(), Mock.Of<ILogger<MotorcyclesController>>());
@@ -172,7 +176,7 @@ namespace MotoHubTests.Unit.Controllers
             };
 
             // Act
-            var result = controller.GetAll();
+            var result = await controller.GetAll(null, null);
 
             // Assert
             Assert.IsType<OkObjectResult>(result);

--- a/MotoHub/MotoHubTests/Unit/Repositories/MotorcycleRepositoryTests.cs
+++ b/MotoHub/MotoHubTests/Unit/Repositories/MotorcycleRepositoryTests.cs
@@ -10,13 +10,13 @@ namespace MotoHubTests.Unit.Repositories
     public class MotorcycleRepositoryTests
     {
         [Fact]
-        public void GetAll_ReturnsAllMotorcycles()
+        public async Task GetPage_ReturnsAllMotorcyclesInFirstPage()
         {
             // Arrange
             var motorcycles = new List<Motorcycle>
             {
-                new Motorcycle { Id = Guid.NewGuid().ToString(), LicensePlate = "ABC123", Model = "Honda", Year = 2020 },
-                new Motorcycle { Id = Guid.NewGuid().ToString(), LicensePlate = "DEF456", Model = "Yamaha", Year = 2021 }
+                new Motorcycle { Id = "motorcycle-0001", LicensePlate = "ABC123", Model = "Honda", Year = 2020 },
+                new Motorcycle { Id = "motorcycle-0002", LicensePlate = "DEF456", Model = "Yamaha", Year = 2021 }
             };
 
             var mockContext = new Mock<IApplicationDbContext>();
@@ -25,12 +25,12 @@ namespace MotoHubTests.Unit.Repositories
             var repository = new MotorcycleRepository(mockContext.Object);
 
             // Act
-            var result = repository.GetAll();
+            var result = await repository.GetPageAsync(null, null);
 
             // Assert
             Assert.NotNull(result);
-            var returnedMotorcycles = result.ToList();
-            Assert.Equal(2, returnedMotorcycles.Count());
+            var returnedMotorcycles = result.Items;
+            Assert.Equal(2, returnedMotorcycles.Count);
             Assert.Collection(returnedMotorcycles,
                 item => Assert.Equal("ABC123", item.LicensePlate),
                 item => Assert.Equal("DEF456", item.LicensePlate)

--- a/MotoHub/MotoHubTests/Unit/Services/MotorcycleServicesTests.cs
+++ b/MotoHub/MotoHubTests/Unit/Services/MotorcycleServicesTests.cs
@@ -9,13 +9,14 @@ using MotoHub.Models;
 using MotoHub.Repositories;
 using MotoHub.Services;
 using MotoHub.Services.RabbitMQ;
+using ProjectY.Shared.Pagination;
 
 namespace MotoHubTests.Unit.Services
 {
     public class MotorcycleServiceTests
     {
         [Fact]
-        public void GetAllMotorcycles_ReturnsAllMotorcycles()
+        public async Task GetMotorcyclesAsync_ReturnsPageOfMotorcycles()
         {
             // Arrange
             var motorcycles = new List<Motorcycle>
@@ -31,7 +32,7 @@ namespace MotoHubTests.Unit.Services
             };
 
             var mockMapper = new Mock<IMapper>();
-            mockMapper.Setup(m => m.Map<IEnumerable<MotorcycleDTO>>(It.IsAny<IEnumerable<Motorcycle>>()))
+            mockMapper.Setup(m => m.Map<IReadOnlyList<MotorcycleDTO>>(It.IsAny<IReadOnlyList<Motorcycle>>()))
                       .Returns(motorcycleDTOs);
 
             var mockRepository = new Mock<IMotorcycleRepository>();
@@ -40,17 +41,17 @@ namespace MotoHubTests.Unit.Services
 
             var mockCrossCutting = new Mock<IRentalOperationService>();
 
-            mockRepository.Setup(repo => repo.GetAll())
-                          .Returns(motorcycles);
+            mockRepository.Setup(repo => repo.GetPageAsync(null, null))
+                          .ReturnsAsync(new CursorPage<Motorcycle>(motorcycles, null));
 
             var service = new MotorcycleService(mockRepository.Object, mockMapper.Object, mockMessagingPublish.Object, mockCrossCutting.Object);
 
             // Act
-            var result = service.GetAllMotorcycles();
+            var result = await service.GetMotorcyclesAsync(null, null);
 
             // Assert
             Assert.NotNull(result);
-            Assert.Collection(result,
+            Assert.Collection(result.Items,
                 item => Assert.Equal("ABC123", item.LicensePlate),
                 item => Assert.Equal("DEF456", item.LicensePlate)
             );

--- a/RentalOperations/RentalOperations/Controllers/RentalController.cs
+++ b/RentalOperations/RentalOperations/Controllers/RentalController.cs
@@ -61,7 +61,9 @@ namespace RentalOperations.Controllers
         [Authorize]
         [ServiceFilter(typeof(AuthorizationFilter))]
         [HttpGet("user")]
-        public async Task<IActionResult> GetRentalsByUser()
+        public async Task<IActionResult> GetRentalsByUser(
+            [FromQuery] string? cursor,
+            [FromQuery] int? pageSize)
         {
             try
             {
@@ -70,11 +72,10 @@ namespace RentalOperations.Controllers
                 {
                     return Forbid();
                 }
-                var rentals = await _rentalService.GetRentalsByUserIdAsync(userIdClaim.Value);
-                if (rentals == null || rentals.Count == 0)
-                    return NotFound($"No rentals found for user ID {userIdClaim.Value}");
-
-                return Ok(rentals);
+                return Ok(await _rentalService.GetRentalsByUserIdAsync(
+                    userIdClaim.Value,
+                    cursor,
+                    pageSize));
             }
             catch (Exception ex)
             {
@@ -85,15 +86,14 @@ namespace RentalOperations.Controllers
         [Authorize]
         [ServiceFilter(typeof(AdminAuthorizationFilter))]
         [HttpGet("user/{userId}")]
-        public async Task<IActionResult> GetRentalsByUserAdmin(string userId)
+        public async Task<IActionResult> GetRentalsByUserAdmin(
+            string userId,
+            [FromQuery] string? cursor,
+            [FromQuery] int? pageSize)
         {
             try
             {
-                var rentals = await _rentalService.GetRentalsByUserIdAsync(userId);
-                if (rentals == null || rentals.Count == 0)
-                    return NotFound($"No rentals found for user ID {userId}");
-
-                return Ok(rentals);
+                return Ok(await _rentalService.GetRentalsByUserIdAsync(userId, cursor, pageSize));
             }
             catch (Exception ex)
             {

--- a/RentalOperations/RentalOperations/Data/MongoRentalIndexInitializer.cs
+++ b/RentalOperations/RentalOperations/Data/MongoRentalIndexInitializer.cs
@@ -9,6 +9,8 @@ namespace RentalOperations.Data;
 public sealed class MongoRentalIndexInitializer : IHostedService
 {
     public const string ActiveRentalIndexName = "ux_rentals_one_active_per_motorcycle";
+    public const string UserRentalPageIndexName = "ix_rentals_user_cursor";
+    public const string MotorcycleAvailabilityIndexName = "ix_rentals_motorcycle_availability";
     public const string LegacyDuplicateQuarantineMessage =
         "Quarantined during active-rental index migration: duplicate open rental; review required.";
     public const string RetiredMotorcycleQuarantineMessage =
@@ -40,7 +42,28 @@ public sealed class MongoRentalIndexInitializer : IHostedService
                     RentalStatus.Active)
             });
 
-        await rentals.Indexes.CreateOneAsync(index, cancellationToken: cancellationToken);
+        var userPageIndex = new CreateIndexModel<Rental>(
+            Builders<Rental>.IndexKeys
+                .Ascending(rental => rental.UserId)
+                .Ascending(rental => rental._id),
+            new CreateIndexOptions { Name = UserRentalPageIndexName });
+        var availabilityIndex = new CreateIndexModel<Rental>(
+            Builders<Rental>.IndexKeys
+                .Ascending(rental => rental.MotorcycleLicencePlate)
+                .Ascending(rental => rental.Status)
+                .Ascending(rental => rental.StartDate)
+                .Ascending(rental => rental.PredictedEndDate),
+            new CreateIndexOptions<Rental>
+            {
+                Name = MotorcycleAvailabilityIndexName,
+                PartialFilterExpression = Builders<Rental>.Filter.Eq(
+                    rental => rental.Status,
+                    RentalStatus.Active)
+            });
+
+        await rentals.Indexes.CreateManyAsync(
+            [index, userPageIndex, availabilityIndex],
+            cancellationToken);
         await ReconcileMotorcycleClaimsAsync(cancellationToken);
         await EnsureHistoricalMotorcycleReferencesAsync(cancellationToken);
     }

--- a/RentalOperations/RentalOperations/Data/MongoRentalIndexInitializer.cs
+++ b/RentalOperations/RentalOperations/Data/MongoRentalIndexInitializer.cs
@@ -11,6 +11,7 @@ public sealed class MongoRentalIndexInitializer : IHostedService
     public const string ActiveRentalIndexName = "ux_rentals_one_active_per_motorcycle";
     public const string UserRentalPageIndexName = "ix_rentals_user_cursor";
     public const string MotorcycleAvailabilityIndexName = "ix_rentals_motorcycle_availability";
+    public const string MotorcycleScheduleIndexName = "ix_rentals_motorcycle_schedule";
     public const string LegacyDuplicateQuarantineMessage =
         "Quarantined during active-rental index migration: duplicate open rental; review required.";
     public const string RetiredMotorcycleQuarantineMessage =
@@ -60,9 +61,17 @@ public sealed class MongoRentalIndexInitializer : IHostedService
                     rental => rental.Status,
                     RentalStatus.Active)
             });
+        var scheduleIndex = new CreateIndexModel<Rental>(
+            Builders<Rental>.IndexKeys
+                .Ascending(rental => rental.MotorcycleLicencePlate)
+                .Ascending(rental => rental.Status)
+                .Ascending(rental => rental.StartDate)
+                .Ascending(rental => rental.EndDate)
+                .Ascending(rental => rental.PredictedEndDate),
+            new CreateIndexOptions { Name = MotorcycleScheduleIndexName });
 
         await rentals.Indexes.CreateManyAsync(
-            [index, userPageIndex, availabilityIndex],
+            [index, userPageIndex, availabilityIndex, scheduleIndex],
             cancellationToken);
         await ReconcileMotorcycleClaimsAsync(cancellationToken);
         await EnsureHistoricalMotorcycleReferencesAsync(cancellationToken);

--- a/RentalOperations/RentalOperations/RentalOperations.csproj
+++ b/RentalOperations/RentalOperations/RentalOperations.csproj
@@ -30,6 +30,7 @@
     <Compile Include="..\..\Shared\Health\ServiceHealthChecks.cs" Link="Shared\Health\ServiceHealthChecks.cs" />
     <Compile Include="..\..\Shared\Hosting\SwaggerPolicy.cs" Link="Shared\Hosting\SwaggerPolicy.cs" />
     <Compile Include="..\..\Shared\Idempotency\*.cs" Link="Shared\Idempotency\%(Filename)%(Extension)" />
+    <Compile Include="..\..\Shared\Pagination\*.cs" Link="Shared\Pagination\%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/RentalOperations/RentalOperations/Repository/IRentalRepository.cs
+++ b/RentalOperations/RentalOperations/Repository/IRentalRepository.cs
@@ -1,14 +1,16 @@
 using RentalOperations.Domain;
 using RentalOperations.Model;
 
+using ProjectY.Shared.Pagination;
+
 namespace RentalOperations.Repository
 {
     public interface IRentalRepository
     {
         Task<Rental> CreateRentalAsync(Rental rental);
         Task<Rental> GetRentalByIdAsync(string id);
-        Task<List<Rental>> GetRentalsByUserId(string userId);
-        Task<List<Rental>> GetRentalsByMotorcycleIdAsync(string licencePlate);
+        Task<CursorPage<Rental>> GetRentalsByUserId(string userId, string? cursor, int? pageSize);
+        Task<bool> HasOverlappingRentalAsync(string licencePlate, DateTime startDate, DateTime endDate);
         Task<bool> IsMotorcycleCurrentlyRentedAsync(string licencePlate);
         Task UpdateRentalAsync(Rental rental);
         Task UpdateLicensePlateForAllRentalsAsync(string oldLicensePlate, string newLicensePlate);

--- a/RentalOperations/RentalOperations/Repository/RentalRepository.cs
+++ b/RentalOperations/RentalOperations/Repository/RentalRepository.cs
@@ -73,11 +73,21 @@ namespace RentalOperations.Repository
             DateTime startDate,
             DateTime endDate)
         {
+            var schedulableStatuses = Builders<Rental>.Filter.In(
+                rental => rental.Status,
+                [RentalStatus.Active, RentalStatus.Completed]);
+            var existingPeriodEndsAfterRequestedStart = Builders<Rental>.Filter.Or(
+                Builders<Rental>.Filter.And(
+                    Builders<Rental>.Filter.Ne(rental => rental.EndDate, null),
+                    Builders<Rental>.Filter.Gt(rental => rental.EndDate, startDate)),
+                Builders<Rental>.Filter.And(
+                    Builders<Rental>.Filter.Eq(rental => rental.EndDate, null),
+                    Builders<Rental>.Filter.Gt(rental => rental.PredictedEndDate, startDate)));
             var filter = Builders<Rental>.Filter.And(
                 Builders<Rental>.Filter.Eq(rental => rental.MotorcycleLicencePlate, licencePlate),
-                Builders<Rental>.Filter.Eq(rental => rental.Status, RentalStatus.Active),
+                schedulableStatuses,
                 Builders<Rental>.Filter.Lt(rental => rental.StartDate, endDate),
-                Builders<Rental>.Filter.Gt(rental => rental.PredictedEndDate, startDate));
+                existingPeriodEndsAfterRequestedStart);
             return _rentals.Find(filter).Limit(1).AnyAsync();
         }
 

--- a/RentalOperations/RentalOperations/Repository/RentalRepository.cs
+++ b/RentalOperations/RentalOperations/Repository/RentalRepository.cs
@@ -4,6 +4,8 @@ using RentalOperations.Data;
 using RentalOperations.Domain;
 using RentalOperations.Model;
 
+using ProjectY.Shared.Pagination;
+
 namespace RentalOperations.Repository
 {
     public class RentalRepository : IRentalRepository
@@ -38,25 +40,56 @@ namespace RentalOperations.Repository
             return await _rentals.Find(r => r._id == objectId).FirstOrDefaultAsync();
         }
 
-        public async Task<List<Rental>> GetRentalsByUserId(string userId)
+        public async Task<CursorPage<Rental>> GetRentalsByUserId(
+            string userId,
+            string? cursor,
+            int? pageSize)
         {
-            return await _rentals.Find(r => r.UserId == userId).ToListAsync();
+            var size = CursorPagination.NormalizePageSize(pageSize);
+            var cursorValue = CursorPagination.Decode(cursor);
+            var filter = Builders<Rental>.Filter.Eq(rental => rental.UserId, userId);
+            if (cursorValue is not null)
+            {
+                if (!ObjectId.TryParse(cursorValue, out var afterId))
+                {
+                    throw new FormatException("The pagination cursor is invalid.");
+                }
+
+                filter &= Builders<Rental>.Filter.Gt(rental => rental._id, afterId);
+            }
+
+            var fetched = await _rentals.Find(filter)
+                .SortBy(rental => rental._id)
+                .Limit(size + 1)
+                .ToListAsync();
+            return CursorPagination.CreatePage(
+                fetched,
+                size,
+                rental => rental._id!.Value.ToString());
         }
 
-        public async Task<List<Rental>> GetRentalsByMotorcycleIdAsync(string licencePlate)
+        public Task<bool> HasOverlappingRentalAsync(
+            string licencePlate,
+            DateTime startDate,
+            DateTime endDate)
         {
-            return await _rentals.Find(r => r.MotorcycleLicencePlate == licencePlate).ToListAsync();
+            var filter = Builders<Rental>.Filter.And(
+                Builders<Rental>.Filter.Eq(rental => rental.MotorcycleLicencePlate, licencePlate),
+                Builders<Rental>.Filter.Eq(rental => rental.Status, RentalStatus.Active),
+                Builders<Rental>.Filter.Lt(rental => rental.StartDate, endDate),
+                Builders<Rental>.Filter.Gt(rental => rental.PredictedEndDate, startDate));
+            return _rentals.Find(filter).Limit(1).AnyAsync();
         }
 
         public async Task<bool> IsMotorcycleCurrentlyRentedAsync(string licencePlate)
         {
             var today = DateTime.UtcNow;
-            var rentals = await _rentals.Find(r => r.MotorcycleLicencePlate == licencePlate).ToListAsync();
-
-            return rentals.Any(r =>
-                r.Status == RentalStatus.Active &&
-                r.StartDate <= today &&
-                r.PredictedEndDate >= today);
+            var filter = Builders<Rental>.Filter.And(
+                Builders<Rental>.Filter.Eq(rental => rental.MotorcycleLicencePlate, licencePlate),
+                Builders<Rental>.Filter.Eq(rental => rental.Status, RentalStatus.Active),
+                Builders<Rental>.Filter.Lte(rental => rental.StartDate, today),
+                Builders<Rental>.Filter.Gte(rental => rental.PredictedEndDate, today));
+            return await _rentals.Find(filter).Limit(1).AnyAsync();
         }
 
         public async Task UpdateRentalAsync(Rental rental)

--- a/RentalOperations/RentalOperations/Services/IRentalService.cs
+++ b/RentalOperations/RentalOperations/Services/IRentalService.cs
@@ -1,13 +1,18 @@
 ﻿using RentalOperations.DTOs;
 using RentalOperations.Model;
 
+using ProjectY.Shared.Pagination;
+
 namespace RentalOperations.Services
 {
     public interface IRentalService
     {
         Task CreateRentalAsync(RentalCreateDto createDto, string userId);
         Task<ResponseRentalDTO> CalculateFinalCostAsync(string rentalId, string userId, DateTime actualEndDate);
-        Task<List<ResponseRentalDTO>> GetRentalsByUserIdAsync(string userId);
+        Task<CursorPage<ResponseRentalDTO>> GetRentalsByUserIdAsync(
+            string userId,
+            string? cursor,
+            int? pageSize);
         Task UpdateMotorcycleLicensePlateAsync(string oldLicensePlate, string newLicensePlate);
         Task<bool> IsMotorcycleCurrentlyRentedAsync(string licencePlate);
         Task<bool> TryRetireMotorcycleAsync(string licencePlate);

--- a/RentalOperations/RentalOperations/Services/RentalService.cs
+++ b/RentalOperations/RentalOperations/Services/RentalService.cs
@@ -5,6 +5,8 @@ using RentalOperations.DTOs;
 using RentalOperations.Model;
 using RentalOperations.Repository;
 
+using ProjectY.Shared.Pagination;
+
 namespace RentalOperations.Services
 {
     public class RentalService : IRentalService
@@ -34,11 +36,10 @@ namespace RentalOperations.Services
                 throw new InvalidOperationException("The Rent time must at least one day");
             }
 
-            var existingRentals = await _repository.GetRentalsByMotorcycleIdAsync(createDto.MotocycleLicencePlate);
-            if (existingRentals.Any(rent => RentalPeriod.Overlaps(
-                rent,
+            if (await _repository.HasOverlappingRentalAsync(
+                createDto.MotocycleLicencePlate,
                 createDto.StartDate,
-                createDto.PredictedEndDate)))
+                createDto.PredictedEndDate))
             {
                 throw new ActiveRentalConflictException(createDto.MotocycleLicencePlate);
             }
@@ -149,11 +150,15 @@ namespace RentalOperations.Services
             return response;
         }
 
-        public async Task<List<ResponseRentalDTO>> GetRentalsByUserIdAsync(string userId)
+        public async Task<CursorPage<ResponseRentalDTO>> GetRentalsByUserIdAsync(
+            string userId,
+            string? cursor,
+            int? pageSize)
         {
-            var rentals = await _repository.GetRentalsByUserId(userId);
-            var rentalDtos = _mapper.Map<List<ResponseRentalDTO>>(rentals);
-            return rentalDtos;
+            var page = await _repository.GetRentalsByUserId(userId, cursor, pageSize);
+            return new CursorPage<ResponseRentalDTO>(
+                _mapper.Map<IReadOnlyList<ResponseRentalDTO>>(page.Items),
+                page.NextCursor);
         }
 
         public async Task UpdateMotorcycleLicensePlateAsync(string oldLicensePlate, string newLicensePlate)

--- a/RentalOperations/RentalOperationsTests/Integration/InMemoryRentalRepository.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/InMemoryRentalRepository.cs
@@ -2,6 +2,7 @@ using MongoDB.Bson;
 using RentalOperations.Domain;
 using RentalOperations.Model;
 using RentalOperations.Repository;
+using ProjectY.Shared.Pagination;
 using System.Collections.Concurrent;
 
 namespace RentalOperationsTests.Integration;
@@ -44,17 +45,35 @@ public sealed class InMemoryRentalRepository : IRentalRepository
     public Task<Rental> GetRentalByIdAsync(string id) =>
         Task.FromResult(FindRental(id)!);
 
-    public Task<List<Rental>> GetRentalsByUserId(string userId) =>
-        Task.FromResult(_rentals.Values
+    public Task<CursorPage<Rental>> GetRentalsByUserId(
+        string userId,
+        string? cursor,
+        int? pageSize)
+    {
+        var normalizedPageSize = CursorPagination.NormalizePageSize(pageSize);
+        var after = CursorPagination.Decode(cursor);
+        var rentals = _rentals.Values
             .Where(rental => rental.UserId == userId)
+            .Where(rental => after is null || rental._id > ObjectId.Parse(after))
+            .OrderBy(rental => rental._id)
+            .Take(normalizedPageSize + 1)
             .Select(Clone)
-            .ToList());
+            .ToList();
+        return Task.FromResult(CursorPagination.CreatePage(
+            rentals,
+            normalizedPageSize,
+            rental => rental._id!.Value.ToString()));
+    }
 
-    public Task<List<Rental>> GetRentalsByMotorcycleIdAsync(string licencePlate) =>
-        Task.FromResult(_rentals.Values
-            .Where(rental => rental.MotorcycleLicencePlate == licencePlate)
-            .Select(Clone)
-            .ToList());
+    public Task<bool> HasOverlappingRentalAsync(
+        string licencePlate,
+        DateTime startDate,
+        DateTime endDate) =>
+        Task.FromResult(_rentals.Values.Any(rental =>
+            rental.MotorcycleLicencePlate == licencePlate &&
+            rental.Status == RentalStatus.Active &&
+            rental.StartDate < endDate &&
+            rental.PredictedEndDate > startDate));
 
     public Task<bool> IsMotorcycleCurrentlyRentedAsync(string licencePlate)
     {

--- a/RentalOperations/RentalOperationsTests/Integration/InMemoryRentalRepository.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/InMemoryRentalRepository.cs
@@ -71,9 +71,9 @@ public sealed class InMemoryRentalRepository : IRentalRepository
         DateTime endDate) =>
         Task.FromResult(_rentals.Values.Any(rental =>
             rental.MotorcycleLicencePlate == licencePlate &&
-            rental.Status == RentalStatus.Active &&
+            rental.Status is not RentalStatus.Cancelled and not RentalStatus.Quarantined &&
             rental.StartDate < endDate &&
-            rental.PredictedEndDate > startDate));
+            (rental.EndDate ?? rental.PredictedEndDate) > startDate));
 
     public Task<bool> IsMotorcycleCurrentlyRentedAsync(string licencePlate)
     {

--- a/RentalOperations/RentalOperationsTests/Integration/MongoDb/ActiveRentalApiTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/MongoDb/ActiveRentalApiTests.cs
@@ -207,6 +207,66 @@ public sealed class ActiveRentalApiTests : IAsyncLifetime
         });
         Assert.Contains("IXSCAN", availabilityPlan);
         Assert.DoesNotContain("COLLSCAN", availabilityPlan);
+
+        var schedulePlan = await ExplainFindAsync(database, new BsonDocument
+        {
+            ["MotorcycleLicencePlate"] = "LEGACY-0001",
+            ["status"] = new BsonDocument("$in", new BsonArray
+            {
+                RentalStatus.Active.ToString(),
+                RentalStatus.Completed.ToString()
+            }),
+            ["startDate"] = new BsonDocument("$lt", now.AddDays(1)),
+            ["$or"] = new BsonArray
+            {
+                new BsonDocument
+                {
+                    ["endDate"] = new BsonDocument
+                    {
+                        ["$ne"] = BsonNull.Value,
+                        ["$gt"] = now.AddDays(-1)
+                    }
+                },
+                new BsonDocument
+                {
+                    ["endDate"] = BsonNull.Value,
+                    ["predictedEndDate"] = new BsonDocument("$gt", now.AddDays(-1))
+                }
+            }
+        });
+        Assert.Contains(MongoRentalIndexInitializer.MotorcycleScheduleIndexName, schedulePlan);
+        Assert.DoesNotContain("COLLSCAN", schedulePlan);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task OverlapQuery_RejectsPeriodsInsideCompletedRentalHistory()
+    {
+        using var client = CreateAuthenticatedClient();
+        _ = await client.GetAsync("/api/Rental/user?pageSize=1");
+        var context = new MongoDbContext(_database.GetConnectionString(), DatabaseName);
+        var repository = new RentalRepository(context);
+        var existingStart = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+        var existingEnd = existingStart.AddDays(7);
+        await repository.CreateRentalAsync(new Rental
+        {
+            MotorcycleLicencePlate = "HISTORY-0001",
+            UserId = "rider-history",
+            StartDate = existingStart,
+            EndDate = existingEnd,
+            PredictedEndDate = existingEnd,
+            InitCost = 210m,
+            Status = RentalStatus.Completed
+        });
+
+        Assert.True(await repository.HasOverlappingRentalAsync(
+            "HISTORY-0001",
+            existingStart.AddDays(1),
+            existingEnd.AddDays(-1)));
+        Assert.False(await repository.HasOverlappingRentalAsync(
+            "HISTORY-0001",
+            existingEnd,
+            existingEnd.AddDays(7)));
     }
 
     private HttpClient CreateAuthenticatedClient()

--- a/RentalOperations/RentalOperationsTests/Integration/MongoDb/ActiveRentalApiTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/MongoDb/ActiveRentalApiTests.cs
@@ -14,6 +14,7 @@ using RentalOperations.Data;
 using RentalOperations.DTOs;
 using RentalOperations.Model;
 using RentalOperations.Repository;
+using ProjectY.Shared.Pagination;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Net.Http.Headers;
@@ -128,6 +129,7 @@ public sealed class ActiveRentalApiTests : IAsyncLifetime
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public async Task RiderCannotCreatePermanentMotorcycleRetirementClaim()
     {
         using var client = CreateAuthenticatedClient();
@@ -144,6 +146,69 @@ public sealed class ActiveRentalApiTests : IAsyncLifetime
             claim.MotorcycleLicencePlate == "ADMIN-ONLY-0001"));
     }
 
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task UserListing_IsCursorPagedAndEnforcesTheServerMaximum()
+    {
+        using var client = CreateAuthenticatedClient();
+        _ = await client.GetAsync("/api/Rental/user?pageSize=1");
+        var rentals = new MongoClient(_database.GetConnectionString())
+            .GetDatabase(DatabaseName)
+            .GetCollection<Rental>("Rentals");
+        await rentals.InsertManyAsync(Enumerable.Range(0, 105).Select(index => new Rental
+        {
+            MotorcycleLicencePlate = $"PAGE-{index:D4}",
+            UserId = "rider-1",
+            StartDate = DateTime.UtcNow.Date.AddDays(-14),
+            EndDate = DateTime.UtcNow.Date.AddDays(-7),
+            PredictedEndDate = DateTime.UtcNow.Date.AddDays(-7),
+            InitCost = 210m,
+            Status = RentalStatus.Completed
+        }));
+
+        var first = await client.GetFromJsonAsync<CursorPage<ResponseRentalDTO>>(
+            "/api/Rental/user?pageSize=1000");
+        Assert.NotNull(first);
+        Assert.Equal(100, first.Items.Count);
+        Assert.NotNull(first.NextCursor);
+
+        var second = await client.GetFromJsonAsync<CursorPage<ResponseRentalDTO>>(
+            $"/api/Rental/user?pageSize=1000&cursor={Uri.EscapeDataString(first.NextCursor)}");
+        Assert.NotNull(second);
+        Assert.Equal(5, second.Items.Count);
+        Assert.Null(second.NextCursor);
+        Assert.Empty(first.Items.Select(item => item.RentalId)
+            .Intersect(second.Items.Select(item => item.RentalId)));
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ListingAndAvailabilityQueries_HaveIndexBackedPlans()
+    {
+        using var client = CreateAuthenticatedClient();
+        _ = await client.GetAsync("/api/Rental/user?pageSize=1");
+        var database = new MongoClient(_database.GetConnectionString()).GetDatabase(DatabaseName);
+
+        var userPlan = await ExplainFindAsync(database, new BsonDocument
+        {
+            ["userId"] = "rider-1",
+            ["_id"] = new BsonDocument("$gt", ObjectId.Empty)
+        }, new BsonDocument("_id", 1));
+        Assert.Contains(MongoRentalIndexInitializer.UserRentalPageIndexName, userPlan);
+        Assert.DoesNotContain("COLLSCAN", userPlan);
+
+        var now = DateTime.UtcNow;
+        var availabilityPlan = await ExplainFindAsync(database, new BsonDocument
+        {
+            ["MotorcycleLicencePlate"] = "LEGACY-0001",
+            ["status"] = RentalStatus.Active.ToString(),
+            ["startDate"] = new BsonDocument("$lte", now),
+            ["predictedEndDate"] = new BsonDocument("$gte", now)
+        });
+        Assert.Contains("IXSCAN", availabilityPlan);
+        Assert.DoesNotContain("COLLSCAN", availabilityPlan);
+    }
+
     private HttpClient CreateAuthenticatedClient()
     {
         var factory = _factory ?? throw new InvalidOperationException("The test database has not started.");
@@ -156,6 +221,30 @@ public sealed class ActiveRentalApiTests : IAsyncLifetime
             "Bearer",
             CreateToken("Rider", "rider-1"));
         return client;
+    }
+
+    private static async Task<string> ExplainFindAsync(
+        IMongoDatabase database,
+        BsonDocument filter,
+        BsonDocument? sort = null)
+    {
+        var find = new BsonDocument
+        {
+            ["find"] = "Rentals",
+            ["filter"] = filter,
+            ["limit"] = 101
+        };
+        if (sort is not null)
+        {
+            find["sort"] = sort;
+        }
+
+        var explanation = await database.RunCommandAsync<BsonDocument>(new BsonDocument
+        {
+            ["explain"] = find,
+            ["verbosity"] = "queryPlanner"
+        });
+        return explanation["queryPlanner"]["winningPlan"].ToJson();
     }
 
     private static BsonDocument CreateLegacyOpenRental(string userId, DateTime startDate) => new()
@@ -285,11 +374,16 @@ internal sealed class SynchronizingRentalRepository : IRentalRepository
 
     public Task<Rental> GetRentalByIdAsync(string id) => _repository.GetRentalByIdAsync(id);
 
-    public Task<List<Rental>> GetRentalsByUserId(string userId) =>
-        _repository.GetRentalsByUserId(userId);
+    public Task<CursorPage<Rental>> GetRentalsByUserId(
+        string userId,
+        string? cursor,
+        int? pageSize) => _repository.GetRentalsByUserId(userId, cursor, pageSize);
 
-    public Task<List<Rental>> GetRentalsByMotorcycleIdAsync(string licencePlate) =>
-        _repository.GetRentalsByMotorcycleIdAsync(licencePlate);
+    public Task<bool> HasOverlappingRentalAsync(
+        string licencePlate,
+        DateTime startDate,
+        DateTime endDate) =>
+        _repository.HasOverlappingRentalAsync(licencePlate, startDate, endDate);
 
     public Task<bool> IsMotorcycleCurrentlyRentedAsync(string licencePlate) =>
         _repository.IsMotorcycleCurrentlyRentedAsync(licencePlate);

--- a/RentalOperations/RentalOperationsTests/Unit/Services/RentalServiceTests.cs
+++ b/RentalOperations/RentalOperationsTests/Unit/Services/RentalServiceTests.cs
@@ -15,8 +15,11 @@ public sealed class RentalServiceTests
     public async Task CreateRental_WhenRetirementClaimWins_RejectsWithoutInsertingRental()
     {
         var repository = new Mock<IRentalRepository>();
-        repository.Setup(candidate => candidate.GetRentalsByMotorcycleIdAsync("RET-0001"))
-            .ReturnsAsync([]);
+        repository.Setup(candidate => candidate.HasOverlappingRentalAsync(
+                "RET-0001",
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>()))
+            .ReturnsAsync(false);
         repository.Setup(candidate => candidate.TryClaimRentalAsync("RET-0001", It.IsAny<string>()))
             .ReturnsAsync(MotorcycleClaimResult.Retired);
         var riders = new Mock<IRiderManagerService>();

--- a/RiderManager/RiderManager/Controllers/RiderController.cs
+++ b/RiderManager/RiderManager/Controllers/RiderController.cs
@@ -21,10 +21,18 @@ namespace RiderManager.Controllers
         [Authorize]
         [ServiceFilter(typeof(AdminAuthorizationFilter))]
         [HttpGet]
-        public async Task<IActionResult> GetAllRiders()
+        public async Task<IActionResult> GetAllRiders(
+            [FromQuery] string? cursor,
+            [FromQuery] int? pageSize)
         {
-            var riders = await _riderManager.GetAllRidersAsync();
-            return Ok(riders);
+            try
+            {
+                return Ok(await _riderManager.GetRidersAsync(cursor, pageSize));
+            }
+            catch (FormatException exception)
+            {
+                return BadRequest(exception.Message);
+            }
         }
 
 

--- a/RiderManager/RiderManager/Managers/IRiderManager.cs
+++ b/RiderManager/RiderManager/Managers/IRiderManager.cs
@@ -1,5 +1,7 @@
 ﻿using RiderManager.DTOs;
 
+using ProjectY.Shared.Pagination;
+
 namespace RiderManager.Managers
 {
     public interface IRiderManager
@@ -8,7 +10,7 @@ namespace RiderManager.Managers
         Task UpdateRiderAsync(string userId, RiderDTO riderDto);
         Task DeleteRiderAsync(string userId);
         Task UpdateRiderImageAsync(string userId, IFormFile cnhFile, string? objectName = null);
-        Task<IEnumerable<RiderResponseDTO>> GetAllRidersAsync();
+        Task<CursorPage<RiderResponseDTO>> GetRidersAsync(string? cursor, int? pageSize);
         Task<RiderResponseDTO> GetRiderByUserIdAsync(string userId);
     }
 }

--- a/RiderManager/RiderManager/Managers/RidersManager.cs
+++ b/RiderManager/RiderManager/Managers/RidersManager.cs
@@ -2,6 +2,7 @@
 using RiderManager.Services.MinioStorageService;
 using RiderManager.Services.PreSignedService;
 using RiderManager.Services.RiderServices;
+using ProjectY.Shared.Pagination;
 
 namespace RiderManager.Managers
 {
@@ -62,31 +63,11 @@ namespace RiderManager.Managers
             return;
         }
 
-        public async Task<IEnumerable<RiderResponseDTO>> GetAllRidersAsync()
+        public Task<CursorPage<RiderResponseDTO>> GetRidersAsync(string? cursor, int? pageSize)
         {
-            var riders = await _riderService.GetAllRidersAsync();
-            var riderDtos = new List<RiderResponseDTO>();
-
-            foreach (var rider in riders)
-            {
-                var (isExpired, uploadFile) = await _preSignedUrlService.GetOrCreatePresignedUrlAsync(rider.Id);
-                if (uploadFile != null)
-                {
-                    if (isExpired)
-                    {
-                        var link = await _minioFileStorageService.GetPresignedUrlAsync(uploadFile.fileName, uploadFile.riderId);
-                        await _preSignedUrlService.StorePresignedUrlAsync(link);
-                    }
-                    rider.CNHUrl = uploadFile.fileUrl;
-                    riderDtos.Add(rider);
-                }
-                else
-                {
-                    riderDtos.Add(rider);
-                }
-            }
-
-            return riderDtos;
+            // Listing is a read-only database operation. URL refresh remains on the
+            // single-rider path so a page never performs one object-storage call per row.
+            return _riderService.GetRidersAsync(cursor, pageSize);
         }
 
         public async Task<RiderResponseDTO> GetRiderByUserIdAsync(string userId)

--- a/RiderManager/RiderManager/Repositories/IRiderRepository.cs
+++ b/RiderManager/RiderManager/Repositories/IRiderRepository.cs
@@ -1,12 +1,14 @@
 ﻿using RiderManager.Models;
 
+using ProjectY.Shared.Pagination;
+
 namespace RiderManager.Repositories
 {
     public interface IRiderRepository
     {
         Task<Rider> GetByIdAsync(string id);
         Task<Rider> GetByUserIdAsync(string userId);
-        Task<List<Rider>> GetAllAsync();
+        Task<CursorPage<Rider>> GetPageAsync(string? cursor, int? pageSize);
         Task AddAsync(Rider rider);
         Task UpdateAsync(Rider rider);
         Task DeleteAsync(string id);

--- a/RiderManager/RiderManager/Repositories/RiderRepository.cs
+++ b/RiderManager/RiderManager/Repositories/RiderRepository.cs
@@ -29,15 +29,17 @@ namespace RiderManager.Repositories
         {
             var size = CursorPagination.NormalizePageSize(pageSize);
             var afterId = CursorPagination.Decode(cursor);
-            var query = _context.Riders
+            var source = afterId is null
+                ? _context.Riders
+                : _context.Riders.FromSqlInterpolated($$"""
+                    SELECT * FROM "Riders"
+                    WHERE "Id" > {{afterId}}
+                    """);
+            var query = source
                 .AsNoTracking()
                 .Include(rider => rider.CNHUrl)
                 .OrderBy(rider => rider.Id)
                 .AsQueryable();
-            if (afterId is not null)
-            {
-                query = query.Where(rider => string.Compare(rider.Id, afterId) > 0);
-            }
 
             var fetched = await query.Take(size + 1).ToListAsync();
             return CursorPagination.CreatePage(fetched, size, rider => rider.Id);

--- a/RiderManager/RiderManager/Repositories/RiderRepository.cs
+++ b/RiderManager/RiderManager/Repositories/RiderRepository.cs
@@ -2,6 +2,8 @@
 using RiderManager.Data;
 using RiderManager.Models;
 
+using ProjectY.Shared.Pagination;
+
 namespace RiderManager.Repositories
 {
     public class RiderRepository : IRiderRepository
@@ -23,9 +25,22 @@ namespace RiderManager.Repositories
             return await _context.Riders.FirstOrDefaultAsync(r => r.UserId == userId);
         }
 
-        public async Task<List<Rider>> GetAllAsync()
+        public async Task<CursorPage<Rider>> GetPageAsync(string? cursor, int? pageSize)
         {
-            return await _context.Riders.ToListAsync();
+            var size = CursorPagination.NormalizePageSize(pageSize);
+            var afterId = CursorPagination.Decode(cursor);
+            var query = _context.Riders
+                .AsNoTracking()
+                .Include(rider => rider.CNHUrl)
+                .OrderBy(rider => rider.Id)
+                .AsQueryable();
+            if (afterId is not null)
+            {
+                query = query.Where(rider => string.Compare(rider.Id, afterId) > 0);
+            }
+
+            var fetched = await query.Take(size + 1).ToListAsync();
+            return CursorPagination.CreatePage(fetched, size, rider => rider.Id);
         }
 
         public async Task AddAsync(Rider rider)

--- a/RiderManager/RiderManager/RiderManager.csproj
+++ b/RiderManager/RiderManager/RiderManager.csproj
@@ -37,6 +37,7 @@
     <Compile Include="..\..\Shared\Hosting\DatabaseMigrationCommand.cs" Link="Shared\Hosting\DatabaseMigrationCommand.cs" />
     <Compile Include="..\..\Shared\Messaging\QueueMessageAuthenticator.cs" Link="Shared\Messaging\QueueMessageAuthenticator.cs" />
     <Compile Include="..\..\Shared\Idempotency\*.cs" Link="Shared\Idempotency\%(Filename)%(Extension)" />
+    <Compile Include="..\..\Shared\Pagination\*.cs" Link="Shared\Pagination\%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/RiderManager/RiderManager/Services/RiderServices/IRiderService.cs
+++ b/RiderManager/RiderManager/Services/RiderServices/IRiderService.cs
@@ -1,11 +1,13 @@
 ﻿using RiderManager.DTOs;
 using RiderManager.Models;
 
+using ProjectY.Shared.Pagination;
+
 namespace RiderManager.Services.RiderServices
 {
     public interface IRiderService
     {
-        Task<IEnumerable<RiderResponseDTO>> GetAllRidersAsync();
+        Task<CursorPage<RiderResponseDTO>> GetRidersAsync(string? cursor, int? pageSize);
         Task<RiderResponseDTO> GetRiderByUserIdAsync(string userId);
         Task<RiderResponseDTO> AddRiderAsync(RiderDTO riderDto);
         Task UpdateRiderAsync(string userId, RiderDTO riderDto);

--- a/RiderManager/RiderManager/Services/RiderServices/RiderService.cs
+++ b/RiderManager/RiderManager/Services/RiderServices/RiderService.cs
@@ -3,6 +3,8 @@ using RiderManager.DTOs;
 using RiderManager.Models;
 using RiderManager.Repositories;
 
+using ProjectY.Shared.Pagination;
+
 namespace RiderManager.Services.RiderServices
 {
     public class RiderService : IRiderService
@@ -16,10 +18,12 @@ namespace RiderManager.Services.RiderServices
             _mapper = mapper;
         }
 
-        public async Task<IEnumerable<RiderResponseDTO>> GetAllRidersAsync()
+        public async Task<CursorPage<RiderResponseDTO>> GetRidersAsync(string? cursor, int? pageSize)
         {
-            var riders = await _repository.GetAllAsync();
-            return _mapper.Map<IEnumerable<RiderResponseDTO>>(riders);
+            var page = await _repository.GetPageAsync(cursor, pageSize);
+            return new CursorPage<RiderResponseDTO>(
+                _mapper.Map<IReadOnlyList<RiderResponseDTO>>(page.Items),
+                page.NextCursor);
         }
 
         public async Task<RiderResponseDTO> GetRiderByUserIdAsync(string userId)

--- a/RiderManager/RiderManagerTests/Integration/PostgreSql/MigrationTests.cs
+++ b/RiderManager/RiderManagerTests/Integration/PostgreSql/MigrationTests.cs
@@ -95,7 +95,7 @@ public sealed class MigrationTests : IAsyncLifetime
         Assert.Null(second.NextCursor);
         Assert.Equal("https://storage.example.test/cnh-rider-0000", first.Items[0].CNHUrl?.Url);
         Assert.Empty(first.Items.Select(item => item.Id).Intersect(second.Items.Select(item => item.Id)));
-        Assert.Contains(sql, command => command.Contains("WHERE \"Id\" >", StringComparison.Ordinal));
+        Assert.Contains(sql, command => command.Contains("\"Id\" > @", StringComparison.Ordinal));
         Assert.DoesNotContain(sql, command => command.Contains("CASE", StringComparison.Ordinal));
     }
 }

--- a/RiderManager/RiderManagerTests/Integration/PostgreSql/MigrationTests.cs
+++ b/RiderManager/RiderManagerTests/Integration/PostgreSql/MigrationTests.cs
@@ -77,9 +77,16 @@ public sealed class MigrationTests : IAsyncLifetime
         }));
         await context.SaveChangesAsync();
         context.ChangeTracker.Clear();
-        var repository = new RiderRepository(context);
+        var sql = new List<string>();
+        var listingOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(_database.GetConnectionString())
+            .LogTo(sql.Add)
+            .Options;
+        await using var listingContext = new ApplicationDbContext(listingOptions);
+        var repository = new RiderRepository(listingContext);
 
         var first = await repository.GetPageAsync(null, 1_000);
+        sql.Clear();
         var second = await repository.GetPageAsync(first.NextCursor, 1_000);
 
         Assert.Equal(100, first.Items.Count);
@@ -88,6 +95,8 @@ public sealed class MigrationTests : IAsyncLifetime
         Assert.Null(second.NextCursor);
         Assert.Equal("https://storage.example.test/cnh-rider-0000", first.Items[0].CNHUrl?.Url);
         Assert.Empty(first.Items.Select(item => item.Id).Intersect(second.Items.Select(item => item.Id)));
+        Assert.Contains(sql, command => command.Contains("WHERE \"Id\" >", StringComparison.Ordinal));
+        Assert.DoesNotContain(sql, command => command.Contains("CASE", StringComparison.Ordinal));
     }
 }
 

--- a/RiderManager/RiderManagerTests/Integration/PostgreSql/MigrationTests.cs
+++ b/RiderManager/RiderManagerTests/Integration/PostgreSql/MigrationTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using RiderManager.Data;
 using RiderManager.Models;
+using RiderManager.Repositories;
 using Testcontainers.PostgreSql;
 
 namespace RiderManagerTests.Integration.PostgreSql;
@@ -43,6 +44,50 @@ public sealed class MigrationTests : IAsyncLifetime
         Assert.Equal(2, (await context.Database.GetAppliedMigrationsAsync()).Count());
         Assert.Equal(1, await context.Riders.CountAsync());
         Assert.Empty(await context.InboxMessages.ToListAsync());
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task RiderListing_IsCursorPagedBoundedAndLoadsStoredUrlsInOneQuery()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(_database.GetConnectionString())
+            .Options;
+        await using var context = new ApplicationDbContext(options);
+        await context.Database.MigrateAsync();
+        context.Riders.AddRange(Enumerable.Range(0, 105).Select(index => new Rider
+        {
+            Id = $"rider-{index:D4}",
+            UserId = $"user-{index:D4}",
+            Email = $"rider-{index:D4}@example.test",
+            Name = $"Rider {index:D4}",
+            CNPJ = $"{index:D14}",
+            DateOfBirth = DateTime.UtcNow.AddYears(-25),
+            CNHNumber = $"{index:D11}",
+            CNHType = "A",
+            CNHUrl = index == 0
+                ? new PresignedUrl
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    ObjectName = "cnh-rider-0000",
+                    Url = "https://storage.example.test/cnh-rider-0000",
+                    Expiry = DateTime.UtcNow.AddHours(1)
+                }
+                : null
+        }));
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+        var repository = new RiderRepository(context);
+
+        var first = await repository.GetPageAsync(null, 1_000);
+        var second = await repository.GetPageAsync(first.NextCursor, 1_000);
+
+        Assert.Equal(100, first.Items.Count);
+        Assert.Equal(5, second.Items.Count);
+        Assert.NotNull(first.NextCursor);
+        Assert.Null(second.NextCursor);
+        Assert.Equal("https://storage.example.test/cnh-rider-0000", first.Items[0].CNHUrl?.Url);
+        Assert.Empty(first.Items.Select(item => item.Id).Intersect(second.Items.Select(item => item.Id)));
     }
 }
 

--- a/RiderManager/RiderManagerTests/Unit/Managers/RidersManagerTests.cs
+++ b/RiderManager/RiderManagerTests/Unit/Managers/RidersManagerTests.cs
@@ -1,0 +1,44 @@
+using Moq;
+using ProjectY.Shared.Pagination;
+using RiderManager.DTOs;
+using RiderManager.Managers;
+using RiderManager.Services.MinioStorageService;
+using RiderManager.Services.PreSignedService;
+using RiderManager.Services.RiderServices;
+
+namespace RiderManagerTests.Unit.Managers;
+
+public sealed class RidersManagerTests
+{
+    [Fact]
+    public async Task Listing_DoesNotRefreshPresignedUrlsPerRider()
+    {
+        var page = new CursorPage<RiderResponseDTO>(
+            [
+                CreateRider("rider-1"),
+                CreateRider("rider-2")
+            ],
+            "next");
+        var riderService = new Mock<IRiderService>();
+        riderService.Setup(service => service.GetRidersAsync("cursor", 50)).ReturnsAsync(page);
+        var storage = new Mock<IMinioFileStorageService>(MockBehavior.Strict);
+        var presignedUrls = new Mock<IPresignedUrlService>(MockBehavior.Strict);
+        var manager = new RidersManager(riderService.Object, storage.Object, presignedUrls.Object);
+
+        var result = await manager.GetRidersAsync("cursor", 50);
+
+        Assert.Same(page, result);
+        storage.VerifyNoOtherCalls();
+        presignedUrls.VerifyNoOtherCalls();
+    }
+
+    private static RiderResponseDTO CreateRider(string id) => new()
+    {
+        Id = id,
+        UserId = id,
+        Name = id,
+        CNPJ = id,
+        CNHNumber = id,
+        CNHType = "A"
+    };
+}

--- a/Shared/Pagination/CursorPage.cs
+++ b/Shared/Pagination/CursorPage.cs
@@ -1,0 +1,54 @@
+using System.Text;
+
+namespace ProjectY.Shared.Pagination;
+
+public sealed record CursorPage<T>(IReadOnlyList<T> Items, string? NextCursor);
+
+public static class CursorPagination
+{
+    public const int DefaultPageSize = 25;
+    public const int MaximumPageSize = 100;
+
+    public static int NormalizePageSize(int? pageSize) =>
+        Math.Clamp(pageSize ?? DefaultPageSize, 1, MaximumPageSize);
+
+    public static string Encode(string value)
+    {
+        var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+        return base64.TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+
+    public static string? Decode(string? cursor)
+    {
+        if (string.IsNullOrWhiteSpace(cursor))
+        {
+            return null;
+        }
+
+        try
+        {
+            var base64 = cursor.Replace('-', '+').Replace('_', '/');
+            base64 = base64.PadRight(base64.Length + ((4 - base64.Length % 4) % 4), '=');
+            var value = Encoding.UTF8.GetString(Convert.FromBase64String(base64));
+            return string.IsNullOrWhiteSpace(value)
+                ? throw new FormatException("The pagination cursor is empty.")
+                : value;
+        }
+        catch (FormatException exception)
+        {
+            throw new FormatException("The pagination cursor is invalid.", exception);
+        }
+    }
+
+    public static CursorPage<T> CreatePage<T>(
+        IReadOnlyList<T> fetched,
+        int pageSize,
+        Func<T, string> cursorValue)
+    {
+        var items = fetched.Take(pageSize).ToList();
+        var nextCursor = fetched.Count > pageSize && items.Count > 0
+            ? Encode(cursorValue(items[^1]))
+            : null;
+        return new CursorPage<T>(items, nextCursor);
+    }
+}

--- a/docs/performance/pagination-growth.md
+++ b/docs/performance/pagination-growth.md
@@ -1,0 +1,16 @@
+# Pagination growth proof
+
+Issue #98 makes every public collection endpoint cursor-paged with a server-side maximum of 100 rows. The database plans are guarded by integration tests:
+
+- MotoHub lists active motorcycles through `IX_Motorcycles_Active_Id`.
+- RiderManager walks the rider primary key and joins the stored CNH URL in the same query.
+- RentalOperations lists a user's rentals through `ix_rentals_user_cursor`; motorcycle availability and overlap predicates run inside MongoDB and are index-backed.
+
+Run the growth check against the root Compose stack with a local k6 binary after obtaining an admin JWT for MotoHub:
+
+```powershell
+$env:ADMIN_TOKEN = '<admin-jwt>'
+k6 run load/k6/pagination-growth.js
+```
+
+The script seeds a baseline, measures its p99, adds 2,000 rows, then measures the same bounded first-page query under load. It fails when fewer than 99% of grown-dataset requests stay within `MAX_P99_GROWTH_RATIO` (default `1.50`) plus a small jitter allowance. `BASELINE_RECORDS`, `GROWTH_RECORDS`, `BASELINE_SAMPLES`, `VUS`, and `DURATION` are configurable environment variables.

--- a/load/k6/pagination-growth.js
+++ b/load/k6/pagination-growth.js
@@ -1,0 +1,146 @@
+import http from "k6/http";
+import { check, fail, sleep } from "k6";
+import { Gauge, Rate, Trend } from "k6/metrics";
+
+const BASE_URL = __ENV.MOTO_HUB_URL || "http://localhost:8100";
+const ADMIN_TOKEN = __ENV.ADMIN_TOKEN || "";
+const BASELINE_RECORDS = parseInt(__ENV.BASELINE_RECORDS || "100", 10);
+const GROWTH_RECORDS = parseInt(__ENV.GROWTH_RECORDS || "2000", 10);
+const BASELINE_SAMPLES = parseInt(__ENV.BASELINE_SAMPLES || "40", 10);
+const MAX_P99_GROWTH_RATIO = parseFloat(__ENV.MAX_P99_GROWTH_RATIO || "1.50");
+const MIN_JITTER_BUDGET_MS = parseFloat(__ENV.MIN_JITTER_BUDGET_MS || "20");
+
+const baselineP99 = new Gauge("pagination_baseline_p99_ms");
+const grownLatency = new Trend("pagination_grown_dataset_ms", true);
+const flatAtP99 = new Rate("pagination_flat_at_p99");
+
+export const options = {
+  scenarios: {
+    grownDataset: {
+      executor: "constant-vus",
+      vus: parseInt(__ENV.VUS || "10", 10),
+      duration: __ENV.DURATION || "30s",
+      gracefulStop: "5s",
+    },
+  },
+  thresholds: {
+    checks: ["rate>0.99"],
+    pagination_flat_at_p99: ["rate>=0.99"],
+  },
+  discardResponseBodies: false,
+  setupTimeout: __ENV.SETUP_TIMEOUT || "10m",
+};
+
+function headers(idempotencyKey) {
+  const result = {
+    Authorization: `Bearer ${ADMIN_TOKEN}`,
+    "Content-Type": "application/json",
+  };
+  if (__ENV.MOTO_HUB_API_KEY) {
+    result["X-API-Key"] = __ENV.MOTO_HUB_API_KEY;
+  }
+  if (idempotencyKey) {
+    result["Idempotency-Key"] = idempotencyKey;
+  }
+  return result;
+}
+
+function seed(count, prefix) {
+  const batchSize = 20;
+  for (let offset = 0; offset < count; offset += batchSize) {
+    const requests = [];
+    for (let index = offset; index < Math.min(offset + batchSize, count); index += 1) {
+      requests.push({
+        method: "POST",
+        url: `${BASE_URL}/api/Motorcycles`,
+        body: JSON.stringify({
+          year: 2026,
+          model: "Pagination growth proof",
+          licensePlate: `${prefix}-${index}`,
+        }),
+        params: {
+          headers: headers(`${prefix}-${index}`),
+          tags: { name: "seed motorcycles" },
+        },
+      });
+    }
+
+    const responses = http.batch(requests);
+    for (const response of responses) {
+      if (response.status !== 200 && response.status !== 409) {
+        fail(`Seed failed with HTTP ${response.status}: ${response.body}`);
+      }
+    }
+  }
+}
+
+function sampleP99(sampleCount) {
+  const durations = [];
+  for (let index = 0; index < sampleCount; index += 1) {
+    const response = http.get(`${BASE_URL}/api/Motorcycles?pageSize=100`, {
+      headers: headers(),
+      tags: { name: "baseline motorcycle page" },
+    });
+    if (response.status !== 200) {
+      fail(`Baseline listing failed with HTTP ${response.status}: ${response.body}`);
+    }
+    durations.push(response.timings.duration);
+  }
+
+  durations.sort((left, right) => left - right);
+  return durations[Math.max(0, Math.ceil(durations.length * 0.99) - 1)];
+}
+
+export function setup() {
+  if (!ADMIN_TOKEN) {
+    fail("ADMIN_TOKEN is required to seed and query MotoHub.");
+  }
+
+  const runId = `${Date.now()}-${Math.floor(Math.random() * 100000)}`;
+  seed(BASELINE_RECORDS, `BASE-${runId}`);
+  const measuredBaselineP99 = sampleP99(BASELINE_SAMPLES);
+  seed(GROWTH_RECORDS, `GROW-${runId}`);
+
+  return {
+    measuredBaselineP99,
+    allowedDuration: Math.max(
+      measuredBaselineP99 * MAX_P99_GROWTH_RATIO,
+      measuredBaselineP99 + MIN_JITTER_BUDGET_MS,
+    ),
+  };
+}
+
+export default function (data) {
+  const response = http.get(`${BASE_URL}/api/Motorcycles?pageSize=100`, {
+    headers: headers(),
+    tags: { name: "grown motorcycle page" },
+  });
+
+  baselineP99.add(data.measuredBaselineP99);
+  grownLatency.add(response.timings.duration);
+  flatAtP99.add(response.status === 200 && response.timings.duration <= data.allowedDuration);
+  check(response, {
+    "listing succeeds": (result) => result.status === 200,
+    "page remains server bounded": (result) => {
+      try {
+        return JSON.parse(result.body).items.length <= 100;
+      } catch (_) {
+        return false;
+      }
+    },
+  });
+  sleep(0.05);
+}
+
+export function handleSummary(data) {
+  const baseline = data.metrics.pagination_baseline_p99_ms?.values?.value || 0;
+  const grown = data.metrics.pagination_grown_dataset_ms?.values?.["p(99)"] || 0;
+  const ratio = baseline > 0 ? grown / baseline : 0;
+  return {
+    stdout:
+      "\nProjectY pagination growth proof\n" +
+      `baseline p99: ${baseline.toFixed(2)} ms\n` +
+      `grown dataset p99: ${grown.toFixed(2)} ms\n` +
+      `p99 growth ratio: ${ratio.toFixed(2)}x (limit ${MAX_P99_GROWTH_RATIO.toFixed(2)}x plus jitter budget)\n\n`,
+  };
+}


### PR DESCRIPTION
## Summary

- add a shared opaque cursor contract with a default page size of 25 and a server maximum of 100
- paginate the MotoHub, RiderManager, and RentalOperations collection endpoints with stable primary-key/ObjectId traversal
- move rental overlap and current-status predicates into MongoDB and add the supporting Mongo/PostgreSQL indexes
- remove RiderManager's per-rider presigned URL refresh from list requests and load stored URL metadata in the listing query
- add bounded-page, cursor continuity, N+1, migration, and query-plan regression coverage plus a k6 data-growth proof

## Validation

- `dotnet build AuthGate/AuthGate.sln --no-restore`
- `dotnet build MotoHub/MotoHub.sln --no-restore`
- `dotnet build RiderManager/RiderManager.sln --no-restore`
- `dotnet build RentalOperations/RentalOperations.sln --no-restore`
- MotoHub unit tests: 29 passed
- RiderManager unit tests: 8 passed
- RentalOperations unit tests: 10 passed
- PostgreSQL/MongoDB integration tests and the k6 run require Docker/k6 and are left to the PR environment

Refs #98
