### PR TITLE
feat(observability): define rental SLO and error budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,11 @@ jobs:
           grep --recursive --quiet "${metric_prefix}_duration_milliseconds_bucket" deploy/observability/grafana
           grep --quiet --extended-regexp '^[[:space:]]+unit: ms$' deploy/observability/otel-collector.yaml
           ! grep --recursive --quiet "traces_spanmetrics_" deploy/observability/grafana
-          grep --fixed-strings --quiet 'service_name=\"rental-operations\"' deploy/observability/grafana/dashboards/slo-aluguel.json
-          grep --fixed-strings --quiet 'span_name=~\"POST /?api/Rental/create\"' deploy/observability/grafana/dashboards/slo-aluguel.json
+          grep --fixed-strings --quiet 'service_name=\"rental-operations\"' deploy/observability/grafana/dashboards/rental-creation-slo.json
+          grep --fixed-strings --quiet 'span_name=~\"POST /?api/Rental/create\"' deploy/observability/grafana/dashboards/rental-creation-slo.json
+          grep --fixed-strings --quiet 'http_response_status_code!~\"2..\"' deploy/observability/grafana/dashboards/rental-creation-slo.json
+          grep --fixed-strings --quiet 'le=\"2000.0\"' deploy/observability/grafana/dashboards/rental-creation-slo.json
+          test ! -e deploy/observability/grafana/dashboards/slo-aluguel.json
           ! grep --recursive --quiet 'rental-core' deploy/observability
 
       - name: Validate application telemetry exporters
@@ -200,6 +203,28 @@ jobs:
       - name: Generate ephemeral local credentials
         shell: pwsh
         run: ./scripts/New-LocalSecrets.ps1
+
+      - name: Verify Prometheus alert rules
+        run: |
+          docker run --rm --entrypoint promtool \
+            --volume "$PWD/deploy/observability:/observability:ro" \
+            prom/prometheus:v3.14.0 \
+            check rules \
+              /observability/rules/outbox.yml \
+              /observability/rules/rental-creation-slo.yml
+          docker run --rm --entrypoint promtool \
+            --volume "$PWD/deploy/observability:/observability:ro" \
+            prom/prometheus:v3.14.0 \
+            test rules /observability/tests/rental-creation-slo.test.yml
+
+      - name: Validate rental SLO drill
+        run: |
+          docker run --rm \
+            --volume "$PWD/load/k6:/scripts:ro" \
+            grafana/k6:2.2.0 \
+            inspect \
+              --env GATEWAY_IDENTITY_SIGNING_KEY=00000000000000000000000000000000 \
+              /scripts/rental-slo-drill.js
 
       - name: Start LGTM stack
         run: |

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ See [Running the audited baseline locally](docs/getting-started.md). This code
 contains known security flaws and development credentials; use it only in an
 isolated local environment.
 
+The [rental creation SLO and error-budget policy](docs/operations/rental-creation-slo.md)
+defines the 30-day availability and latency objectives, paging thresholds, and
+the release decision made when the budget is exhausted.
+
 Database-backed tests use the shared
 [PostgreSQL Testcontainers pattern](docs/testing/testcontainers-postgres.md).
 State-changing API retries follow the shared

