### PR TITLE
feat(observability): propagate traces across services

### DIFF
--- a/AuthGate/AuthGate/AuthGate.csproj
+++ b/AuthGate/AuthGate/AuthGate.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.18.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
     <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
     <PackageReference Include="Serilog" Version="4.4.0" />

--- a/AuthGate/AuthGate/Migrations/20260902184354_AddOutboxTraceContext.Designer.cs
+++ b/AuthGate/AuthGate/Migrations/20260902184354_AddOutboxTraceContext.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AuthGate.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace AuthGate.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260902184354_AddOutboxTraceContext")]
+    partial class AddOutboxTraceContext
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AuthGate/AuthGate/Migrations/20260902184354_AddOutboxTraceContext.cs
+++ b/AuthGate/AuthGate/Migrations/20260902184354_AddOutboxTraceContext.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AuthGate.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOutboxTraceContext : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "TraceParent",
+                table: "OutboxMessages",
+                type: "character varying(55)",
+                maxLength: 55,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TraceState",
+                table: "OutboxMessages",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TraceParent",
+                table: "OutboxMessages");
+
+            migrationBuilder.DropColumn(
+                name: "TraceState",
+                table: "OutboxMessages");
+        }
+    }
+}

--- a/AuthGate/AuthGate/Program.cs
+++ b/AuthGate/AuthGate/Program.cs
@@ -3,6 +3,8 @@ using AuthGate.Model;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
+using Serilog.Formatting.Compact;
+using OpenTelemetry.Trace;
 using AuthGate.Configurations;
 using AuthGate.Services.RabbitMQ;
 using AuthGate.Services.File;
@@ -26,12 +28,15 @@ var serviceName = builder.Configuration["OTEL_SERVICE_NAME"]
     ?? builder.Configuration["ApplicationName"]
     ?? "auth-gate";
 
-builder.Services.AddProjectYTelemetry(builder.Configuration, serviceName);
+builder.Services.AddProjectYTelemetry(
+    builder.Configuration,
+    serviceName,
+    tracing => tracing.AddEntityFrameworkCoreInstrumentation());
 
 Log.Logger = new LoggerConfiguration()
     .Enrich.FromLogContext()
     .Enrich.WithProperty("ApplicationName", serviceName)
-    .WriteTo.Console()
+    .WriteTo.Console(new RenderedCompactJsonFormatter())
     .WriteToProjectYTelemetry(builder.Configuration, serviceName)
     .CreateLogger();
 builder.Host.UseSerilog();

--- a/AuthGate/AuthGateTests/Integration/PostgreSql/MigrationTests.cs
+++ b/AuthGate/AuthGateTests/Integration/PostgreSql/MigrationTests.cs
@@ -29,7 +29,7 @@ public sealed class MigrationTests : IAsyncLifetime
         await context.Database.MigrateAsync();
 
         Assert.Empty(await context.Database.GetPendingMigrationsAsync());
-        Assert.Equal(4, (await context.Database.GetAppliedMigrationsAsync()).Count());
+        Assert.Equal(5, (await context.Database.GetAppliedMigrationsAsync()).Count());
         Assert.Equal(2, await context.Roles.CountAsync());
     }
 

--- a/MotoHub/MotoHub/Migrations/20260902184357_AddOutboxTraceContext.Designer.cs
+++ b/MotoHub/MotoHub/Migrations/20260902184357_AddOutboxTraceContext.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MotoHub.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MotoHub.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260902184357_AddOutboxTraceContext")]
+    partial class AddOutboxTraceContext
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MotoHub/MotoHub/Migrations/20260902184357_AddOutboxTraceContext.cs
+++ b/MotoHub/MotoHub/Migrations/20260902184357_AddOutboxTraceContext.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MotoHub.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOutboxTraceContext : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "TraceParent",
+                table: "OutboxMessages",
+                type: "character varying(55)",
+                maxLength: 55,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TraceState",
+                table: "OutboxMessages",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TraceParent",
+                table: "OutboxMessages");
+
+            migrationBuilder.DropColumn(
+                name: "TraceState",
+                table: "OutboxMessages");
+        }
+    }
+}

