### PR TITLE
docs(adr): assign the identity and rider domains, and move to asymmetric tokens

### DIFF
--- a/docs/adr/0001-polyglot-technology-choices.md
+++ b/docs/adr/0001-polyglot-technology-choices.md
@@ -30,6 +30,13 @@ next to the code.**
 | Transactional store | Postgres-compatible | Serializable isolation, and a partial unique index that makes double-booking impossible in the database |
 | Time series | Cassandra | Write-heavy, partition-scoped reads, data that ages out — the canonical case |
 | Coordination | Redis | Rate limiting, token revocation, idempotency keys, distributed locks — shared low-latency state, not "the cache" |
+| Identity | Go | The exception: no workload argument. Adopted for the OIDC and OAuth2 ecosystem, and stated as an ecosystem choice in ADR 0012 rather than dressed as a workload one |
+| Rider records | .NET 10 | Regulatory documents kept in their own store and behind their own IAM role, so a compromise of rentals does not reach CNPJ and CNH |
+
+**This table assigns technology to workload; it is not the service inventory.**
+Reading it as one is how the identity and rider domains went unassigned — see
+ADR 0012, which adds `identity` and `rider-core` and records why `identity` is
+the single entry here justified by ecosystem rather than by workload.
 
 The command-versus-event split is the decision most likely to be challenged, so
 it is made visible in naming: commands are `cmd.*` queues, events are

--- a/docs/adr/0002-development-loop-and-containers.md
+++ b/docs/adr/0002-development-loop-and-containers.md
@@ -25,7 +25,7 @@ variants living as overlays rather than branches.**
 - `local_resource` owns migrations, schema creation and topic creation — setup
   steps that live in README prose are steps nobody runs.
 
-Three invariants hold for all six images: multi-stage build leaving the
+Three invariants hold for all eight images (six here plus `identity` and `rider-core` from ADR 0012): multi-stage build leaving the
 toolchain behind, a non-root user in the final image, and an exec-form
 `ENTRYPOINT`.
 

--- a/docs/adr/0011-deployment-variants-as-overlays.md
+++ b/docs/adr/0011-deployment-variants-as-overlays.md
@@ -1,4 +1,4 @@
-# ADR 0008: Keep deployment variants as overlays
+# ADR 0011: Keep deployment variants as overlays
 
 ## Status
 

