### PR TITLE
fix(dev): stop gating cockroach-init behind a mandatory profile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -51,7 +51,7 @@ if missing_local_files:
     ) % ', '.join(missing_local_files)
     fail(missing_files_message)
 
-profiles = ['init', 'full'] if full else ['init']
+profiles = ['full'] if full else []
 docker_compose(
     'deploy/overlays/selfhost/compose.yaml',
     env_file = '.env',

--- a/deploy/overlays/selfhost/compose.override.yaml
+++ b/deploy/overlays/selfhost/compose.override.yaml
@@ -22,7 +22,6 @@ services:
       - "26080:8080"
 
   cockroach-init:
-    profiles: ["init"]
     command: ["--insecure", "--host=cockroachdb:26257", "--file=/sql/001_init.sql"]
     volumes:
       - ./db/cockroach:/sql:ro


### PR DESCRIPTION
Every documented compose command in `docs/getting-started.md` fails on the current `main`:

```
service "rental-core" depends on undefined service "cockroach-init": invalid compose project
```

Reproduced against `origin/main` with the exact command the guide gives at line 203.

## The cause

`cockroach-init` applies the core schema, and `rental-core` declares `condition: service_completed_successfully` on it — so `rental-core` cannot start without it. The selfhost overlay nonetheless placed it behind a profile named `init`, and Compose rejects a service in the always-on set depending on a profile-gated one.

**A profile that must always be enabled is not a profile.** `cockroach-init` belongs to the default set.

## Why this was invisible

`tilt up` always worked, because the Tiltfile passed the profile itself:

```python
profiles = ['init', 'full'] if full else ['init']
```

The breakage was confined to manual invocation — which is exactly the path the getting-started guide documents, and the path anyone reproducing the stack without Tilt takes. The Tiltfile was compensating for the bug rather than exposing it.

## The change

Two lines: drop `profiles: ["init"]` from `cockroach-init`, and drop `init` from the Tiltfile's profile list. `full` and `load` remain real profiles and are untouched.

## Verification

`docker compose config` against the selfhost overlay:

| Check | Result |
|---|---|
| Documented command, no profile flag | validates |
| `--profile full` | resolves |
| `cockroach-init` in default service set | yes |
| `cassandra`, `mongodb`, `minio`, `console`, `telemetry` in default set | no — still `full`-only |
| `k6` in default set / under `--profile load` | no / yes |

Not covered: the Tiltfile edit itself. Tilt is not installed in the environment this was prepared in, so `profiles = []` for the core profile is unverified at runtime — it is the natural empty case for the same argument, but worth one `tilt up` to confirm.

## Context

Found while validating #127. I had flagged it there as pre-existing and out of scope; it is pre-existing, but "the documented quickstart does not run" earns its own fix rather than a footnote.

Independent of #127 — no overlapping files beyond the overlay, and the two do not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQRkUCjsVNmzUaV5qp4SvM


---
_Generated by [Claude Code](https://claude.ai/code/session_01PQRkUCjsVNmzUaV5qp4SvM)_