--- a/MotoHub/MotoHub/MotoHub.csproj
+++ b/MotoHub/MotoHub/MotoHub.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.18.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
     <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
     <PackageReference Include="Serilog" Version="4.4.0" />

--- a/MotoHub/MotoHub/Program.cs
+++ b/MotoHub/MotoHub/Program.cs
@@ -1,5 +1,6 @@
 using Serilog.Formatting.Compact;
 using Serilog;
+using OpenTelemetry.Trace;
 using Microsoft.EntityFrameworkCore;
 using MotoHub.Data;
 using MotoHub.Services;
@@ -27,12 +28,15 @@ var serviceName = builder.Configuration["OTEL_SERVICE_NAME"]
     ?? builder.Configuration["ApplicationName"]
     ?? "moto-hub";
 
-builder.Services.AddProjectYTelemetry(builder.Configuration, serviceName);
+builder.Services.AddProjectYTelemetry(
+    builder.Configuration,
+    serviceName,
+    tracing => tracing.AddEntityFrameworkCoreInstrumentation());
 
 Log.Logger = new LoggerConfiguration()
     .Enrich.FromLogContext()
     .Enrich.WithProperty("ApplicationName", serviceName)
-    .WriteTo.Console()
+    .WriteTo.Console(new RenderedCompactJsonFormatter())
     .WriteToProjectYTelemetry(builder.Configuration, serviceName)
     .CreateLogger();
 builder.Host.UseSerilog();

--- a/MotoHub/MotoHubTests/Integration/PostgreSql/MigrationTests.cs
+++ b/MotoHub/MotoHubTests/Integration/PostgreSql/MigrationTests.cs
@@ -36,7 +36,7 @@ public sealed class MigrationTests : IAsyncLifetime
         await context.SaveChangesAsync();
 
         Assert.Empty(await context.Database.GetPendingMigrationsAsync());
-        Assert.Equal(6, (await context.Database.GetAppliedMigrationsAsync()).Count());
+        Assert.Equal(7, (await context.Database.GetAppliedMigrationsAsync()).Count());
         Assert.Equal(1, await context.Motorcycles.CountAsync());
     }
 

--- a/MotoHub/MotoHubTests/Unit/Messaging/RabbitMqOutboxTransportTests.cs
+++ b/MotoHub/MotoHubTests/Unit/Messaging/RabbitMqOutboxTransportTests.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics;
+using System.Text;
 using Moq;
 using ProjectY.Shared.Messaging;
+using ProjectY.Shared.Observability;
 using RabbitMQ.Client;
 
 namespace MotoHubTests.Unit.Messaging;