--- a/deploy/observability/grafana/dashboards/rental-creation-slo.json
+++ b/deploy/observability/grafana/dashboards/rental-creation-slo.json
@@ -1,42 +1,27 @@
 {
-  "uid": "projecty-slo-aluguel",
-  "title": "ProjectY — SLO da criação de aluguel",
-  "description": "Objetivo: 99,5% das criações de aluguel bem-sucedidas em janela de 30 dias. O que separa um painel bonito de engenharia é ter um número que decide alguma coisa — aqui é o orçamento de erro.",
+  "uid": "projecty-rental-creation-slo",
+  "title": "ProjectY — Rental Creation SLO",
+  "description": "Objectives over a rolling 30-day window: 99.5% of rental creation requests return 2xx, and 99% complete within 2 seconds. The error budget controls release policy.",
   "tags": ["projecty", "slo"],
   "timezone": "browser",
   "editable": true,
   "schemaVersion": 39,
   "refresh": "30s",
   "time": { "from": "now-6h", "to": "now" },
-  "templating": {
-    "list": [
-      {
-        "name": "objetivo",
-        "label": "Objetivo (SLO)",
-        "type": "custom",
-        "query": "0.99,0.995,0.999",
-        "current": { "text": "0.995", "value": "0.995" },
-        "options": [
-          { "text": "0.99", "value": "0.99", "selected": false },
-          { "text": "0.995", "value": "0.995", "selected": true },
-          { "text": "0.999", "value": "0.999", "selected": false }
-        ]
-      }
-    ]
-  },
+  "templating": { "list": [] },
   "panels": [
     {
       "id": 1,
       "type": "stat",
-      "title": "Disponibilidade — 30 dias",
-      "description": "Requisições bem-sucedidas sobre o total, na janela do SLO.",
+      "title": "Availability — 30 days",
+      "description": "2xx rental creation responses divided by all eligible rental creation responses.",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
       "targets": [
         {
           "refId": "A",
-          "expr": "1 - (sum(increase(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\",status_code=\"STATUS_CODE_ERROR\"}[30d])) / clamp_min(sum(increase(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\"}[30d])), 1))",
-          "legendFormat": "disponibilidade"
+          "expr": "sum(increase(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\",span_kind=\"SPAN_KIND_SERVER\",http_response_status_code=~\"2..\"}[30d])) / clamp_min(sum(increase(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\",span_kind=\"SPAN_KIND_SERVER\"}[30d])), 1)",
+          "legendFormat": "availability"
         }
       ],
       "options": {
@@ -66,15 +51,15 @@
     {
       "id": 2,
       "type": "gauge",
-      "title": "Orçamento de erro restante",
-      "description": "Quanto do 0,5% de falha permitido ainda está disponível neste mês. Zerou, congela lançamento e o time volta para confiabilidade.",
+      "title": "Availability error budget remaining",
+      "description": "The remaining share of the 0.5% bad-event budget over the rolling 30-day window.",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "gridPos": { "h": 6, "w": 8, "x": 8, "y": 0 },
       "targets": [
         {
           "refId": "A",
-          "expr": "clamp_min(1 - ((sum(increase(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\",status_code=\"STATUS_CODE_ERROR\"}[30d])) / clamp_min(sum(increase(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\"}[30d])), 1)) / (1 - $objetivo)), 0)",
-          "legendFormat": "restante"
+          "expr": "clamp(1 - ((sum(increase(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\",span_kind=\"SPAN_KIND_SERVER\",http_response_status_code!~\"2..\"}[30d])) / clamp_min(sum(increase(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\",span_kind=\"SPAN_KIND_SERVER\"}[30d])), 1)) / 0.005), 0, 1)",
+          "legendFormat": "remaining"
         }
       ],
       "options": {
@@ -103,14 +88,14 @@
     {
       "id": 3,
       "type": "stat",
-      "title": "Queima agora (1 h)",
-      "description": "1x consome o orçamento exatamente no ritmo do mês. 14,4x esgota em pouco mais de dois dias — é o limiar de página.",
+      "title": "Current availability burn (1 hour)",
+      "description": "A burn rate of 1 consumes the budget exactly over 30 days. Paging requires both the long and short windows to cross their threshold.",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "gridPos": { "h": 6, "w": 8, "x": 16, "y": 0 },
       "targets": [
         {
           "refId": "A",
-          "expr": "(sum(rate(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\",status_code=\"STATUS_CODE_ERROR\"}[1h])) / clamp_min(sum(rate(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\"}[1h])), 0.001)) / (1 - $objetivo)",
+          "expr": "projecty:rental_creation_availability_bad_event_ratio:rate1h / 0.005",
           "legendFormat": "burn rate"
         }
       ],
@@ -139,20 +124,20 @@
     {
       "id": 4,
       "type": "timeseries",
-      "title": "Velocidade de queima em duas janelas",
-      "description": "A janela curta detecta rápido; a longa evita alarme por ruído. Só é incidente quando as duas cruzam o limiar juntas — é o padrão multi-window do SRE Workbook.",
+      "title": "Availability burn rate — short and long windows",
+      "description": "The short window detects an active incident; the long window rejects transient noise. Paging requires both windows to cross together.",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "gridPos": { "h": 9, "w": 24, "x": 0, "y": 6 },
       "targets": [
         {
           "refId": "A",
-          "expr": "(sum(rate(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\",status_code=\"STATUS_CODE_ERROR\"}[5m])) / clamp_min(sum(rate(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\"}[5m])), 0.001)) / (1 - $objetivo)",
-          "legendFormat": "janela curta (5 min)"
+          "expr": "projecty:rental_creation_availability_bad_event_ratio:rate5m / 0.005",
+          "legendFormat": "short window (5 minutes)"
         },
         {
           "refId": "B",
-          "expr": "(sum(rate(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\",status_code=\"STATUS_CODE_ERROR\"}[1h])) / clamp_min(sum(rate(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\"}[1h])), 0.001)) / (1 - $objetivo)",
-          "legendFormat": "janela longa (1 h)"
+          "expr": "projecty:rental_creation_availability_bad_event_ratio:rate1h / 0.005",
+          "legendFormat": "long window (1 hour)"
         }
       ],
       "options": {
@@ -186,12 +171,49 @@
       }
     },
     {
+      "id": 7,
+      "type": "stat",
+      "title": "Latency compliance — 30 days",
+      "description": "Share of eligible rental creation requests that completed within the 2-second objective.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 15 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(traces_span_metrics_duration_milliseconds_bucket{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\",span_kind=\"SPAN_KIND_SERVER\",le=\"2000.0\"}[30d])) / clamp_min(sum(increase(traces_span_metrics_duration_milliseconds_count{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\",span_kind=\"SPAN_KIND_SERVER\"}[30d])), 1)",
+          "legendFormat": "within 2 seconds"
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 3,
+          "min": 0.95,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 0.99 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
       "id": 5,
       "type": "timeseries",
-      "title": "Latência de criação de aluguel — p50, p95, p99",
-      "description": "O SLO de latência caminha junto com o de disponibilidade: uma requisição que responde em 8 s tecnicamente não falhou, mas o usuário desistiu.",
+      "title": "Rental creation latency — p50, p95, p99",
+      "description": "Latency objective: 99% of eligible rental creation requests complete within 2 seconds over 30 days.",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 15 },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 21 },
       "targets": [
         {
           "refId": "A",
@@ -232,20 +254,20 @@
     {
       "id": 6,
       "type": "timeseries",
-      "title": "Sucesso e falha por minuto",
-      "description": "O numerador e o denominador do SLO, lado a lado — para conferir que a conta acima está olhando volume de verdade e não uma amostra vazia.",
+      "title": "Success and failure per minute",
+      "description": "The availability SLI numerator and denominator shown together to expose low traffic and empty samples.",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 15 },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 21 },
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(rate(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\",status_code!=\"STATUS_CODE_ERROR\"}[1m])) * 60",
-          "legendFormat": "sucesso"
+          "expr": "sum(rate(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\",span_kind=\"SPAN_KIND_SERVER\",http_response_status_code=~\"2..\"}[1m])) * 60",
+          "legendFormat": "success"
         },
         {
           "refId": "B",
-          "expr": "sum(rate(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\",status_code=\"STATUS_CODE_ERROR\"}[1m])) * 60",
-          "legendFormat": "falha"
+          "expr": "sum(rate(traces_span_metrics_calls_total{service_name=\"rental-operations\",span_name=~\"POST /?api/Rental/create\",span_kind=\"SPAN_KIND_SERVER\",http_response_status_code!~\"2..\"}[1m])) * 60",
+          "legendFormat": "failure"
         }
       ],
       "options": {
@@ -268,7 +290,7 @@
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "falha" },
+            "matcher": { "id": "byName", "options": "failure" },
             "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }]
           }
         ]

--- a/deploy/observability/otel-collector.yaml
+++ b/deploy/observability/otel-collector.yaml
@@ -40,7 +40,7 @@ connectors:
     histogram:
       unit: ms
       explicit:
-        buckets: [2ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s]
+        buckets: [2ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2s, 2.5s, 5s]
     dimensions:
       - name: http.route
       - name: http.request.method

--- a/deploy/observability/rules/rental-creation-slo.yml
+++ b/deploy/observability/rules/rental-creation-slo.yml
@@ -1,0 +1,135 @@
+groups:
+  - name: projecty-rental-creation-slo
+    interval: 30s
+    rules:
+      - record: projecty:rental_creation_availability_bad_event_ratio:rate5m
+        expr: |
+          sum(rate(traces_span_metrics_calls_total{service_name="rental-operations",span_name=~"POST /?api/Rental/create",span_kind="SPAN_KIND_SERVER",http_response_status_code!~"2.."}[5m]))
+          /
+          clamp_min(sum(rate(traces_span_metrics_calls_total{service_name="rental-operations",span_name=~"POST /?api/Rental/create",span_kind="SPAN_KIND_SERVER"}[5m])), 0.001)
+        labels:
+          service: rental-operations
+
+      - record: projecty:rental_creation_availability_bad_event_ratio:rate30m
+        expr: |
+          sum(rate(traces_span_metrics_calls_total{service_name="rental-operations",span_name=~"POST /?api/Rental/create",span_kind="SPAN_KIND_SERVER",http_response_status_code!~"2.."}[30m]))
+          /
+          clamp_min(sum(rate(traces_span_metrics_calls_total{service_name="rental-operations",span_name=~"POST /?api/Rental/create",span_kind="SPAN_KIND_SERVER"}[30m])), 0.001)
+        labels:
+          service: rental-operations
+
+      - record: projecty:rental_creation_availability_bad_event_ratio:rate1h
+        expr: |
+          sum(rate(traces_span_metrics_calls_total{service_name="rental-operations",span_name=~"POST /?api/Rental/create",span_kind="SPAN_KIND_SERVER",http_response_status_code!~"2.."}[1h]))
+          /
+          clamp_min(sum(rate(traces_span_metrics_calls_total{service_name="rental-operations",span_name=~"POST /?api/Rental/create",span_kind="SPAN_KIND_SERVER"}[1h])), 0.001)
+        labels:
+          service: rental-operations
+
+      - record: projecty:rental_creation_availability_bad_event_ratio:rate6h
+        expr: |
+          sum(rate(traces_span_metrics_calls_total{service_name="rental-operations",span_name=~"POST /?api/Rental/create",span_kind="SPAN_KIND_SERVER",http_response_status_code!~"2.."}[6h]))
+          /
+          clamp_min(sum(rate(traces_span_metrics_calls_total{service_name="rental-operations",span_name=~"POST /?api/Rental/create",span_kind="SPAN_KIND_SERVER"}[6h])), 0.001)
+        labels:
+          service: rental-operations
+
+      - record: projecty:rental_creation_latency_bad_event_ratio:rate5m
+        expr: |
+          clamp_min(
+            1 - (
+              sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name="rental-operations",span_name=~"POST /?api/Rental/create",span_kind="SPAN_KIND_SERVER",le="2000.0"}[5m]))
+              /
+              clamp_min(sum(rate(traces_span_metrics_duration_milliseconds_count{service_name="rental-operations",span_name=~"POST /?api/Rental/create",span_kind="SPAN_KIND_SERVER"}[5m])), 0.001)
+            ),
+            0
+          )
+        labels:
+          service: rental-operations
+
+      - record: projecty:rental_creation_latency_bad_event_ratio:rate30m
+        expr: |
+          clamp_min(
+            1 - (
+              sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name="rental-operations",span_name=~"POST /?api/Rental/create",span_kind="SPAN_KIND_SERVER",le="2000.0"}[30m]))
+              /
+              clamp_min(sum(rate(traces_span_metrics_duration_milliseconds_count{service_name="rental-operations",span_name=~"POST /?api/Rental/create",span_kind="SPAN_KIND_SERVER"}[30m])), 0.001)
+            ),
+            0
+          )
+        labels:
+          service: rental-operations
+
+      - record: projecty:rental_creation_latency_bad_event_ratio:rate1h
+        expr: |
+          clamp_min(
+            1 - (
+              sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name="rental-operations",span_name=~"POST /?api/Rental/create",span_kind="SPAN_KIND_SERVER",le="2000.0"}[1h]))
+              /
+              clamp_min(sum(rate(traces_span_metrics_duration_milliseconds_count{service_name="rental-operations",span_name=~"POST /?api/Rental/create",span_kind="SPAN_KIND_SERVER"}[1h])), 0.001)
+            ),
+            0
+          )
+        labels:
+          service: rental-operations
+
+      - record: projecty:rental_creation_latency_bad_event_ratio:rate6h
+        expr: |
+          clamp_min(
+            1 - (
+              sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name="rental-operations",span_name=~"POST /?api/Rental/create",span_kind="SPAN_KIND_SERVER",le="2000.0"}[6h]))
+              /
+              clamp_min(sum(rate(traces_span_metrics_duration_milliseconds_count{service_name="rental-operations",span_name=~"POST /?api/Rental/create",span_kind="SPAN_KIND_SERVER"}[6h])), 0.001)
+            ),
+            0
+          )
+        labels:
+          service: rental-operations
+
+      - alert: ProjectYRentalCreationAvailabilityBudgetFastBurn
+        expr: |
+          (
+            projecty:rental_creation_availability_bad_event_ratio:rate1h > (14.4 * 0.005)
+            and
+            projecty:rental_creation_availability_bad_event_ratio:rate5m > (14.4 * 0.005)
+          )
+          or
+          (
+            projecty:rental_creation_availability_bad_event_ratio:rate6h > (6 * 0.005)
+            and
+            projecty:rental_creation_availability_bad_event_ratio:rate30m > (6 * 0.005)
+          )
+        for: 2m
+        labels:
+          severity: page
+          service: rental-operations
+          slo: availability
+          team: rentals
+        annotations:
+          summary: Rental creation availability is consuming error budget too quickly
+          description: Both a long and a short burn-rate window crossed the paging threshold.
+          runbook_url: https://github.com/iVega123/ProjectY/blob/main/docs/operations/rental-creation-slo.md
+
+      - alert: ProjectYRentalCreationLatencyBudgetFastBurn
+        expr: |
+          (
+            projecty:rental_creation_latency_bad_event_ratio:rate1h > (14.4 * 0.01)
+            and
+            projecty:rental_creation_latency_bad_event_ratio:rate5m > (14.4 * 0.01)
+          )
+          or
+          (
+            projecty:rental_creation_latency_bad_event_ratio:rate6h > (6 * 0.01)
+            and
+            projecty:rental_creation_latency_bad_event_ratio:rate30m > (6 * 0.01)
+          )
+        for: 2m
+        labels:
+          severity: page
+          service: rental-operations
+          slo: latency
+          team: rentals
+        annotations:
+          summary: Rental creation latency is consuming error budget too quickly
+          description: Both a long and a short burn-rate window crossed the paging threshold.
+          runbook_url: https://github.com/iVega123/ProjectY/blob/main/docs/operations/rental-creation-slo.md