--- a/docs/adr/0012-identity-and-rider-domains.md
+++ b/docs/adr/0012-identity-and-rider-domains.md
@@ -1,0 +1,130 @@
+# ADR 0012 — The identity and rider domains get their own services
+
+- **Status:** Accepted
+- **Date:** 2026-09-01
+- **Related findings:** B10
+- **Refines:** ADR 0001
+
+## Context
+
+ADR 0001 lists **technology roles** — which runtime serves which kind of work.
+That table then became the service inventory in ADR 0002's image list and in the
+cloud topology, without anyone deciding it should. Six roles, six images.
+
+Two legacy domains never got a row. The strangler migration maps `moto-hub` and
+`rental-operations` onto `rental-core`, which matches
+`deploy/db/cockroach/001_init.sql` exactly — `motorcycles` and `rentals`, and
+nothing else. `auth-gate` and `rider-manager` had no target at all.
+
+The rest of the design already depends on both existing:
+
+- ADR 0006 and ADR 0008 name AuthGate the sole token issuer.
+- `rentals.rider_id STRING NOT NULL` is a reference with no owning service.
+- Cassandra partitions `rider_positions` by `rider_id`.
+- `risk-pricing` cross-checks an OCR'd CNH number against what the rider
+  registered — a record that no service owns.
+- `media-guard` owns the CNH *file*; nothing owns the *record* that links a
+  rider to the stored object.
+
+## Decision
+
+**Eight services, not six.** `identity` and `rider-core` join the target
+architecture.
+
+### identity — Go
+
+Users, roles, credentials and token issuance. Its own database.
+
+Go is adopted here on **ecosystem grounds, not workload** — and this record says
+so plainly rather than inventing a workload argument after the fact. Identity's
+work is CRUD, password hashing and token minting, all on the cold path: login
+happens once per session, and the gateway does the per-request verification.
+There is no latency or concurrency case, which is exactly what every other row
+of ADR 0001 rests on.
+
+What Go does bring: it is the lingua franca of identity infrastructure, with the
+strongest OIDC and OAuth2 library ecosystem of any option here, and it is the one
+major backend language absent from this stack.
+
+Naming the different basis keeps ADR 0001's rule intact. Bending the rule
+silently would corrupt the thing that makes that record credible.
+
+### rider-core — .NET
+
+Rider records: CNPJ, CNH number and type, date of birth, and the pointer to the
+object `media-guard` stored. Its own database.
+
+Not folded into `rental-core`: that merges two bounded contexts, and — the
+stronger reason — it puts CNPJ and CNH in the same store as rentals and money.
+A separate store with its own IAM role keeps the blast radius small, which is
+the same argument that closed finding A2.
+
+Not folded into `identity`: credentials and regulatory documents have different
+lifecycles and different sensitivity. Merging them means the credential store
+also holds CNH numbers.
+
+### The file/record split
+
+`media-guard` owns the **file** pipeline — validate the real bytes, strip EXIF,
+re-encode, store, issue access. `rider-core` owns the **record** — which rider,
+which object key, which expiry. Both earlier documents left this ambiguous and
+implied `media-guard` did both.
+
+### One identifier, everywhere
+
+`rider_id` appears in three places in the target design: `rentals.rider_id`,
+Cassandra's `rider_positions.rider_id`, and the JWT `sub`. **These are the same
+value.** The identity subject is the rider identifier; `rider-core` keys its
+records on it and mints no surrogate of its own.
+
+Finding B10 was `Rider.Id` and `Rider.UserId` used as if they were one key, which
+threw `ArgumentException("Rider not found")` on the image path. Task #99
+reconciled the legacy usage, but the model still carries both fields and no
+record said which one is canonical. Without this decision the same bug
+regenerates across service boundaries, where it is far harder to catch than
+inside one class.
+
+## Alternatives considered
+
+- **Keep identity in .NET.** The cheaper and workload-justified option, and the
+  one originally recommended: C1, C2, C3 and ADR 0007's signed queue envelope
+  were all earned inside AuthGate, and a rewrite means earning them again.
+  Overridden deliberately to widen ecosystem coverage; the cost is accepted, not
+  overlooked.
+- **Fold identity into the gateway.** Rejected: ADR 0008 mitigates the gateway
+  being a single point of failure for authentication precisely by it holding no
+  state. A user database destroys that property.
+- **Cognito or another managed identity provider.** Rejected in ADR 0004 as a
+  one-way door, and because authentication is part of what this repository sets
+  out to demonstrate.
+- **Rust, Elixir, Python or Node for identity.** Each has a workload argument in
+  ADR 0001 that identity does not match — hostile input at high throughput, long
+  lived connections, statistical work, I/O fan-out with shared types.
+
+## What was explicitly rejected
+
+Retrofitting a workload justification for Go. It is an ecosystem choice, and the
+record states it as one.
+
+`rider-core` minting its own surrogate key for riders.
+
+## Consequences
+
+- **Seven languages on a solo repository.** ADR 0005 and the evidence review
+  already name breadth as the main misreading risk for this project. This makes
+  it worse, and the countermeasure does not change: the deep column stays
+  distributed consistency, which identity does not feed.
+- **Password migration is the real work, not the rewrite.** AuthGate stores
+  ASP.NET Identity PBKDF2 hashes. The Go service must verify that format on
+  first login and re-hash to Argon2id on success, or every existing user is
+  locked out. Dual-verify is the migration path; a forced reset is the fallback,
+  and it is worse.
+- **ADR 0007's signed queue envelope is issued by AuthGate today.** The Go
+  service must reproduce it byte-for-byte or the authenticated queue boundary
+  regresses and finding C5 reopens.
+- Two more databases, two more IAM roles, two more images in the supply chain.
+
+## Follow-up
+
+- ADR 0013 — asymmetric signing, shipped with this move rather than after it.
+- Epic and tasks for the two services, the schemas and the identifier migration.