@@ -11,6 +14,7 @@ public sealed class RabbitMqOutboxTransportTests
     {
         var channel = new Mock<IModel>();
         var properties = new Mock<IBasicProperties>();
+        properties.SetupAllProperties();
         channel.Setup(item => item.CreateBasicProperties()).Returns(properties.Object);
         var connection = new Mock<IConnection>();
         connection.Setup(item => item.CreateModel()).Returns(channel.Object);
@@ -52,5 +56,83 @@ public sealed class RabbitMqOutboxTransportTests
             properties.Object,
             It.IsAny<ReadOnlyMemory<byte>>()), Times.Once);
         properties.VerifySet(item => item.MessageId = message.Id.ToString("D"), Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishAsync_ContinuesStoredRequestTraceAcrossOutboxAndConsumer()
+    {
+        using var listener = ListenToProjectYMessaging();
+        using var request = new Activity("request").SetIdFormat(ActivityIdFormat.W3C).Start();
+        Assert.NotNull(request);
+        request.TraceStateString = "vendor=value";
+        var message = new OutboxMessage
+        {
+            AggregateType = "motorcycle",
+            AggregateId = "motorcycle-1",
+            AggregateSequence = 0,
+            EventType = "motorcycle.updated.v1",
+            Destination = "motorcycle-events",
+            Payload = "{}"
+        };
+        var requestTraceId = request.TraceId;
+        var requestSpanId = request.SpanId;
+        Assert.Equal(request.Id, message.TraceParent);
+        Assert.Equal(request.TraceStateString, message.TraceState);
+        request.Stop();
+
+        var channel = new Mock<IModel>();
+        var properties = new Mock<IBasicProperties>();
+        properties.SetupAllProperties();
+        channel.Setup(item => item.CreateBasicProperties()).Returns(properties.Object);
+        var connection = new Mock<IConnection>();
+        connection.Setup(item => item.CreateModel()).Returns(channel.Object);
+        var connectionProvider = new Mock<IRabbitMqConnectionProvider>();
+        connectionProvider.Setup(item => item.Create()).Returns(connection.Object);
+        var transport = new RabbitMqOutboxTransport(
+            new OutboxRelayOptions
+            {
+                ServiceName = "test",
+                HostName = "rabbitmq",
+                VirtualHost = "test",
+                UserName = "test",
+                Password = "test"
+            },
+            connectionProvider.Object);
+
+        await transport.PublishAsync(message, CancellationToken.None);
+
+        Assert.NotNull(properties.Object.Headers);
+        var publishedTraceParent = Encoding.UTF8.GetString(
+            Assert.IsType<byte[]>(properties.Object.Headers[MessagingTraceContext.TraceParentHeader]));
+        Assert.True(ActivityContext.TryParse(publishedTraceParent, null, true, out var publishedContext));
+        Assert.Equal(requestTraceId, publishedContext.TraceId);
+        Assert.NotEqual(requestSpanId, publishedContext.SpanId);
+        Assert.Equal(
+            "vendor=value",
+            Encoding.UTF8.GetString(
+                Assert.IsType<byte[]>(properties.Object.Headers[MessagingTraceContext.TraceStateHeader])));
+
+        using var consumer = MessagingTraceContext.StartConsumerActivity(
+            "rabbitmq",
+            message.Destination,
+            properties.Object.Headers,
+            message.Id.ToString("D"));
+        Assert.NotNull(consumer);
+        Assert.Equal(requestTraceId, consumer.TraceId);
+        Assert.Equal(publishedContext.SpanId, consumer.ParentSpanId);
+        Assert.Equal("vendor=value", consumer.TraceStateString);
+        Assert.Equal(ActivityKind.Consumer, consumer.Kind);
+    }
+
+    private static ActivityListener ListenToProjectYMessaging()
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == MessagingTraceContext.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
     }
 }

--- a/RentalOperations/RentalOperations/Program.cs
+++ b/RentalOperations/RentalOperations/Program.cs
@@ -12,6 +12,7 @@ using RentalOperations.Repository;
 using RentalOperations.Services;
 using RentalOperations.Services.RabbitMQService;
 using Serilog;
