### PR TITLE
chore(deps): update container images and fix the config they break

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,15 @@ updates:
       time: "09:00"
       timezone: America/Manaus
     groups:
+      # Minor and patch bumps travel together; majors arrive as individual PRs
+      # so each one can be reviewed and smoke-tested on its own. A bundle of
+      # sixteen updates where one breaks the stack is not reviewable.
       container-images:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: docker
     directories:
@@ -30,3 +36,6 @@ updates:
       dotnet-base-images:
         patterns:
           - "mcr.microsoft.com/dotnet/*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/deploy/base/compose.yaml
+++ b/deploy/base/compose.yaml
@@ -25,7 +25,7 @@ services:
   # ─────────────────────────────────────────────────────────────────────────
 
   cockroachdb:
-    image: cockroachdb/cockroach:v24.3.5
+    image: cockroachdb/cockroach:v26.3.1
     volumes:
       - cockroach-data:/cockroach/cockroach-data
     networks: [projecty]
@@ -37,7 +37,7 @@ services:
       start_period: 20s
 
   cockroach-init:
-    image: cockroachdb/cockroach:v24.3.5
+    image: cockroachdb/cockroach:v26.3.1
     entrypoint: ["cockroach", "sql"]
     networks: [projecty]
     depends_on:
@@ -45,7 +45,7 @@ services:
         condition: service_healthy
 
   redis:
-    image: redis:7.4-alpine
+    image: redis:8.10-alpine
     command: ["redis-server", "--appendonly", "yes", "--appendfsync", "always"]
     volumes:
       - redis-data:/data
@@ -57,7 +57,7 @@ services:
       retries: 12
 
   rabbitmq:
-    image: rabbitmq:4.0-management-alpine
+    image: rabbitmq:4.3-management-alpine
     volumes:
       - rabbitmq-data:/var/lib/rabbitmq
     networks: [projecty]
@@ -69,7 +69,7 @@ services:
       start_period: 20s
 
   kafka:
-    image: apache/kafka:3.9.0
+    image: apache/kafka:4.3.1
     volumes:
       - kafka-data:/var/lib/kafka/data
     networks: [projecty]
@@ -93,7 +93,7 @@ services:
       start_period: 60s
 
   mongodb:
-    image: mongo:8.0
+    image: mongo:8.3
     volumes:
       - mongo-data:/data/db
     networks: [projecty]
@@ -120,7 +120,7 @@ services:
   # ─────────────────────────────────────────────────────────────────────────
 
   toxiproxy:
-    image: ghcr.io/shopify/toxiproxy:2.11.0
+    image: ghcr.io/shopify/toxiproxy:2.12.0
     networks: [projecty]
     healthcheck:
       test: ["CMD", "/toxiproxy-cli", "list"]
@@ -148,7 +148,7 @@ services:
       start_period: 10s
 
   prometheus:
-    image: prom/prometheus:v3.2.1
+    image: prom/prometheus:v3.14.0
     volumes:
       - prometheus-data:/prometheus
     networks: [projecty]
@@ -163,7 +163,7 @@ services:
       start_period: 10s
 
   tempo:
-    image: grafana/tempo:2.7.1
+    image: grafana/tempo:3.0.3
     volumes:
       - tempo-data:/var/tempo
     networks: [projecty]
@@ -175,7 +175,7 @@ services:
       start_period: 10s
 
   loki:
-    image: grafana/loki:3.4.2
+    image: grafana/loki:3.7.7
     volumes:
       - loki-data:/loki
     networks: [projecty]
@@ -187,7 +187,7 @@ services:
       start_period: 10s
 
   grafana:
-    image: grafana/grafana:11.6.0
+    image: grafana/grafana:13.2.0
     volumes:
       - grafana-data:/var/lib/grafana
     networks: [projecty]
@@ -332,7 +332,7 @@ services:
   # ─────────────────────────────────────────────────────────────────────────
 
   k6:
-    image: grafana/k6:0.57.0
+    image: grafana/k6:2.2.0
     networks: [projecty]
     depends_on:
       api-gateway:

--- a/deploy/overlays/selfhost/compose.override.yaml
+++ b/deploy/overlays/selfhost/compose.override.yaml
@@ -154,7 +154,6 @@ services:
       GF_SECURITY_ADMIN_USER: "${GRAFANA_USER:?Set GRAFANA_USER in .env}"
       GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_PASSWORD:?Set GRAFANA_PASSWORD in .env}"
       GF_USERS_DEFAULT_THEME: system
-      GF_FEATURE_TOGGLES_ENABLE: traceqlEditor,traceToMetrics
       GF_INSTALL_PLUGINS: ""
     ports:
       - "3001:3000"
@@ -270,7 +269,7 @@ services:
 
   k6:
     profiles: ["load"]
-    command: ["run", "--out", "experimental-prometheus-rw", "/scripts/rental-flow.js"]
+    command: ["run", "--out", "prometheus-rw", "/scripts/rental-flow.js"]
     environment:
       K6_PROMETHEUS_RW_SERVER_URL: http://prometheus:9090/api/v1/write
       K6_PROMETHEUS_RW_TREND_STATS: "p(95),p(99),min,max"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,11 +41,15 @@ x-moto-hub-environment: &moto-hub-environment
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.5.2
     container_name: elasticsearch
     environment:
       - discovery.type=single-node
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      # Explicit, not accidental: Elasticsearch 8+ enables security by default.
+      # Audit finding A1 documents this stack running without it. Kept visible
+      # rather than implicit until issue #63 retires ELK for the LGTM stack.
+      - xpack.security.enabled=false
     ports:
       - "9200:9200"
       - "9300:9300"