--- a/docs/adr/0013-asymmetric-token-signing.md
+++ b/docs/adr/0013-asymmetric-token-signing.md
@@ -1,0 +1,79 @@
+# ADR 0013 — Tokens are signed asymmetrically and validated from a JWKS
+
+- **Status:** Accepted
+- **Date:** 2026-09-01
+- **Supersedes:** the signing half of ADR 0006
+- **Related findings:** C3
+
+## Context
+
+ADR 0006 replaced the single shared JWT key from finding C3 with one symmetric
+key per audience. That was a real improvement — a leaked key stopped working on
+sibling services — and its consequences section already flags what remained:
+compromising the issuer exposes every signing key.
+
+It does not record the sharper consequence. Under HMAC the validator key **is**
+the signing key. Every service holds a secret that can *mint* tokens for its own
+audience, not merely verify them. The record says a leaked validator key does not
+work on siblings, which is true; it works perfectly well on itself, and a service
+compromised through any other path can forge its own callers.
+
+Rotation has the matching problem: changing a key means distributing a new secret
+to whichever services validate that audience.
+
+## Decision
+
+**EdDSA (Ed25519) signing, with public keys published as a JWKS.**
+
+- `identity` holds the private keys and is the only component that can sign.
+- `identity` serves `/.well-known/jwks.json`, and an OIDC discovery document
+  alongside it — the discovery document is cheap and makes the service legible to
+  standard tooling.
+- Validators fetch the JWKS and select the key by `kid`. **No validator holds a
+  secret capable of signing anything.**
+- Rotation: publish the new key first, sign with it only after propagation,
+  overlap for at least one token lifetime, then retire the old one. Rotation is a
+  JWKS update, not a secret distribution.
+- Under ADR 0008 the gateway is the only validator on the request path, so it is
+  the primary JWKS consumer. It caches with a bounded TTL, refetches once on an
+  unknown `kid`, rate-limits that refetch, and **fails closed** when the JWKS
+  cannot be resolved — consistent with the posture ADR 0003 sets for token
+  verification.
+
+This ships **with** the Go rewrite in ADR 0012, not after it.
+
+## Alternatives considered
+
+- **RS256.** Equally standard and equally well supported. EdDSA chosen for
+  smaller keys and signatures and faster verification; the gateway verifies on
+  every request, so verification cost is the one that compounds.
+- **Keep symmetric per-audience keys.** The status quo. Cheapest, and it leaves
+  every validator holding a minting key.
+- **A full OIDC provider — authorization code flow, consent, clients.** Out of
+  scope. The useful subset here is asymmetric signing, a JWKS and discovery;
+  the rest is surface without a consumer.
+
+## What was explicitly rejected
+
+Rewriting identity in Go while keeping hand-rolled symmetric HMAC. That is the
+worst available combination: the full cost of a rewrite with none of the security
+gain. The two changes are deliberately coupled — the rewrite is the moment the
+signing scheme is cheapest to change, and doing one without the other wastes it.
+
+## Consequences
+
+- The gateway gains a network dependency on `identity` for key material. It is
+  bounded by the cache, and the failure mode is deliberate: unresolvable JWKS
+  means requests are refused, not waved through.
+- Key rotation becomes an operation with a procedure, which is more moving parts
+  than a static secret and the reason it can actually be performed.
+- Tests must cover: a valid token, an unknown `kid`, a key retired mid-flight,
+  and the JWKS endpoint unreachable.
+- ADR 0006's secret-loading half stands unchanged. Only its signing table is
+  superseded.
+
+## Follow-up
+
+- ADR 0012 — the Go identity service this ships with.
+- The validator side lands in the gateway epic; the issuer side in the identity
+  epic.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,14 +21,20 @@ is what separates a decision from a preference.
 | [0008](0008-single-trust-boundary.md) | One trust boundary, at the edge | Why domain services stop parsing tokens, and what is traded for it |
 | [0009](0009-exactly-once-effect.md) | Exactly-once effect is layered and bounded | Which layer provides each guarantee, how it fails, and what is deliberately not promised |
 | [0010](0010-motorcycle-retirement-protocol.md) | Serialize motorcycle retirement with rental claims | How retirement races rentals and how legacy orphan plates remain resolvable |
+| [0011](0011-deployment-variants-as-overlays.md) | Keep deployment variants as overlays | What lives in the base, what lives in an overlay, and why not a branch |
+| [0012](0012-identity-and-rider-domains.md) | The identity and rider domains get their own services | Where AuthGate and RiderManager go, why identity moves to Go, and which identifier is canonical |
+| [0013](0013-asymmetric-token-signing.md) | Tokens are signed asymmetrically and validated from a JWKS | Why every validator currently holds a minting key, and what replaces it |
 
 ## Reading order
 
 Records 0000–0005 are the design trail and read in sequence. ADR 0008 belongs
 to that trail but was written later, after review showed the trust-boundary
 decision was implied everywhere and recorded nowhere; read it after 0001.
-Records 0006 and 0007 are remediation decisions taken while closing individual
-findings, and read on their own. Numbers are never reused or reassigned.
+Records 0006, 0007, 0010 and 0011 are decisions taken while closing individual
+findings or building a specific piece, and read on their own. ADR 0012 refines
+0001 by separating technology role from service inventory; ADR 0013 supersedes
+the signing half of 0006. Numbers are never reused or reassigned — 0011 was
+renumbered once, from a 0008 that collided with an existing record.
 ADR 0009 is the executable consistency contract and refines the shorter
 outbox/inbox statement in ADR 0003.
 ADR 0010 applies that contract to the cross-database motorcycle-retirement race.


