### PR TITLE
fix(gateway): isolate circuit-breaker request outcomes

### DIFF
--- a/services/api-gateway/src/lib.rs
+++ b/services/api-gateway/src/lib.rs
@@ -456,12 +456,11 @@ async fn forward(
         let upstream_response = match upstream_request.timeout(resilience.timeout).send().await {
             Ok(response) => response,
             Err(error) if attempt < max_retries => {
-                policy.record_failure();
                 warn!(upstream = ?upstream_name, attempt, error = %error, "retryable upstream transport failure");
                 continue;
             }
             Err(error) => {
-                policy.record_failure();
+                policy.record_failure(&admission);
                 return if error.is_timeout() {
                     Err(ForwardError::Timeout)
                 } else {
@@ -470,13 +469,10 @@ async fn forward(
             }
         };
         if upstream_response.status().is_server_error() && attempt < max_retries {
-            policy.record_failure();
             continue;
         }
         if upstream_response.status().is_server_error() {
-            policy.record_failure();
-        } else {
-            policy.record_success();
+            policy.record_failure(&admission);
         }
         return Ok(upstream_response_to_client(
             upstream_response,
@@ -502,14 +498,31 @@ fn upstream_response_to_client(
         }
     }
 
-    let count_body_error = !status.is_server_error();
-    let body = upstream_response.bytes_stream().map(move |chunk| {
-        let _keep_bulkhead_permit = &admission;
-        if count_body_error && chunk.is_err() {
-            policy.record_failure();
-        }
-        chunk
-    });
+    let track_outcome = !status.is_server_error();
+    let body = futures_util::stream::unfold(
+        (
+            Box::pin(upstream_response.bytes_stream()),
+            Some(admission),
+            policy,
+        ),
+        move |(mut upstream_body, mut admission, policy)| async move {
+            match upstream_body.next().await {
+                Some(Ok(chunk)) => Some((Ok(chunk), (upstream_body, admission, policy))),
+                Some(Err(error)) => {
+                    if track_outcome && let Some(completed) = admission.take() {
+                        policy.record_failure(&completed);
+                    }
+                    Some((Err(error), (upstream_body, admission, policy)))
+                }
+                None => {
+                    if track_outcome && let Some(completed) = admission.take() {
+                        policy.record_success(&completed);
+                    }
+                    None
+                }
+            }
+        },
+    );
     response
         .body(Body::from_stream(body))
         .expect("upstream response status and headers are valid")
@@ -979,6 +992,27 @@ mod tests {
         serde_json::from_slice(&body).unwrap()
     }
 
+    async fn auth_gate_circuit_state(app: &Router) -> String {
+        let readiness = app
+            .clone()
+            .oneshot(
+                HttpRequest::get("/health/ready")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let readiness = response_json(readiness).await;
+        readiness["upstream_breakers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["upstream"] == "auth_gate")
+            .and_then(|entry| entry["state"].as_str())
+            .unwrap()
+            .to_owned()
+    }
+
     struct StubRevocationStore {
         result: Result<bool, RevocationError>,
         checks: AtomicUsize,
@@ -1232,6 +1266,113 @@ mod tests {
 
         assert_eq!(not_retried.status(), StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(single_state.requests.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn retryable_5xx_counts_once_per_completed_client_request() {
+        let (upstream, state) = spawn_sequence_upstream(vec![
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ])
+        .await;
+        let mut config = test_config(upstream);
+        config.resilience.auth_gate.breaker_failure_threshold = 2;
+        config.resilience.auth_gate.max_retries = 2;
+        let (app, _) = app_with_rate_limit(
+            config,
+            Ok(RateLimitDecision {
+                allowed: true,
+                remaining: 10,
+                retry_after_seconds: 1,
+            }),
+        );
+
+        let first = app
+            .clone()
+            .oneshot(
+                HttpRequest::post("/api/auth/login")
+                    .header("idempotency-key", "first")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(auth_gate_circuit_state(&app).await, "closed");
+
+        let second = app
+            .clone()
+            .oneshot(
+                HttpRequest::post("/api/auth/login")
+                    .header("idempotency-key", "second")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(auth_gate_circuit_state(&app).await, "open");
+        assert_eq!(state.requests.load(Ordering::SeqCst), 6);
+
+        let shed = app
+            .oneshot(
+                HttpRequest::post("/api/auth/login")
+                    .header("idempotency-key", "third")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(shed.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(state.requests.load(Ordering::SeqCst), 6);
+    }
+
+    #[tokio::test]
+    async fn retryable_transport_errors_count_once_per_completed_client_request() {
+        let unused_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let unused_address = unused_listener.local_addr().unwrap();
+        drop(unused_listener);
+        let mut config = test_config(Url::parse(&format!("http://{unused_address}/")).unwrap());
+        config.resilience.auth_gate.breaker_failure_threshold = 2;
+        config.resilience.auth_gate.max_retries = 2;
+        let (app, _) = app_with_rate_limit(
+            config,
+            Ok(RateLimitDecision {
+                allowed: true,
+                remaining: 10,
+                retry_after_seconds: 1,
+            }),
+        );
+
+        let first = app
+            .clone()
+            .oneshot(
+                HttpRequest::post("/api/auth/login")
+                    .header("idempotency-key", "first")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(auth_gate_circuit_state(&app).await, "closed");
+
+        let second = app
+            .clone()
+            .oneshot(
+                HttpRequest::post("/api/auth/login")
+                    .header("idempotency-key", "second")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(auth_gate_circuit_state(&app).await, "open");
     }
 
     #[tokio::test]

--- a/services/api-gateway/src/lib.rs
+++ b/services/api-gateway/src/lib.rs
@@ -498,26 +498,18 @@ fn upstream_response_to_client(
         }
     }
 
-    let track_outcome = !status.is_server_error();
+    let outcome = ResponseOutcomeGuard::new(admission, policy, !status.is_server_error());
     let body = futures_util::stream::unfold(
-        (
-            Box::pin(upstream_response.bytes_stream()),
-            Some(admission),
-            policy,
-        ),
-        move |(mut upstream_body, mut admission, policy)| async move {
+        (Box::pin(upstream_response.bytes_stream()), outcome),
+        move |(mut upstream_body, mut outcome)| async move {
             match upstream_body.next().await {
-                Some(Ok(chunk)) => Some((Ok(chunk), (upstream_body, admission, policy))),
+                Some(Ok(chunk)) => Some((Ok(chunk), (upstream_body, outcome))),
                 Some(Err(error)) => {
-                    if track_outcome && let Some(completed) = admission.take() {
-                        policy.record_failure(&completed);
-                    }
-                    Some((Err(error), (upstream_body, admission, policy)))
+                    outcome.resolve_failure();
+                    Some((Err(error), (upstream_body, outcome)))
                 }
                 None => {
-                    if track_outcome && let Some(completed) = admission.take() {
-                        policy.record_success(&completed);
-                    }
+                    outcome.resolve_success();
                     None
                 }
             }
@@ -526,6 +518,45 @@ fn upstream_response_to_client(
     response
         .body(Body::from_stream(body))
         .expect("upstream response status and headers are valid")
+}
+
+struct ResponseOutcomeGuard {
+    admission: resilience::Admission,
+    policy: Arc<UpstreamPolicy>,
+    pending: bool,
+}
+
+impl ResponseOutcomeGuard {
+    fn new(admission: resilience::Admission, policy: Arc<UpstreamPolicy>, pending: bool) -> Self {
+        Self {
+            admission,
+            policy,
+            pending,
+        }
+    }
+
+    fn resolve_success(&mut self) {
+        if self.pending {
+            self.policy.record_success(&self.admission);
+            self.pending = false;
+        }
+    }
+
+    fn resolve_failure(&mut self) {
+        if self.pending {
+            self.policy.record_failure(&self.admission);
+            self.pending = false;
+        }
+    }
+}
+
+impl Drop for ResponseOutcomeGuard {
+    fn drop(&mut self) {
+        // Non-5xx headers prove that the upstream answered. If the downstream
+        // abandons the body, resolve the admission as a success instead of
+        // leaking a half-open probe or blaming a client cancellation on it.
+        self.resolve_success();
+    }
 }
 
 fn retry_allowed(method: &Method, headers: &HeaderMap) -> bool {
@@ -1373,6 +1404,67 @@ mod tests {
             .unwrap();
         assert_eq!(second.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(auth_gate_circuit_state(&app).await, "open");
+    }
+
+    #[tokio::test]
+    async fn dropping_a_half_open_response_body_resolves_the_probe() {
+        let (upstream, state) = spawn_sequence_upstream(vec![
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::NO_CONTENT,
+            StatusCode::NO_CONTENT,
+        ])
+        .await;
+        let mut config = test_config(upstream);
+        config.resilience.auth_gate.breaker_failure_threshold = 1;
+        config.resilience.auth_gate.breaker_open_duration = Duration::from_millis(1);
+        let (app, _) = app_with_rate_limit(
+            config,
+            Ok(RateLimitDecision {
+                allowed: true,
+                remaining: 10,
+                retry_after_seconds: 1,
+            }),
+        );
+
+        let failure = app
+            .clone()
+            .oneshot(
+                HttpRequest::post("/api/auth/login")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(failure.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        drop(failure);
+        assert_eq!(auth_gate_circuit_state(&app).await, "open");
+
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        let probe = app
+            .clone()
+            .oneshot(
+                HttpRequest::post("/api/auth/login")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(probe.status(), StatusCode::NO_CONTENT);
+        assert_eq!(auth_gate_circuit_state(&app).await, "half_open");
+
+        drop(probe);
+
+        assert_eq!(auth_gate_circuit_state(&app).await, "closed");
+        let admitted = app
+            .oneshot(
+                HttpRequest::post("/api/auth/login")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(admitted.status(), StatusCode::NO_CONTENT);
+        assert_eq!(state.requests.load(Ordering::SeqCst), 3);
     }
 
     #[tokio::test]

--- a/services/api-gateway/src/resilience.rs
+++ b/services/api-gateway/src/resilience.rs
@@ -34,6 +34,13 @@ pub enum Rejection {
 #[derive(Debug)]
 pub struct Admission {
     _permit: OwnedSemaphorePermit,
+    breaker: BreakerAdmission,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct BreakerAdmission {
+    generation: u64,
+    state: CircuitState,
 }
 
 pub struct UpstreamPolicy {
@@ -61,25 +68,29 @@ impl UpstreamPolicy {
             .clone()
             .try_acquire_owned()
             .map_err(|_| Rejection::BulkheadFull)?;
-        self.breaker
+        let breaker = self
+            .breaker
             .lock()
             .expect("circuit breaker lock is not poisoned")
             .before_request(Instant::now())?;
-        Ok(Admission { _permit: permit })
+        Ok(Admission {
+            _permit: permit,
+            breaker,
+        })
     }
 
-    pub fn record_success(&self) {
+    pub fn record_success(&self, admission: &Admission) {
         self.breaker
             .lock()
             .expect("circuit breaker lock is not poisoned")
-            .record_success();
+            .record_success(admission.breaker);
     }
 
-    pub fn record_failure(&self) {
+    pub fn record_failure(&self, admission: &Admission) {
         self.breaker
             .lock()
             .expect("circuit breaker lock is not poisoned")
-            .record_failure(Instant::now());
+            .record_failure(admission.breaker, Instant::now());
     }
 
     pub fn state(&self) -> CircuitState {
@@ -163,6 +174,7 @@ impl CircuitState {
 
 struct CircuitBreaker {
     state: CircuitState,
+    generation: u64,
     consecutive_failures: u32,
     opened_at: Option<Instant>,
     half_open_probe_in_flight: bool,
@@ -174,6 +186,7 @@ impl CircuitBreaker {
     fn new(config: UpstreamResilienceConfig) -> Self {
         Self {
             state: CircuitState::Closed,
+            generation: 0,
             consecutive_failures: 0,
             opened_at: None,
             half_open_probe_in_flight: false,
@@ -182,9 +195,9 @@ impl CircuitBreaker {
         }
     }
 
-    fn before_request(&mut self, now: Instant) -> Result<(), Rejection> {
+    fn before_request(&mut self, now: Instant) -> Result<BreakerAdmission, Rejection> {
         match self.state {
-            CircuitState::Closed => Ok(()),
+            CircuitState::Closed => Ok(self.admission()),
             CircuitState::Open => {
                 let elapsed = now.saturating_duration_since(
                     self.opened_at
@@ -193,27 +206,45 @@ impl CircuitBreaker {
                 if elapsed >= self.open_duration {
                     self.state = CircuitState::HalfOpen;
                     self.half_open_probe_in_flight = true;
-                    Ok(())
+                    Ok(self.admission())
                 } else {
                     Err(Rejection::CircuitOpen(self.open_duration - elapsed))
                 }
             }
             CircuitState::HalfOpen if !self.half_open_probe_in_flight => {
                 self.half_open_probe_in_flight = true;
-                Ok(())
+                Ok(self.admission())
             }
             CircuitState::HalfOpen => Err(Rejection::CircuitOpen(self.open_duration)),
         }
     }
 
-    fn record_success(&mut self) {
+    fn admission(&self) -> BreakerAdmission {
+        BreakerAdmission {
+            generation: self.generation,
+            state: self.state,
+        }
+    }
+
+    fn record_success(&mut self, admission: BreakerAdmission) {
+        if !self.accepts(admission) {
+            return;
+        }
+
+        if self.state == CircuitState::HalfOpen {
+            self.advance_generation();
+        }
         self.state = CircuitState::Closed;
         self.consecutive_failures = 0;
         self.opened_at = None;
         self.half_open_probe_in_flight = false;
     }
 
-    fn record_failure(&mut self, now: Instant) {
+    fn record_failure(&mut self, admission: BreakerAdmission, now: Instant) {
+        if !self.accepts(admission) {
+            return;
+        }
+
         if self.state == CircuitState::HalfOpen {
             self.open(now);
             return;
@@ -227,9 +258,18 @@ impl CircuitBreaker {
     }
 
     fn open(&mut self, now: Instant) {
+        self.advance_generation();
         self.state = CircuitState::Open;
         self.opened_at = Some(now);
         self.half_open_probe_in_flight = false;
+    }
+
+    fn accepts(&self, admission: BreakerAdmission) -> bool {
+        admission.generation == self.generation && admission.state == self.state
+    }
+
+    fn advance_generation(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
     }
 }
 
@@ -264,20 +304,20 @@ mod tests {
         let now = Instant::now();
         let mut breaker = CircuitBreaker::new(config());
 
-        breaker.record_failure(now);
+        let first = breaker.before_request(now).unwrap();
+        breaker.record_failure(first, now);
         assert_eq!(breaker.state, CircuitState::Closed);
-        breaker.record_failure(now);
+        let second = breaker.before_request(now).unwrap();
+        breaker.record_failure(second, now);
         assert_eq!(breaker.state, CircuitState::Open);
         assert!(
             breaker
                 .before_request(now + Duration::from_millis(99))
                 .is_err()
         );
-        assert!(
-            breaker
-                .before_request(now + Duration::from_millis(100))
-                .is_ok()
-        );
+        let probe = breaker
+            .before_request(now + Duration::from_millis(100))
+            .unwrap();
         assert_eq!(breaker.state, CircuitState::HalfOpen);
         assert!(
             breaker
@@ -285,7 +325,7 @@ mod tests {
                 .is_err()
         );
 
-        breaker.record_success();
+        breaker.record_success(probe);
         assert_eq!(breaker.state, CircuitState::Closed);
         assert!(
             breaker
@@ -298,18 +338,42 @@ mod tests {
     fn failed_half_open_probe_reopens_the_breaker() {
         let now = Instant::now();
         let mut breaker = CircuitBreaker::new(config());
-        breaker.record_failure(now);
-        breaker.record_failure(now);
-        breaker
+        let first = breaker.before_request(now).unwrap();
+        breaker.record_failure(first, now);
+        let second = breaker.before_request(now).unwrap();
+        breaker.record_failure(second, now);
+        let probe = breaker
             .before_request(now + Duration::from_millis(100))
             .unwrap();
 
-        breaker.record_failure(now + Duration::from_millis(101));
+        breaker.record_failure(probe, now + Duration::from_millis(101));
 
         assert_eq!(breaker.state, CircuitState::Open);
         assert!(
             breaker
                 .before_request(now + Duration::from_millis(150))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn pre_open_success_cannot_close_a_new_breaker_generation() {
+        let now = Instant::now();
+        let mut policy = config();
+        policy.breaker_failure_threshold = 1;
+        let mut breaker = CircuitBreaker::new(policy);
+        let older_request = breaker.before_request(now).unwrap();
+        let failing_request = breaker.before_request(now).unwrap();
+
+        breaker.record_failure(failing_request, now);
+        assert_eq!(breaker.state, CircuitState::Open);
+
+        breaker.record_success(older_request);
+
+        assert_eq!(breaker.state, CircuitState::Open);
+        assert!(
+            breaker
+                .before_request(now + Duration::from_millis(99))
                 .is_err()
         );
     }


### PR DESCRIPTION
## Summary

- count one breaker outcome per completed client request, after all eligible retries
- carry the breaker generation and admission state with every bulkhead permit
- ignore late successes or failures from requests admitted before a newer open/half-open generation
- resolve non-5xx streamed responses on EOF, stream failure, or downstream cancellation/drop

## Regression coverage

- repeated retryable 5xx responses require two complete failed requests to reach a threshold of two
- repeated retryable transport errors require two complete failed requests to reach the same threshold
- an older concurrent success cannot close a circuit opened by another admitted request
- dropping a successful half-open response body resolves the probe and allows later traffic

## Validation

- cargo fmt --check
- cargo clippy --locked --all-targets -- -D warnings
- cargo test --locked --all-targets: 45 passed
- git diff --check

Addresses the breaker review feedback on #147.