@@ -53,7 +57,7 @@ services:
       - elk
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.17.3
+    image: docker.elastic.co/logstash/logstash:9.5.2
     container_name: logstash
     volumes:
       - ./logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml
@@ -66,7 +70,7 @@ services:
       - elk
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.17.3
+    image: docker.elastic.co/kibana/kibana:9.5.2
     container_name: kibana
     ports:
       - "5601:5601"
@@ -78,7 +82,7 @@ services:
       - elk
 
   postgres:
-    image: postgres:15
+    image: postgres:18
     container_name: postgres
     environment:
       POSTGRES_USER: "${POSTGRES_USER:?Set POSTGRES_USER in .env}"
@@ -101,7 +105,7 @@ services:
       start_period: 10s
 
   redis:
-    image: redis:7.4-alpine
+    image: redis:8.10-alpine
     container_name: redis
     command: ["redis-server", "--appendonly", "yes", "--appendfsync", "always"]
     ports:
@@ -117,7 +121,7 @@ services:
       retries: 12
 
   pgadmin:
-    image: dpage/pgadmin4:9.13
+    image: dpage/pgadmin4:9.17
     container_name: pgadmin
     environment:
       PGADMIN_DEFAULT_EMAIL: "${PGADMIN_EMAIL:?Set PGADMIN_EMAIL in .env}"
@@ -130,7 +134,7 @@ services:
       - elk
 
   mongodb:
-    image: mongo:8.0
+    image: mongo:8.3
     container_name: mongodb
     ports:
       - "27017:27017"
@@ -149,7 +153,7 @@ services:
       start_period: 10s
 
   rabbitmq:
-    image: rabbitmq:3-management
+    image: rabbitmq:4-management
     container_name: rabbitmq
     networks:
       - elk


### PR DESCRIPTION
Supersedes the three open Dependabot PRs with one change that carries the bumps **and** the configuration each major requires. Merging the bundle on its own would have left the stack unable to start.

## Why not just merge #126

| PR | Verdict |
|---|---|
| #113 | Obsolete — bumps `sdk:8.0` to `sdk:10.0` in RiderManager, but all four Dockerfiles have been on `sdk:10.0` since #115. The PR was cut from an older `main` and its diff is already applied. |
| #114 | Superseded by #126 — same group, same 16 updates, older base. |
| #126 | Correct version numbers, but three of the majors need configuration changes that a version-string bump cannot carry. |

## Version bumps

**Modern stack** (`deploy/base/compose.yaml`) — cockroachdb `v24.3.5`→`v26.3.1`, kafka `3.9.0`→`4.3.1`, redis `7.4`→`8.10`, rabbitmq `4.0`→`4.3`, mongo `8.0`→`8.3`, toxiproxy `2.11.0`→`2.12.0`, prometheus `v3.2.1`→`v3.14.0`, tempo `2.7.1`→`3.0.3`, loki `3.4.2`→`3.7.7`, grafana `11.6.0`→`13.2.0`, k6 `0.57.0`→`2.2.0`.

**Legacy stack** (`docker-compose.yml`) — elasticsearch/logstash/kibana `7.17.3`→`9.5.2`, postgres `15`→`18`, redis `7.4`→`8.10`, pgadmin4 `9.13`→`9.17`, mongo `8.0`→`8.3`, rabbitmq `3-management`→`4-management`.

## Configuration the majors require

**k6** promoted the Prometheus remote-write output out of experimental in v1.0. The overlay invoked `--out experimental-prometheus-rw`; jumping to 2.x with that flag would fail to start. Now `--out prometheus-rw`.

**Elasticsearch 8+ enables xpack security by default.** Left implicit, the bump would either break Logstash and Kibana or silently change the posture that audit finding A1 documents. It is now disabled *explicitly*, with a comment, so the audited behaviour stays visible rather than accidental — until #63 retires ELK for the LGTM stack.

**Grafana feature toggles** `traceqlEditor` and `traceToMetrics` reached GA long before v13. Dead configuration; removed.

## Dependabot grouping

The root cause of a sixteen-update bundle is `groups: patterns: ["*"]` with no `update-types`. Minor and patch bumps now travel together; majors arrive as individual PRs, each reviewable and smoke-testable on its own.

## Verification, and its limits

Passing:
- `docker compose config` on the legacy stack
- `docker compose config` on `deploy/base/compose.yaml`
- `docker compose config` on base + selfhost overlay, with `--profile init`

Not done, and worth knowing before merging:
- **Registry access is unavailable from the environment this was prepared in.** Tag existence comes from Dependabot's resolution, which reads the registries directly — but no tag was independently confirmed here.
- **No container was started.** Config schema changes in Tempo 3.x and Kafka 4.x cannot be ruled out statically; one `tilt up` is the real check.
- **Volumes will not survive these major jumps** — cockroachdb skips a major, postgres crosses three. A `down -v` is required. Acceptable here because all local data is disposable.

## Noted, not fixed

The base + overlay composition only validates with `--profile init`, because `rental-core` depends on the profile-gated `cockroach-init`. This is pre-existing on `main` — verified against the current head — and out of scope here.

`docker-compose.yml` still carries an obsolete top-level `version:` key that Compose warns about.

## Related

Closes #113, closes #114, closes #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQRkUCjsVNmzUaV5qp4SvM


---
_Generated by [Claude Code](https://claude.ai/code/session_01PQRkUCjsVNmzUaV5qp4SvM)_