+using Serilog.Formatting.Compact;
 
 if (await HealthProbeCommand.TryRunAsync(args))
 {
@@ -24,12 +25,16 @@ var serviceName = builder.Configuration["OTEL_SERVICE_NAME"]
     ?? builder.Configuration["ApplicationName"]
     ?? "rental-operations";
 
-builder.Services.AddProjectYTelemetry(builder.Configuration, serviceName);
+builder.Services.AddProjectYTelemetry(
+    builder.Configuration,
+    serviceName,
+    configureTracing: null,
+    MongoTelemetry.ActivitySourceName);
 
 Log.Logger = new LoggerConfiguration()
     .Enrich.FromLogContext()
     .Enrich.WithProperty("ApplicationName", serviceName)
-    .WriteTo.Console()
+    .WriteTo.Console(new RenderedCompactJsonFormatter())
     .WriteToProjectYTelemetry(builder.Configuration, serviceName)
     .CreateLogger();
 builder.Host.UseSerilog();

--- a/RentalOperations/RentalOperations/Services/RabbitMQService/MessagingConsumerService.cs
+++ b/RentalOperations/RentalOperations/Services/RabbitMQService/MessagingConsumerService.cs
@@ -7,6 +7,7 @@ using RentalOperations.Services.RabbitMQService;
 using RentalOperations.Configurations;
 using RentalOperations.Services;
 using RentalOperations.Entities;
+using ProjectY.Shared.Observability;
 
 namespace RentalOperations.Services.RabbitMQService
 {
@@ -52,6 +53,11 @@ namespace RentalOperations.Services.RabbitMQService
             {
                 var body = ea.Body.ToArray();
                 var message = Encoding.UTF8.GetString(body);
+                using var activity = MessagingTraceContext.StartConsumerActivity(
+                    "rabbitmq",
+                    queueName,
+                    ea.BasicProperties.Headers,
+                    ea.BasicProperties.MessageId);
                 try
                 {
                     await processMessageFunc(message, GetMessageId(ea.BasicProperties, body));
@@ -59,8 +65,9 @@ namespace RentalOperations.Services.RabbitMQService
                 }
                 catch (Exception ex)
                 {
+                    MessagingTraceContext.RecordException(activity, ex);
                     _channel.BasicNack(ea.DeliveryTag, false, true);
-                    _logger.LogError($"Error processing message: {ex.Message}", ex);
+                    _logger.LogError(ex, "Error processing message from {QueueName}.", queueName);
                 }
             };
 
@@ -96,6 +103,11 @@ namespace RentalOperations.Services.RabbitMQService
 
                 var body = ea.Body.ToArray();
                 var message = Encoding.UTF8.GetString(body);
+                using var activity = MessagingTraceContext.StartConsumerActivity(
+                    "rabbitmq",
+                    poisonQueueName,
+                    ea.BasicProperties.Headers,
+                    ea.BasicProperties.MessageId);
 
                 try
                 {
@@ -104,10 +116,14 @@ namespace RentalOperations.Services.RabbitMQService
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError($"Error processing poison message: {ex.Message}", ex);
+                    MessagingTraceContext.RecordException(activity, ex);
+                    _logger.LogError(
+                        ex,
+                        "Error processing poison message from {QueueName}.",
+                        poisonQueueName);
                     if (retriesHeader < 3)
                     {
-                        ScheduleRetry(message, retriesHeader + 1);
+                        ScheduleRetry(message, retriesHeader + 1, ea.BasicProperties);
                     }
                     else
                     {
@@ -120,11 +136,21 @@ namespace RentalOperations.Services.RabbitMQService
             _channel.BasicConsume(queue: poisonQueueName, autoAck: false, consumer: consumer);
         }
 
-        private void ScheduleRetry(string message, int retryCount)
+        private void ScheduleRetry(
+            string message,
+            int retryCount,
+            IBasicProperties originalProperties)
         {
             var delay = (int)Math.Pow(2, retryCount) * 1000; // Exponential backoff, e.g., 2s, 4s, 8s
             var properties = _channel.CreateBasicProperties();
-            properties.Headers = new Dictionary<string, object> { { "x-retries", retryCount } };
+            properties.Headers = originalProperties.Headers is null
+                ? new Dictionary<string, object>()
+                : new Dictionary<string, object>(originalProperties.Headers);
+            properties.Headers["x-retries"] = retryCount;
+            properties.MessageId = originalProperties.MessageId;
+            properties.Type = originalProperties.Type;
+            properties.Persistent = true;
+            MessagingTraceContext.InjectCurrent(properties.Headers);
             properties.Expiration = delay.ToString();
 
             _channel.QueueDeclare($"retry-poison-{retryCount}", durable: true, exclusive: false, autoDelete: false);

--- a/RiderManager/RiderManager/Program.cs
+++ b/RiderManager/RiderManager/Program.cs
@@ -5,6 +5,7 @@ using RiderManager.Configurations;
 using RiderManager.Data;
 using Serilog.Formatting.Compact;
 using Serilog;
+using OpenTelemetry.Trace;
 using Microsoft.OpenApi.Models;
 using RiderManager.Services.RiderServices;
 using RiderManager.Repositories;
@@ -56,12 +57,15 @@ var serviceName = builder.Configuration["OTEL_SERVICE_NAME"]
     ?? builder.Configuration["ApplicationName"]
     ?? "rider-manager";
 
-builder.Services.AddProjectYTelemetry(builder.Configuration, serviceName);
+builder.Services.AddProjectYTelemetry(
+    builder.Configuration,
+    serviceName,
+    tracing => tracing.AddEntityFrameworkCoreInstrumentation());
 
 Log.Logger = new LoggerConfiguration()
     .Enrich.FromLogContext()
     .Enrich.WithProperty("ApplicationName", serviceName)
-    .WriteTo.Console()
+    .WriteTo.Console(new RenderedCompactJsonFormatter())
     .WriteToProjectYTelemetry(builder.Configuration, serviceName)
     .CreateLogger();
 

--- a/RiderManager/RiderManager/RiderManager.csproj
+++ b/RiderManager/RiderManager/RiderManager.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.18.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
     <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
     <PackageReference Include="Serilog" Version="4.4.0" />

--- a/RiderManager/RiderManager/Services/RabbitMQService/MessagingConsumerService.cs
+++ b/RiderManager/RiderManager/Services/RabbitMQService/MessagingConsumerService.cs
@@ -4,6 +4,7 @@ using System.Text;
 using RiderManager.Configurations;
 using RiderManager.Entities;
 using ProjectY.Shared.Messaging;
+using ProjectY.Shared.Observability;
 
 namespace RiderManager.Services.RabbitMQService
 {
@@ -65,6 +66,11 @@ namespace RiderManager.Services.RabbitMQService
             {
                 var body = ea.Body.ToArray();
                 var message = Encoding.UTF8.GetString(body);
+                using var activity = MessagingTraceContext.StartConsumerActivity(
+                    "rabbitmq",
+                    queueName,
+                    ea.BasicProperties.Headers,
+                    ea.BasicProperties.MessageId);
                 try
                 {
                     await processMessageFunc(message);
@@ -72,11 +78,13 @@ namespace RiderManager.Services.RabbitMQService
                 }
                 catch (QueueMessageAuthenticationException ex)
                 {
+                    MessagingTraceContext.RecordException(activity, ex);
                     _channel.BasicNack(ea.DeliveryTag, false, false);
                     _logger.LogWarning(ex, "Rejected unauthenticated message from queue {QueueName}.", queueName);
                 }
                 catch (Exception ex)
                 {
+                    MessagingTraceContext.RecordException(activity, ex);
                     if (poisonQueueName is null)
                     {
                         _channel.BasicNack(ea.DeliveryTag, false, true);

--- a/RiderManager/RiderManagerTests/Unit/Messaging/BoundedRabbitMqRetryRouterTests.cs
+++ b/RiderManager/RiderManagerTests/Unit/Messaging/BoundedRabbitMqRetryRouterTests.cs
@@ -1,6 +1,8 @@
 using Moq;
 using RabbitMQ.Client;
 using RiderManager.Services.RabbitMQService;
+using ProjectY.Shared.Observability;
+using System.Text;
 
 namespace RiderManagerTests.Unit.Messaging;
 
@@ -10,6 +12,8 @@ public sealed class BoundedRabbitMqRetryRouterTests
     public void RouteFailure_BeforeLimit_RepublishesPersistentlyAtEndOfSourceQueue()
     {
         var (channel, original, outgoing) = CreateChannel();
+        var traceParent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        original.Object.Headers[MessagingTraceContext.TraceParentHeader] = Encoding.UTF8.GetBytes(traceParent);
         var router = new BoundedRabbitMqRetryRouter();
         ReadOnlyMemory<byte> body = "registration"u8.ToArray();
 
@@ -23,6 +27,10 @@ public sealed class BoundedRabbitMqRetryRouterTests
         Assert.Equal(FailureRoute.Retry, route);
         Assert.True(outgoing.Object.Persistent);
         Assert.Equal(1, outgoing.Object.Headers[BoundedRabbitMqRetryRouter.RetryHeader]);
+        Assert.Equal(
+            traceParent,
+            Encoding.UTF8.GetString(
+                Assert.IsType<byte[]>(outgoing.Object.Headers[MessagingTraceContext.TraceParentHeader])));
         channel.Verify(item => item.BasicPublish(
             string.Empty,
             "rider-info",

--- a/Shared/Messaging/OutboxMessage.cs
+++ b/Shared/Messaging/OutboxMessage.cs
@@ -1,7 +1,14 @@
+using ProjectY.Shared.Observability;
+
 namespace ProjectY.Shared.Messaging;
 
 public sealed class OutboxMessage
 {
+    public OutboxMessage()
+    {
+        (TraceParent, TraceState) = MessagingTraceContext.CaptureCurrent();
+    }
+
     public Guid Id { get; set; } = Guid.NewGuid();
     public required string AggregateType { get; set; }
     public required string AggregateId { get; set; }
@@ -9,6 +16,8 @@ public sealed class OutboxMessage
     public required string EventType { get; set; }
     public required string Destination { get; set; }
     public required string Payload { get; set; }
+    public string? TraceParent { get; set; }
+    public string? TraceState { get; set; }
     public DateTime OccurredAtUtc { get; set; } = DateTime.UtcNow;
     public DateTime? PublishedAtUtc { get; set; }
     public int PublishAttempts { get; set; }

--- a/Shared/Messaging/OutboxModelBuilderExtensions.cs
+++ b/Shared/Messaging/OutboxModelBuilderExtensions.cs
@@ -14,6 +14,8 @@ public static class OutboxModelBuilderExtensions
         message.Property(item => item.EventType).HasMaxLength(200);
         message.Property(item => item.Destination).HasMaxLength(200);
         message.Property(item => item.Payload).HasColumnType("text");
+        message.Property(item => item.TraceParent).HasMaxLength(55);
+        message.Property(item => item.TraceState).HasMaxLength(512);
         message.Property(item => item.LastError).HasMaxLength(2000);
         message.HasIndex(item => new
         {

--- a/Shared/Messaging/RabbitMqOutboxTransport.cs
+++ b/Shared/Messaging/RabbitMqOutboxTransport.cs
@@ -1,4 +1,5 @@
 using RabbitMQ.Client;
+using ProjectY.Shared.Observability;
 using System.Text;
 
 namespace ProjectY.Shared.Messaging;
@@ -20,24 +21,43 @@ public sealed class RabbitMqOutboxTransport : IOutboxTransport
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        using var connection = _connectionProvider.Create();
-        using var channel = connection.CreateModel();
-        channel.QueueDeclare(message.Destination, durable: true, exclusive: false, autoDelete: false);
-        channel.ConfirmSelect();
+        using var activity = MessagingTraceContext.StartProducerActivity(
+            "rabbitmq",
+            message.Destination,
+            message.TraceParent,
+            message.TraceState);
 
-        var properties = channel.CreateBasicProperties();
-        properties.Persistent = true;
-        properties.MessageId = message.Id.ToString("D");
-        properties.Type = message.EventType;
+        try
+        {
+            using var connection = _connectionProvider.Create();
+            using var channel = connection.CreateModel();
+            channel.QueueDeclare(message.Destination, durable: true, exclusive: false, autoDelete: false);
+            channel.ConfirmSelect();
 
-        channel.BasicPublish(
-            exchange: string.Empty,
-            routingKey: message.Destination,
-            mandatory: true,
-            basicProperties: properties,
-            body: Encoding.UTF8.GetBytes(message.Payload));
-        channel.WaitForConfirmsOrDie(_options.ConfirmationTimeout);
+            var properties = channel.CreateBasicProperties();
+            properties.Persistent = true;
+            properties.MessageId = message.Id.ToString("D");
+            properties.Type = message.EventType;
+            properties.Headers = new Dictionary<string, object>();
+            MessagingTraceContext.InjectCurrent(
+                properties.Headers,
+                message.TraceParent,
+                message.TraceState);
 
-        return Task.CompletedTask;
+            channel.BasicPublish(
+                exchange: string.Empty,
+                routingKey: message.Destination,
+                mandatory: true,
+                basicProperties: properties,
+                body: Encoding.UTF8.GetBytes(message.Payload));
+            channel.WaitForConfirmsOrDie(_options.ConfirmationTimeout);
+
+            return Task.CompletedTask;
+        }
+        catch (Exception exception)
+        {
+            MessagingTraceContext.RecordException(activity, exception);
+            throw;
+        }
     }
 }

--- a/Shared/Observability/MessagingTraceContext.cs
+++ b/Shared/Observability/MessagingTraceContext.cs
@@ -1,0 +1,126 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace ProjectY.Shared.Observability;
+
+public static class MessagingTraceContext
+{
+    public const string ActivitySourceName = "ProjectY.Messaging";
+    public const string TraceParentHeader = "traceparent";
+    public const string TraceStateHeader = "tracestate";
+
+    private static readonly ActivitySource Source = new(ActivitySourceName);
+
+    public static (string? TraceParent, string? TraceState) CaptureCurrent()
+        => (Activity.Current?.Id, Activity.Current?.TraceStateString);
+
+    public static Activity? StartProducerActivity(
+        string messagingSystem,
+        string destination,
+        string? traceParent,
+        string? traceState)
+        => StartActivity(
+            $"{destination} publish",
+            ActivityKind.Producer,
+            messagingSystem,
+            destination,
+            "publish",
+            traceParent,
+            traceState);
+
+    public static Activity? StartConsumerActivity(
+        string messagingSystem,
+        string destination,
+        IDictionary<string, object>? headers,
+        string? messageId = null)
+    {
+        var activity = StartActivity(
+            $"{destination} process",
+            ActivityKind.Consumer,
+            messagingSystem,
+            destination,
+            "process",
+            ReadHeader(headers, TraceParentHeader),
+            ReadHeader(headers, TraceStateHeader));
+        activity?.SetTag("messaging.message.id", messageId);
+        return activity;
+    }
+
+    public static void InjectCurrent(
+        IDictionary<string, object> headers,
+        string? fallbackTraceParent = null,
+        string? fallbackTraceState = null)
+    {
+        var traceParent = Activity.Current?.Id ?? fallbackTraceParent;
+        var traceState = Activity.Current?.TraceStateString ?? fallbackTraceState;
+
+        SetHeader(headers, TraceParentHeader, traceParent);
+        SetHeader(headers, TraceStateHeader, traceState);
+    }
+
+    public static void RecordException(Activity? activity, Exception exception)
+    {
+        activity?.SetStatus(ActivityStatusCode.Error, exception.Message);
+        activity?.SetTag("error.type", exception.GetType().FullName);
+        activity?.SetTag("exception.message", exception.Message);
+    }
+
+    private static Activity? StartActivity(
+        string name,
+        ActivityKind kind,
+        string messagingSystem,
+        string destination,
+        string operation,
+        string? traceParent,
+        string? traceState)
+    {
+        var parent = TryParseParent(traceParent, traceState, out var parsed)
+            ? parsed
+            : default;
+        var tags = new ActivityTagsCollection
+        {
+            ["messaging.system"] = messagingSystem,
+            ["messaging.destination.name"] = destination,
+            ["messaging.operation.name"] = operation,
+            ["messaging.operation.type"] = kind == ActivityKind.Producer ? "send" : "process"
+        };
+
+        return Source.StartActivity(name, kind, parent, tags);
+    }
+
+    private static bool TryParseParent(
+        string? traceParent,
+        string? traceState,
+        out ActivityContext parent)
+        => ActivityContext.TryParse(traceParent, traceState, isRemote: true, out parent);
+
+    private static string? ReadHeader(IDictionary<string, object>? headers, string name)
+    {
+        if (headers is null || !headers.TryGetValue(name, out var value))
+        {
+            return null;
+        }
+
+        return value switch
+        {
+            byte[] bytes => Encoding.UTF8.GetString(bytes),
+            ReadOnlyMemory<byte> bytes => Encoding.UTF8.GetString(bytes.Span),
+            string text => text,
+            _ => Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static void SetHeader(
+        IDictionary<string, object> headers,
+        string name,
+        string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            headers.Remove(name);
+            return;
+        }
+
+        headers[name] = Encoding.UTF8.GetBytes(value);
+    }
+}

--- a/Shared/Observability/ProjectYTelemetryExtensions.cs
+++ b/Shared/Observability/ProjectYTelemetryExtensions.cs
@@ -14,7 +14,9 @@ public static class ProjectYTelemetryExtensions
     public static IServiceCollection AddProjectYTelemetry(
         this IServiceCollection services,
         IConfiguration configuration,
-        string fallbackServiceName)
+        string fallbackServiceName,
+        Action<TracerProviderBuilder>? configureTracing = null,
+        params string[] additionalActivitySources)
     {
         var endpoint = GetEndpoint(configuration);
         if (endpoint is null)
@@ -27,16 +29,22 @@ public static class ProjectYTelemetryExtensions
 
         services.AddOpenTelemetry()
             .ConfigureResource(resource => resource.AddService(serviceName))
-            .WithTracing(tracing => tracing
-                .AddAspNetCoreInstrumentation(options =>
+            .WithTracing(tracing =>
+            {
+                tracing
+                    .AddSource(MessagingTraceContext.ActivitySourceName)
+                    .AddSource(additionalActivitySources)
+                    .AddAspNetCoreInstrumentation(options =>
                     options.Filter = context =>
                         !context.Request.Path.StartsWithSegments("/health"))
-                .AddHttpClientInstrumentation()
-                .AddOtlpExporter(options =>
-                {
-                    options.Endpoint = endpoint;
-                    options.Protocol = protocol;
-                }));
+                    .AddHttpClientInstrumentation()
+                    .AddOtlpExporter(options =>
+                    {
+                        options.Endpoint = endpoint;
+                        options.Protocol = protocol;
+                    });
+                configureTracing?.Invoke(tracing);
+            });
 
         return services;
     }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -128,9 +128,17 @@ startup.
 The four ASP.NET Core services instrument inbound requests and outbound
 `HttpClient` calls with the OpenTelemetry SDK. The Rust gateway creates a
 server span for each proxied request and propagates its W3C trace context to the
-upstream. Both runtimes keep their structured console output and also export
-logs and traces over OTLP to the Collector. The rental SLO dashboard selects
-the active `rental-operations` service and its `POST /api/Rental/create` span.
+upstream. PostgreSQL commands emitted through EF Core and native MongoDB driver
+operations are child spans of the request that triggered them. RabbitMQ trace
+context is captured in each transactional outbox row, continued by a producer
+span when the relay publishes, and restored by consumers; bounded retries keep
+the same W3C `traceparent` and `tracestate` headers. The same carrier contract
+applies to Kafka services as they are introduced; no application Kafka producer
+or consumer exists in the current tree.
+
+Both runtimes keep structured JSON console output and also export logs and
+traces over OTLP to the Collector. The rental SLO dashboard selects the active
+`rental-operations` service and its `POST /api/Rental/create` span.
 
 The audited baseline Compose stack runs every application in `Production`, so
 Swagger and the developer exception page are disabled. Local IDE launch


### PR DESCRIPTION
## Summary

- persist W3C trace context in transactional outbox rows and continue it through RabbitMQ producer/consumer spans
- instrument PostgreSQL through EF Core and MongoDB through the native driver activity source
- emit structured JSON logs and preserve trace headers across bounded retries
- document the current HTTP, database, RabbitMQ, and future Kafka carrier contract

## Verification

- `dotnet test AuthGate/AuthGate.sln --no-restore`
- `dotnet test MotoHub/MotoHub.sln --no-restore`
- `dotnet test RiderManager/RiderManager.sln --no-restore`
- `dotnet test RentalOperations/RentalOperations.sln --no-restore`
- `cargo test --manifest-path services/api-gateway/Cargo.toml`
- `dotnet format` for all four solutions
- `cargo fmt --manifest-path services/api-gateway/Cargo.toml -- --check`
- `git diff --check`

Closes #64