### PR TITLE
feat(resilience): route active dependencies through Toxiproxy

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -1,0 +1,24 @@
+name: Dependency chaos
+on:
+  pull_request:
+    paths:
+      - 'docker-compose*.yml'
+      - 'deploy/chaos/**'
+      - 'scripts/*Chaos.ps1'
+      - 'scripts/chaos.sh'
+      - '.github/workflows/chaos.yml'
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  proxy-recovery:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Generate isolated credentials
+        shell: pwsh
+        run: ./scripts/New-LocalSecrets.ps1
+      - name: Verify dependency routing and live fault recovery
+        shell: pwsh
+        run: ./scripts/Test-Chaos.ps1

--- a/README.md
+++ b/README.md
@@ -153,3 +153,5 @@ the scans that run before publication.
 - [All modernization epics](https://github.com/iVega123/ProjectY/issues?q=is%3Aissue%20state%3Aopen%20label%3Aepic)
 - [Architecture decision records](docs/adr/README.md)
 - [Six-part article series](https://github.com/iVega123/ProjectY/issues/13)
+
+Dependency fault injection in the active development stack: [commands and recovery contract](docs/dependency-fault-injection.md).

--- a/Tiltfile
+++ b/Tiltfile
@@ -45,7 +45,7 @@ if missing_local_files:
     fail(missing_files_message)
 
 docker_compose(
-    'docker-compose.yml',
+    ['docker-compose.yml', 'docker-compose.chaos.yml'],
     env_file = '.env',
     project_name = 'projecty',
 )
@@ -83,7 +83,7 @@ configure_live_update(
     'cd /workspace && cargo fetch --locked',
     'cd /workspace && cargo build --locked',
 )
-infra_resources = ['postgres', 'redis', 'rabbitmq', 'mongodb', 'minio']
+infra_resources = ['toxiproxy', 'postgres', 'redis', 'rabbitmq', 'mongodb', 'minio']
 observability_resources = ['tempo', 'loki', 'otel-collector', 'prometheus', 'grafana']
 setup_resources = ['auth-gate-migrations', 'rider-manager-migrations', 'moto-hub-migrations']
 service_resources = ['auth-gate', 'rider-manager', 'moto-hub', 'rental-operations']

--- a/deploy/chaos/toxiproxy-active.json
+++ b/deploy/chaos/toxiproxy-active.json
@@ -1,0 +1,32 @@
+[
+    {
+        "name":  "postgres",
+        "listen":  "0.0.0.0:5432",
+        "upstream":  "postgres:5432",
+        "enabled":  true
+    },
+    {
+        "name":  "redis",
+        "listen":  "0.0.0.0:6379",
+        "upstream":  "redis:6379",
+        "enabled":  true
+    },
+    {
+        "name":  "rabbitmq",
+        "listen":  "0.0.0.0:5672",
+        "upstream":  "rabbitmq:5672",
+        "enabled":  true
+    },
+    {
+        "name":  "mongodb",
+        "listen":  "0.0.0.0:27017",
+        "upstream":  "mongodb:27017",
+        "enabled":  true
+    },
+    {
+        "name":  "minio",
+        "listen":  "0.0.0.0:9000",
+        "upstream":  "minio:9000",
+        "enabled":  true
+    }
+]

--- a/docker-compose.chaos.yml
+++ b/docker-compose.chaos.yml
@@ -1,0 +1,86 @@
+# Development-only: loaded by Tilt, never by the production entrypoint.
+services:
+  toxiproxy:
+    image: ghcr.io/shopify/toxiproxy:2.12.0
+    command: ["-host=0.0.0.0", "-config=/config/toxiproxy.json"]
+    ports:
+      - "127.0.0.1:8474:8474"
+    volumes:
+      - ./deploy/chaos/toxiproxy-active.json:/config/toxiproxy.json:ro
+    networks: [projecty]
+    healthcheck:
+      test: ["CMD", "/toxiproxy-cli", "list"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+
+  api-gateway:
+    environment:
+      GATEWAY_REDIS_URL: redis://toxiproxy:6379/
+    depends_on:
+      toxiproxy:
+        condition: service_healthy
+  auth-gate-migrations:
+    environment:
+      ConnectionStrings__Postgresql: "Host=toxiproxy;Port=5432;Database=${AUTH_GATE_POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
+      Redis__ConnectionString: toxiproxy:6379
+      RabbitMQ__HostName: toxiproxy
+    depends_on:
+      toxiproxy:
+        condition: service_healthy
+
+  auth-gate:
+    environment:
+      ConnectionStrings__Postgresql: "Host=toxiproxy;Port=5432;Database=${AUTH_GATE_POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
+      Redis__ConnectionString: toxiproxy:6379
+      RabbitMQ__HostName: toxiproxy
+    depends_on:
+      toxiproxy:
+        condition: service_healthy
+
+  rider-manager-migrations:
+    environment:
+      ConnectionStrings__Postgresql: "Host=toxiproxy;Port=5432;Database=${RIDER_MANAGER_POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
+      Redis__ConnectionString: toxiproxy:6379
+      RabbitMQ__HostName: toxiproxy
+      MinIO__Endpoint: toxiproxy
+    depends_on:
+      toxiproxy:
+        condition: service_healthy
+
+  rider-manager:
+    environment:
+      ConnectionStrings__Postgresql: "Host=toxiproxy;Port=5432;Database=${RIDER_MANAGER_POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
+      Redis__ConnectionString: toxiproxy:6379
+      RabbitMQ__HostName: toxiproxy
+      MinIO__Endpoint: toxiproxy
+    depends_on:
+      toxiproxy:
+        condition: service_healthy
+
+  moto-hub-migrations:
+    environment:
+      ConnectionStrings__Postgresql: "Host=toxiproxy;Port=5432;Database=${MOTO_HUB_POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
+      Redis__ConnectionString: toxiproxy:6379
+      RabbitMQ__HostName: toxiproxy
+    depends_on:
+      toxiproxy:
+        condition: service_healthy
+
+  moto-hub:
+    environment:
+      ConnectionStrings__Postgresql: "Host=toxiproxy;Port=5432;Database=${MOTO_HUB_POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
+      Redis__ConnectionString: toxiproxy:6379
+      RabbitMQ__HostName: toxiproxy
+    depends_on:
+      toxiproxy:
+        condition: service_healthy
+
+  rental-operations:
+    environment:
+      MongoDbSettings__ConnectionString: "mongodb://${MONGO_USER}:${MONGO_PASSWORD}@toxiproxy:27017/?directConnection=true"
+      Redis__ConnectionString: toxiproxy:6379
+      RabbitMQ__HostName: toxiproxy
+    depends_on:
+      toxiproxy:
+        condition: service_healthy

--- a/docs/dependency-fault-injection.md
+++ b/docs/dependency-fault-injection.md
@@ -1,0 +1,41 @@
+# Dependency fault injection
+
+Tilt loads `docker-compose.yml` plus `docker-compose.chaos.yml`. The latter is
+**development-only**: production retains direct endpoints and uses AWS FIS for
+controlled infrastructure experiments. Do not include the chaos overlay in a
+production deployment. The unauthenticated control API binds to loopback only.
+
+The active .NET topology routes PostgreSQL, Redis, RabbitMQ, MongoDB and MinIO
+through `toxiproxy` on their native ports. Keeping the native AMQP and object-store
+ports also routes the existing TCP readiness checks through the same listeners.
+Migrations wait for both the proxy and their database. Application services and
+the gateway wait for proxy health before startup. Infrastructure self-checks and
+administrative tools intentionally address their own backends directly.
+
+```powershell
+# Tilt enables the overlay automatically.
+tilt up
+powershell -File scripts/Invoke-Chaos.ps1 list
+powershell -File scripts/Invoke-Chaos.ps1 add postgres slow-db -Value 500
+powershell -File scripts/Invoke-Chaos.ps1 remove postgres slow-db
+powershell -File scripts/Invoke-Chaos.ps1 add redis redis-down -Type timeout -Value 0
+powershell -File scripts/Invoke-Chaos.ps1 reset
+```
+
+On Linux/macOS use `bash scripts/chaos.sh` with the same arguments (PowerShell 7
+required). `add` replaces a toxic of the same name, `remove` is repeatable, and
+`reset` removes every toxic and enables all proxies. None restarts a service.
+Removing a fault allows clients to reconnect; application recovery is verified
+separately by the degradation drills, rather than inferred from an open port.
+
+To run Compose directly:
+
+```sh
+docker compose -f docker-compose.yml -f docker-compose.chaos.yml up -d
+```
+
+The separate `deploy/chaos/toxiproxy.json` belongs to the future self-hosted
+topology. Kafka, Cassandra and the new application services are not part of the
+active root stack; their end-to-end drills remain dependent on #10 and #130.
+Task #67 covers the running topology; #68 and #71 must remain open until their
+remaining service-dependent acceptance criteria are demonstrated.

--- a/scripts/Invoke-Chaos.ps1
+++ b/scripts/Invoke-Chaos.ps1
@@ -1,0 +1,38 @@
+#requires -Version 5.1
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position=0)]
+    [ValidateSet('list', 'add', 'remove', 'reset')][string]$Action,
+    [Parameter(Position=1)][ValidatePattern('^[a-z0-9_-]+$')][string]$Proxy,
+    [Parameter(Position=2)][ValidatePattern('^[a-z0-9_-]+$')][string]$Name = 'drill',
+    [ValidateSet('latency', 'timeout', 'slicer', 'limit_data')][string]$Type = 'latency',
+    [ValidateRange(0, 60000)][int]$Value = 500,
+    [string]$Url = 'http://127.0.0.1:8474'
+)
+$ErrorActionPreference = 'Stop'
+$Url = $Url.TrimEnd('/')
+function Request([string]$Method, [string]$Path, $Body) {
+    $parameters = @{Method=$Method; Uri="$Url$Path"; TimeoutSec=10; UseBasicParsing=$true; UserAgent='ProjectY-Chaos/1.0'}
+    if ($null -ne $Body) {
+        $parameters.ContentType = 'application/json'
+        $parameters.Body = $Body | ConvertTo-Json -Depth 8 -Compress
+    }
+    Invoke-RestMethod @parameters
+}
+if ($Action -eq 'list') { Request GET '/proxies' $null | ConvertTo-Json -Depth 10; exit }
+if ($Action -eq 'reset') { Request POST '/reset' $null; Write-Host 'All toxics cleared and proxies enabled.'; exit }
+if (-not $Proxy) { throw 'A proxy name is required; use list to inspect the active topology.' }
+$current = Request GET "/proxies/$Proxy" $null
+if ($current.toxics | Where-Object { $_.name -eq $Name }) {
+    Request DELETE "/proxies/$Proxy/toxics/$Name" $null
+}
+if ($Action -eq 'remove') { Write-Host "Removed $Name from $Proxy."; exit }
+$attributes = switch ($Type) {
+    'latency' { @{latency=$Value; jitter=0} }
+    'timeout' { @{timeout=$Value} }
+    'slicer' { @{average_size=64; size_variation=16; delay=$Value} }
+    'limit_data' { @{bytes=$Value} }
+}
+Request POST "/proxies/$Proxy/toxics" @{name=$Name; type=$Type; stream='downstream'; toxicity=1.0; attributes=$attributes} | Out-Null
+Write-Host "Applied $Name ($Type=$Value) to $Proxy."
+Write-Host 'Observe: http://localhost:3000 (Grafana), gateway /metrics, and the affected service trace.'