### PR DESCRIPTION
Closes a real hole in the target architecture, found by reading the schema against the ADRs.

## The gap

The technology table in ADR 0001 assigns **workload roles**. It then became the **service inventory** in ADR 0002's image list and in the cloud topology, without anyone deciding it should. Six roles, six images.

The strangler migration maps `moto-hub` and `rental-operations` onto `rental-core` — which matches `deploy/db/cockroach/001_init.sql` exactly, `motorcycles` and `rentals` and nothing else. **`auth-gate` and `rider-manager` had no destination at all**, while the rest of the design already assumed both existed:

- ADR 0006 and 0008 name AuthGate the sole token issuer
- `rentals.rider_id STRING NOT NULL` is a reference with no owning service
- Cassandra partitions `rider_positions` by `rider_id`
- `risk-pricing` cross-checks an OCR'd CNH against a record nothing owns
- `media-guard` owns the CNH *file*; nothing owns the *record*

## ADR 0012 — eight services, not six

**`identity` in Go**, with the basis stated plainly: adopted for the OIDC and OAuth2 ecosystem, **not** for a workload argument. Identity's work is CRUD, password hashing and token minting, all cold path — the gateway does per-request verification. It is the only entry in the stack justified on ecosystem grounds, and the record says so rather than inventing a workload case after the fact. Bending ADR 0001's rule in silence would corrupt what makes that record credible.

**`rider-core` in .NET**, own store. Not folded into `rental-core`, because that merges bounded contexts and puts CNPJ and CNH in the same database as rentals and money — separate store, separate IAM role, the argument that closed A2. Not folded into `identity`, because credentials and regulatory documents have different lifecycles.

**The file/record split**, stated for the first time: `media-guard` owns the file pipeline, `rider-core` owns the record. Both earlier documents implied `media-guard` did both.

**One identifier.** `rentals.rider_id`, Cassandra's `rider_positions.rider_id` and the JWT `sub` are the same value; `rider-core` mints no surrogate. Finding B10 was `Rider.Id` versus `Rider.UserId` inside one class — #99 reconciled the usage but the model still carries both fields and nothing recorded which is canonical. Without this, B10 regenerates across service boundaries, where it is far harder to catch.

## ADR 0013 — asymmetric signing with a JWKS

ADR 0006 already noted that compromising the issuer exposes every symmetric key. It did **not** note the sharper consequence: under HMAC the validator key *is* the signing key, so every service holds a secret that can mint tokens for its own audience. The record says a leaked validator key does not work on siblings — true, and it works perfectly on itself.

EdDSA signing, public keys published as a JWKS, validators verify-only, rotation becomes a JWKS update instead of distributing a secret to N services. The gateway caches with a bounded TTL, refetches once on an unknown `kid`, and **fails closed** — consistent with ADR 0003's posture for token verification.

Shipped **with** the Go rewrite, not after: a rewrite that kept hand-rolled symmetric HMAC would be the worst combination available, full cost and no security gain.

## Also in here

Renumbers the orphaned `0008-deployment-variants-as-overlays.md` to **0011**. It collided with the trust-boundary record from #101 and appeared in no index. Numbers are not reassigned; the index records that this one was.

ADR 0001 now states its table is roles rather than inventory and carries the two missing rows. ADR 0002 counts eight images.

## Two costs worth reading before merging

**Seven languages on a solo repository.** The evidence review already names breadth as the main misreading risk for this project, and this makes it worse. The countermeasure is unchanged — the deep column stays distributed consistency, which identity does not feed.

**The password migration is the real work, not the rewrite.** AuthGate stores ASP.NET Identity PBKDF2 hashes. The Go service has to verify that format on first login and re-hash to Argon2id on success, or every existing user is locked out. And ADR 0007's signed queue envelope is issued by AuthGate today — the Go service must reproduce it exactly or finding C5 reopens.

## Verification

Documentation only. All relative links in `docs/adr/` and the README resolve; no file still references the renumbered path.

## Related

Refines #6 and #7. Follow-up epic and tasks for the two services, their schemas and the identifier migration are not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQRkUCjsVNmzUaV5qp4SvM


---
_Generated by [Claude Code](https://claude.ai/code/session_01PQRkUCjsVNmzUaV5qp4SvM)_