--- a/deploy/observability/tests/rental-creation-slo.test.yml
+++ b/deploy/observability/tests/rental-creation-slo.test.yml
@@ -1,0 +1,95 @@
+rule_files:
+  - ../rules/rental-creation-slo.yml
+
+evaluation_interval: 1m
+
+tests:
+  - name: sustained availability failures page after both windows cross
+    interval: 1m
+    input_series:
+      - series: 'traces_span_metrics_calls_total{service_name="rental-operations",span_name="POST api/Rental/create",span_kind="SPAN_KIND_SERVER",http_response_status_code="200"}'
+        values: '0+90x420'
+      - series: 'traces_span_metrics_calls_total{service_name="rental-operations",span_name="POST api/Rental/create",span_kind="SPAN_KIND_SERVER",http_response_status_code="500"}'
+        values: '0+10x420'
+      - series: 'traces_span_metrics_duration_milliseconds_count{service_name="rental-operations",span_name="POST api/Rental/create",span_kind="SPAN_KIND_SERVER"}'
+        values: '0+100x420'
+      - series: 'traces_span_metrics_duration_milliseconds_bucket{service_name="rental-operations",span_name="POST api/Rental/create",span_kind="SPAN_KIND_SERVER",le="2000.0"}'
+        values: '0+100x420'
+    alert_rule_test:
+      - eval_time: 7h
+        alertname: ProjectYRentalCreationAvailabilityBudgetFastBurn
+        exp_alerts:
+          - exp_labels:
+              severity: page
+              service: rental-operations
+              slo: availability
+              team: rentals
+            exp_annotations:
+              summary: Rental creation availability is consuming error budget too quickly
+              description: Both a long and a short burn-rate window crossed the paging threshold.
+              runbook_url: https://github.com/iVega123/ProjectY/blob/main/docs/operations/rental-creation-slo.md
+      - eval_time: 7h
+        alertname: ProjectYRentalCreationLatencyBudgetFastBurn
+        exp_alerts: []
+
+  - name: sustained slow requests page without an availability page
+    interval: 1m
+    input_series:
+      - series: 'traces_span_metrics_calls_total{service_name="rental-operations",span_name="POST api/Rental/create",span_kind="SPAN_KIND_SERVER",http_response_status_code="200"}'
+        values: '0+100x420'
+      - series: 'traces_span_metrics_duration_milliseconds_count{service_name="rental-operations",span_name="POST api/Rental/create",span_kind="SPAN_KIND_SERVER"}'
+        values: '0+100x420'
+      - series: 'traces_span_metrics_duration_milliseconds_bucket{service_name="rental-operations",span_name="POST api/Rental/create",span_kind="SPAN_KIND_SERVER",le="2000.0"}'
+        values: '0+80x420'
+    alert_rule_test:
+      - eval_time: 7h
+        alertname: ProjectYRentalCreationAvailabilityBudgetFastBurn
+        exp_alerts: []
+      - eval_time: 7h
+        alertname: ProjectYRentalCreationLatencyBudgetFastBurn
+        exp_alerts:
+          - exp_labels:
+              severity: page
+              service: rental-operations
+              slo: latency
+              team: rentals
+            exp_annotations:
+              summary: Rental creation latency is consuming error budget too quickly
+              description: Both a long and a short burn-rate window crossed the paging threshold.
+              runbook_url: https://github.com/iVega123/ProjectY/blob/main/docs/operations/rental-creation-slo.md
+
+  - name: healthy traffic does not page
+    interval: 1m
+    input_series:
+      - series: 'traces_span_metrics_calls_total{service_name="rental-operations",span_name="POST api/Rental/create",span_kind="SPAN_KIND_SERVER",http_response_status_code="200"}'
+        values: '0+100x420'
+      - series: 'traces_span_metrics_duration_milliseconds_count{service_name="rental-operations",span_name="POST api/Rental/create",span_kind="SPAN_KIND_SERVER"}'
+        values: '0+100x420'
+      - series: 'traces_span_metrics_duration_milliseconds_bucket{service_name="rental-operations",span_name="POST api/Rental/create",span_kind="SPAN_KIND_SERVER",le="2000.0"}'
+        values: '0+100x420'
+    alert_rule_test:
+      - eval_time: 7h
+        alertname: ProjectYRentalCreationAvailabilityBudgetFastBurn
+        exp_alerts: []
+      - eval_time: 7h
+        alertname: ProjectYRentalCreationLatencyBudgetFastBurn
+        exp_alerts: []
+
+  - name: a short-window availability spike cannot page by itself
+    interval: 1m
+    input_series:
+      - series: 'traces_span_metrics_calls_total{service_name="rental-operations",span_name="POST api/Rental/create",span_kind="SPAN_KIND_SERVER",http_response_status_code="200"}'
+        values: '0+100x414 41490+90x5'
+      - series: 'traces_span_metrics_calls_total{service_name="rental-operations",span_name="POST api/Rental/create",span_kind="SPAN_KIND_SERVER",http_response_status_code="500"}'
+        values: '0+0x414 10+10x5'
+      - series: 'traces_span_metrics_duration_milliseconds_count{service_name="rental-operations",span_name="POST api/Rental/create",span_kind="SPAN_KIND_SERVER"}'
+        values: '0+100x420'
+      - series: 'traces_span_metrics_duration_milliseconds_bucket{service_name="rental-operations",span_name="POST api/Rental/create",span_kind="SPAN_KIND_SERVER",le="2000.0"}'
+        values: '0+100x420'
+    alert_rule_test:
+      - eval_time: 7h
+        alertname: ProjectYRentalCreationAvailabilityBudgetFastBurn
+        exp_alerts: []
+      - eval_time: 7h
+        alertname: ProjectYRentalCreationLatencyBudgetFastBurn
+        exp_alerts: []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -494,6 +494,29 @@ services:
       redis:
         condition: service_healthy
 