--- a/scripts/Test-Chaos.ps1
+++ b/scripts/Test-Chaos.ps1
@@ -52,7 +52,7 @@ try {
 } finally {
     if (Test-Path -LiteralPath $fixture) {
         docker compose -p $project -f $fixture down
-        Remove-Item -LiteralPath $fixture
+        Remove-Item -LiteralPath $fixture -Force
     }
     Pop-Location
 }

--- a/scripts/Test-Chaos.ps1
+++ b/scripts/Test-Chaos.ps1
@@ -1,0 +1,58 @@
+#requires -Version 5.1
+# Integration contract: real Redis traffic crosses the proxy and recovers in-place.
+$ErrorActionPreference = 'Stop'
+$root = Split-Path $PSScriptRoot -Parent
+Push-Location $root
+$fixture = Join-Path $root '.env.chaos-validation.json'
+$project = 'projecty-chaos-validation'
+try {
+    $json = docker compose -f docker-compose.yml -f docker-compose.chaos.yml config --format json
+    if ($LASTEXITCODE) { throw 'Compose configuration failed.' }
+    $model = $json | ConvertFrom-Json
+    foreach ($service in @('auth-gate','rider-manager','moto-hub','rental-operations')) {
+        $environment = $model.services.$service.environment
+        foreach ($key in @('Redis__ConnectionString','RabbitMQ__HostName')) {
+            if ($environment.$key -notmatch '^toxiproxy(:|$)') { throw "$service bypasses proxy: $key" }
+        }
+        $dbKey = if ($service -eq 'rental-operations') { 'MongoDbSettings__ConnectionString' } else { 'ConnectionStrings__Postgresql' }
+        if ($environment.$dbKey -notmatch 'toxiproxy') { throw "$service bypasses its database proxy." }
+        if ($model.services.$service.depends_on.toxiproxy.condition -ne 'service_healthy') { throw "$service is not health-gated." }
+    }
+    if ($model.services.'api-gateway'.environment.GATEWAY_REDIS_URL -notmatch '://toxiproxy:') { throw 'Gateway bypasses Redis proxy.' }
+    if ($model.services.'rider-manager'.environment.MinIO__Endpoint -ne 'toxiproxy') { throw 'Object storage bypasses proxy.' }
+    # Isolate from existing developer containers, names, ports and persistent data.
+    $model.name = $project
+    foreach ($service in $model.services.PSObject.Properties.Value) { $service.PSObject.Properties.Remove('container_name'); $service.PSObject.Properties.Remove('ports') }
+    foreach ($volume in $model.volumes.PSObject.Properties.Value) { $volume.PSObject.Properties.Remove('name') }
+    foreach ($network in $model.networks.PSObject.Properties.Value) { $network.PSObject.Properties.Remove('name') }
+    $model.services.toxiproxy | Add-Member -NotePropertyName ports -NotePropertyValue @(@{target=8474; published='18474'; host_ip='127.0.0.1'; protocol='tcp'})
+    $model | ConvertTo-Json -Depth 100 | Set-Content -LiteralPath $fixture -Encoding utf8
+    docker compose -p $project -f $fixture up -d --wait redis toxiproxy
+    if ($LASTEXITCODE) { throw 'Fixture startup failed.' }
+    function PingProxy {
+        $timer = [Diagnostics.Stopwatch]::StartNew()
+        $reply = docker compose -p $project -f $fixture exec -T redis redis-cli -h toxiproxy -p 6379 ping
+        if ($LASTEXITCODE -or $reply -ne 'PONG') { throw 'Redis did not respond through Toxiproxy.' }
+        $timer.Stop()
+        $timer.ElapsedMilliseconds
+    }
+    $api = 'http://127.0.0.1:18474'
+    $before = PingProxy
+    & "$PSScriptRoot/Invoke-Chaos.ps1" add redis test-latency -Value 500 -Url $api
+    $during = PingProxy
+    if ($during - $before -lt 350) { throw "Latency injection was not observed: before=$before during=$during" }
+    & "$PSScriptRoot/Invoke-Chaos.ps1" remove redis test-latency -Url $api
+    & "$PSScriptRoot/Invoke-Chaos.ps1" remove redis test-latency -Url $api
+    $after = PingProxy
+    if ($during - $after -lt 350) { throw "Latency did not recover: during=$during after=$after" }
+    & "$PSScriptRoot/Invoke-Chaos.ps1" add redis test-timeout -Type timeout -Value 0 -Url $api
+    & "$PSScriptRoot/Invoke-Chaos.ps1" reset -Url $api
+    $null = PingProxy
+    Write-Host "PASS: proxy latency baseline=$before ms injected=$during ms recovered=$after ms; reset restored traffic."
+} finally {
+    if (Test-Path -LiteralPath $fixture) {
+        docker compose -p $project -f $fixture down
+        Remove-Item -LiteralPath $fixture
+    }
+    Pop-Location
+}

--- a/scripts/chaos.sh
+++ b/scripts/chaos.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# PowerShell 7 is also installed on the GitHub Ubuntu runners.
+exec pwsh -NoProfile -File "$(dirname "$0")/Invoke-Chaos.ps1" "$@"


### PR DESCRIPTION
Routes the active development topology through a health-gated Toxiproxy overlay loaded by Tilt. PostgreSQL, Redis, RabbitMQ, MongoDB and MinIO use proxy listeners; the direct deployment remains unchanged.

Adds a named-toxic CLI, recovery documentation and a CI integration test that checks connection configuration and sends real Redis traffic through 500 ms of injected latency. Local measurements: baseline 167 ms, injected 662 ms, recovered 152 ms. Reset restores traffic without restarting clients or backends. Compose validation and Tilt graph evaluation passed.

Refs #67. Parent epic: #9.

Kafka and future-service drills remain dependent on #10 and #130. This PR does not claim those acceptance criteria are complete.