+  k6-slo-drill:
+    image: grafana/k6:2.2.0
+    profiles: ["load"]
+    command: ["run", "--out", "experimental-prometheus-rw", "/scripts/rental-slo-drill.js"]
+    environment:
+      K6_PROMETHEUS_RW_SERVER_URL: http://prometheus:9090/api/v1/write
+      K6_PROMETHEUS_RW_TREND_STATS: "p(95),p(99),min,max"
+      BASE_URL: http://rental-operations:8200
+      GATEWAY_IDENTITY_SIGNING_KEY: "${GATEWAY_IDENTITY_SIGNING_KEY:?Set GATEWAY_IDENTITY_SIGNING_KEY in .env}"
+      GATEWAY_IDENTITY_SIGNING_KEY_ID: local-v1
+      SLO_DRILL_SUBJECT: slo-drill-rider
+      VUS: "${K6_VUS:-5}"
+      DURATION: "${K6_DURATION:-6m}"
+    volumes:
+      - ./load/k6:/scripts:ro
+    networks:
+      - projecty
+    depends_on:
+      rental-operations:
+        condition: service_healthy
+      prometheus:
+        condition: service_healthy
+
 networks:
   projecty:
     driver: bridge

--- a/docs/operations/rental-creation-slo.md
+++ b/docs/operations/rental-creation-slo.md
@@ -1,0 +1,112 @@
+# Rental creation SLO and error-budget policy
+
+## Objectives
+
+The service-level indicator includes every server span named
+`POST api/Rental/create` (with or without a leading slash in the route name)
+from `rental-operations`.
+
+| Objective | Good event | Target | Window | Error budget |
+|---|---|---:|---:|---:|
+| Availability | HTTP response status is 2xx | 99.5% | Rolling 30 days | 0.5% non-2xx responses |
+| Latency | Request completes within 2 seconds | 99% | Rolling 30 days | 1% slower responses |
+
+The latency boundary is an explicit spanmetrics histogram bucket, so the SLI is
+a good-event ratio rather than an estimate derived from a percentile. Empty or
+missing telemetry is unknown, not 100% availability. At low traffic, the team
+must inspect the event counts shown beside the SLI before interpreting a burn
+rate.
+
+For example, 10,000 eligible rental creation attempts provide an availability
+budget of 50 non-2xx responses and a latency budget of 100 responses over two
+seconds. The dashboard reports the remaining fraction of the availability
+budget rather than presenting a calendar-month uptime percentage.
+
+## Paging policy
+
+Prometheus evaluates two multi-window pairs for each objective. The fast pair
+pages when both the five-minute and one-hour bad-event ratios exceed a 14.4x
+burn rate. The sustained pair pages when both the 30-minute and six-hour ratios
+exceed a 6x burn rate. A short window can never page by itself. Availability
+burn is divided by its 0.5% budget; latency burn is divided by its 1% budget.
+
+The Rentals on-call engineer owns the page and incident response. When either
+budget reaches zero, the Rentals engineering lead freezes feature releases and
+risky configuration changes that can affect rental creation; reliability,
+security, rollback, and incident-mitigation changes remain allowed. The
+engineering lead and product owner jointly approve any other exception and
+record the reason in the incident. They may lift the freeze only after the
+active burn is below 1x for 24 hours, a root cause or bounded mitigation has an
+owner, and the rolling-budget projection is positive. Below 25% remaining, any
+change to the path requires an explicit reliability-impact review even if no
+page is active.
+
+The rules live in
+[`deploy/observability/rules/rental-creation-slo.yml`](../../deploy/observability/rules/rental-creation-slo.yml)
+and are unit-tested with `promtool`. The `severity: page`, `team: rentals`, and
+`slo` labels are the routing contract for an Alertmanager integration; the
+local stack intentionally exposes rule state without contacting people.
+
+## Availability burn drill
+
+The drill sends real, authenticated requests to the current Rental Operations
+endpoint. It signs the same short-lived internal identity envelope used by the
+gateway and deliberately supplies an inverted rental period. The controller
+returns `400`, no rental is written, and the application exports the resulting
+server spans through the normal OTLP path. This tests the SLO failure numerator
+without weakening authentication or relying on a future identity issuer.
+
+Start the normal stack, then run the opt-in load profile:
+
+```powershell
+docker compose --env-file .env up --build --detach --wait --wait-timeout 300
+$env:K6_VUS = '5'
+$env:K6_DURATION = '6m'
+docker compose --env-file .env --profile load run --rm k6-slo-drill
+```
+
+After the Collector batch and Prometheus scrape intervals have elapsed, open
+**ProjectY — Rental Creation SLO** in Grafana. The failure series must increase,
+the five-minute availability burn rate must approach `200x` (100% bad events
+divided by the 0.5% budget), and Prometheus must show the availability alert as
+pending or firing once both windows have crossed for the configured duration.
+
+The same facts can be checked through the Prometheus API:
+
+```powershell
+$queries = @(
+    'projecty:rental_creation_availability_bad_event_ratio:rate5m / 0.005',
+    'projecty:rental_creation_availability_bad_event_ratio:rate1h / 0.005',
+    'ALERTS{alertname="ProjectYRentalCreationAvailabilityBudgetFastBurn"}'
+)
+
+foreach ($query in $queries) {
+    $encoded = [uri]::EscapeDataString($query)
+    Invoke-RestMethod "http://localhost:9090/api/v1/query?query=$encoded"
+}
+```
+
+Record the dashboard time range, k6 VUs and duration, both burn-rate values,
+and the alert state in the issue or pull request. Stop the local stack after
+the evidence has been captured:
+
+```powershell
+docker compose --env-file .env down
+```
+
+## Rule verification
+
+CI uses the Prometheus version pinned by Compose. The equivalent local commands
+are:
+
+```powershell
+docker run --rm --entrypoint promtool `
+  --volume "${PWD}/deploy/observability:/observability:ro" `
+  prom/prometheus:v3.14.0 `
+  check rules /observability/rules/rental-creation-slo.yml
+
+docker run --rm --entrypoint promtool `
+  --volume "${PWD}/deploy/observability:/observability:ro" `
+  prom/prometheus:v3.14.0 `
+  test rules /observability/tests/rental-creation-slo.test.yml
+```

--- a/load/k6/rental-slo-drill.js
+++ b/load/k6/rental-slo-drill.js
@@ -1,0 +1,81 @@
+import http from "k6/http";
+import crypto from "k6/crypto";
+import { check, sleep } from "k6";
+
+const BASE_URL = __ENV.BASE_URL || "http://rental-operations:8200";
+const PATH = "/api/Rental/create";
+const SIGNING_KEY = __ENV.GATEWAY_IDENTITY_SIGNING_KEY;
+const KEY_ID = __ENV.GATEWAY_IDENTITY_SIGNING_KEY_ID || "local-v1";
+const SUBJECT = __ENV.SLO_DRILL_SUBJECT || "slo-drill-rider";
+const AUDIENCE = "projecty.rental-operations";
+const VUS = Number.parseInt(__ENV.VUS || "5", 10);
+const DURATION = __ENV.DURATION || "6m";
+
+if (!SIGNING_KEY || SIGNING_KEY.length < 32) {
+  throw new Error("GATEWAY_IDENTITY_SIGNING_KEY must contain at least 32 characters");
+}
+
+export const options = {
+  scenarios: {
+    availabilityBurnDrill: {
+      executor: "constant-vus",
+      vus: VUS,
+      duration: DURATION,
+      gracefulStop: "5s",
+    },
+  },
+  thresholds: {
+    checks: ["rate>0.99"],
+  },
+  discardResponseBodies: true,
+};
+
+function identityHeaders(method, path) {
+  const issuedAt = Math.floor(Date.now() / 1000).toString();
+  const roles = "Rider";
+  const canonical = [
+    "v1",
+    KEY_ID,
+    SUBJECT,
+    roles,
+    issuedAt,
+    method,
+    path,
+    AUDIENCE,
+  ].join("\n");
+  const signature = crypto.hmac(
+    "sha256",
+    SIGNING_KEY,
+    canonical,
+    "base64rawurl",
+  );
+
+  return {
+    "Content-Type": "application/json",
+    "x-identity-key-id": KEY_ID,
+    "x-identity-subject": SUBJECT,
+    "x-identity-roles": roles,
+    "x-identity-issued-at": issuedAt,
+    "x-identity-signature": `v1=${signature}`,
+  };
+}
+
+export default function () {
+  const startsAt = new Date(Date.now() + 8 * 86400000).toISOString();
+  const predictedEndsAt = new Date(Date.now() + 1 * 86400000).toISOString();
+  const payload = JSON.stringify({
+    motocycleLicencePlate: "ABC1D23",
+    startDate: startsAt,
+    predictedEndDate: predictedEndsAt,
+  });
+
+  const response = http.post(`${BASE_URL}${PATH}`, payload, {
+    headers: identityHeaders("POST", PATH),
+    tags: { name: "POST /api/Rental/create", drill: "availability-burn" },
+  });
+
+  check(response, {
+    "controlled invalid period returns 400": (result) => result.status === 400,
+  });
+  sleep(0.2);
+}


### PR DESCRIPTION
Closes #66

## Summary

- define the rental creation availability SLO at 99.5% over 30 days and the latency SLO at 99% within 2 seconds
- version multi-window, multi-burn recording and paging rules plus promtool tests, including proof that a short window cannot page alone
- replace the Portuguese dashboard filename and content with an English error-budget dashboard backed by the versioned rules
- document the exhausted-budget release policy, decision owners, and recovery criteria
- add an opt-in authenticated k6 drill that emits real application spans and remote-writes k6 results to Prometheus

## Validation

- `promtool check rules`: 10 SLO rules and 2 existing outbox rules passed
- `promtool test rules`: availability burn, latency burn, healthy traffic, and short-window-only scenarios passed
- `k6 inspect`: script and default scenario passed with the pinned k6 2.2.0 image
- root and self-hosted Compose configurations passed validation
- isolated runtime drill: 446/446 checks passed; all availability windows reached 200x burn, latency stayed at 0x, and the availability page progressed from pending to firing
- Grafana provisioned `projecty-rental-creation-slo` with 7 panels; the runtime drill used the currently instrumented Rental Operations image from task #65
