### PR TITLE
feat(messaging): bound shared image state across consumer replicas

### DIFF
--- a/MotoHub/MotoHubTests/Integration/Messaging/PublisherChannelSoakTests.cs
+++ b/MotoHub/MotoHubTests/Integration/Messaging/PublisherChannelSoakTests.cs
@@ -1,0 +1,61 @@
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using ProjectY.Shared.Messaging;
+using System.Text.Json;
+
+namespace MotoHubTests.Integration.Messaging;
+
+public sealed class PublisherChannelSoakTests : IAsyncLifetime
+{
+    private readonly string _password = Guid.NewGuid().ToString("N");
+    private IContainer _broker = null!;
+    public async Task InitializeAsync()
+    {
+        _broker = new ContainerBuilder("rabbitmq:4-management")
+            .WithEnvironment("RABBITMQ_DEFAULT_USER", "test")
+            .WithEnvironment("RABBITMQ_DEFAULT_PASS", _password)
+            .WithPortBinding(5672, true)
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(5672))
+            .Build();
+        await _broker.StartAsync();
+    }
+    public Task DisposeAsync() => _broker.DisposeAsync().AsTask();
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task RepeatedOutboxPublications_DoNotAccumulateBrokerChannels()
+    {
+        var options = new OutboxRelayOptions
+        {
+            ServiceName = "soak",
+            HostName = _broker.Hostname,
+            Port = _broker.GetMappedPublicPort(5672),
+            VirtualHost = "/",
+            UserName = "test",
+            Password = _password
+        };
+        var transport = new RabbitMqOutboxTransport(options, new RabbitMqConnectionProvider(options));
+        for (var batch = 0; batch < 4; batch++)
+        {
+            for (var index = 0; index < 750; index++)
+            {
+                await transport.PublishAsync(new OutboxMessage
+                {
+                    AggregateType = "soak",
+                    AggregateId = "soak",
+                    EventType = "soak.v1",
+                    Destination = "soak",
+                    Payload = "{}"
+                }, CancellationToken.None);
+            }
+            // Inspect the broker, rather than merely verifying Dispose on a mock.
+            var result = await _broker.ExecAsync(["rabbitmqctl", "list_channels", "--quiet", "--formatter=json"]);
+            Assert.Equal(0, result.ExitCode);
+            using var channels = JsonDocument.Parse(result.Stdout);
+            Assert.Equal(0, channels.RootElement.GetArrayLength());
+        }
+        using var connection = new RabbitMqConnectionProvider(options).Create();
+        using var channel = connection.CreateModel();
+        Assert.Equal(3000u, channel.MessageCount("soak"));
+    }
+}

--- a/RiderManager/RiderManager/Services/RabbitMQService/MessagingConsumerService.cs
+++ b/RiderManager/RiderManager/Services/RabbitMQService/MessagingConsumerService.cs
@@ -88,7 +88,7 @@ namespace RiderManager.Services.RabbitMQService
                             queueName,
                             poisonQueueName,
                             ea.BasicProperties,
-                            ea.Body, permanent: ex is QueueMessageAuthenticationException);
+                            ea.Body, permanent: ex is QueueMessageAuthenticationException or InvalidDataException);
                         _channel.BasicAck(ea.DeliveryTag, false);
                         if (route == FailureRoute.Retry)
                         {

--- a/RiderManager/RiderManager/Services/RabbitMQService/RiderInboxMessageHandler.cs
+++ b/RiderManager/RiderManager/Services/RabbitMQService/RiderInboxMessageHandler.cs
@@ -10,6 +10,9 @@ namespace RiderManager.Services.RabbitMQService;
 
 public sealed class RiderInboxMessageHandler
 {
+    public const int MaximumUploadBytes = 8 * 1024 * 1024;
+    public const int MaximumPartBytes = 64 * 1024;
+    public const int MaximumParts = 2048;
     public const string RegistrationConsumer = "rider-manager/registration/v1";
     public const string ImageStreamConsumer = "rider-manager/cnh-image-part/v1";
 
@@ -65,19 +68,45 @@ public sealed class RiderInboxMessageHandler
             async token =>
             {
                 var part = message.Payload;
-                if (part.Content is null)
+                if (part.Content is null || part.Content.Length == 0 || part.Content.Length > MaximumPartBytes
+                    || part.SequenceNumber < 0 || part.SequenceNumber >= MaximumParts
+                    || string.IsNullOrWhiteSpace(part.UserId) || string.IsNullOrWhiteSpace(part.FileName))
                 {
-                    throw new InvalidOperationException("The image part content is missing.");
+                    throw new InvalidDataException("The image part exceeds the upload bounds or has invalid identity.");
                 }
 
-                var alreadyStored = await _context.InboxImageParts.AnyAsync(
-                    stored => stored.UserId == part.UserId
-                        && stored.FileName == part.FileName
-                        && stored.SequenceNumber == part.SequenceNumber,
-                    token);
-
-                if (!alreadyStored)
+                // A transaction-scoped database lock serializes replicas for this rider.
+                // The inbox transaction also rolls back the size check and buffered part together.
+                await _context.Database.ExecuteSqlInterpolatedAsync(
+                    $"SELECT pg_advisory_xact_lock(hashtextextended({part.UserId}, 0))", token);
+                var uploadId = "upload:" + Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(
+                    System.Text.Encoding.UTF8.GetBytes($"{part.UserId.Length}:{part.UserId}{part.FileName}")));
+                const string completedConsumer = ImageStreamConsumer + "/completed";
+                if (await _context.InboxMessages.AnyAsync(
+                    row => row.MessageId == uploadId && row.ConsumerName == completedConsumer, token))
                 {
+                    return;
+                }
+
+                var existing = await _context.InboxImageParts.SingleOrDefaultAsync(
+                    row => row.UserId == part.UserId && row.FileName == part.FileName
+                        && row.SequenceNumber == part.SequenceNumber, token);
+                if (existing is not null)
+                {
+                    if (existing.EndOfFile != part.EndOfFile || !existing.Content.SequenceEqual(part.Content))
+                    {
+                        throw new InvalidDataException("An image sequence number cannot be replaced with different content.");
+                    }
+                }
+                else
+                {
+                    var bufferedBytes = await _context.InboxImageParts
+                        .Where(row => row.UserId == part.UserId && row.FileName == part.FileName)
+                        .SumAsync(row => (long)row.Content.Length, token);
+                    if (bufferedBytes + part.Content.Length > MaximumUploadBytes)
+                    {
+                        throw new InvalidDataException("The image upload exceeds the 8 MiB limit.");
+                    }
                     _context.InboxImageParts.Add(new InboxImagePart
                     {
                         UserId = part.UserId,
@@ -89,29 +118,28 @@ public sealed class RiderInboxMessageHandler
                     await _context.SaveChangesAsync(token);
                 }
 
-                if (!part.EndOfFile)
+                var metadata = await _context.InboxImageParts
+                    .Where(row => row.UserId == part.UserId && row.FileName == part.FileName)
+                    .Select(row => new { row.SequenceNumber, row.EndOfFile })
+                    .OrderBy(row => row.SequenceNumber)
+                    .ToListAsync(token);
+                var endings = metadata.Where(row => row.EndOfFile).ToArray();
+                if (endings.Length > 1 || (endings.Length == 1 && metadata[^1].SequenceNumber > endings[0].SequenceNumber))
+                {
+                    throw new InvalidDataException("The image stream has conflicting end markers.");
+                }
+                // An EOF may arrive on another replica before preceding parts. Commit it
+                // and let whichever part completes the sequence perform the upload.
+                if (endings.Length == 0 || metadata.Where((row, index) => row.SequenceNumber != index).Any())
                 {
                     return;
                 }
 
                 var parts = await _context.InboxImageParts
-                    .Where(stored => stored.UserId == part.UserId && stored.FileName == part.FileName)
-                    .OrderBy(stored => stored.SequenceNumber)
-                    .ToListAsync(token);
-
-                if (parts.Count == 0
-                    || parts[^1].SequenceNumber != part.SequenceNumber
-                    || parts.Where((stored, index) => stored.SequenceNumber != index).Any())
-                {
-                    throw new InvalidOperationException("The image stream is incomplete.");
-                }
-
+                    .Where(row => row.UserId == part.UserId && row.FileName == part.FileName)
+                    .OrderBy(row => row.SequenceNumber).ToListAsync(token);
                 await using var stream = new MemoryStream();
-                foreach (var stored in parts)
-                {
-                    await stream.WriteAsync(stored.Content, token);
-                }
-
+                foreach (var stored in parts) { await stream.WriteAsync(stored.Content, token); }
                 stream.Position = 0;
                 var formFile = new FormFile(stream, 0, stream.Length, "cnhImage", part.FileName)
                 {
@@ -119,8 +147,13 @@ public sealed class RiderInboxMessageHandler
                     ContentType = "application/octet-stream"
                 };
                 await _riderManager.UpdateRiderImageAsync(part.UserId, formFile, part.FileName);
-
                 _context.InboxImageParts.RemoveRange(parts);
+                _context.InboxMessages.Add(new InboxMessage
+                {
+                    MessageId = uploadId,
+                    ConsumerName = completedConsumer,
+                    ProcessedAtUtc = DateTime.UtcNow
+                });
             },
             cancellationToken);
 }

--- a/RiderManager/RiderManager/Services/RabbitMQService/RiderInboxRetentionService.cs
+++ b/RiderManager/RiderManager/Services/RabbitMQService/RiderInboxRetentionService.cs
@@ -6,7 +6,8 @@ namespace RiderManager.Services.RabbitMQService;
 public sealed class RiderInboxRetentionOptions
 {
     public TimeSpan RetentionPeriod { get; set; } = TimeSpan.FromDays(7);
-    public TimeSpan SweepInterval { get; set; } = TimeSpan.FromHours(1);
+    public TimeSpan ImageRetentionPeriod { get; set; } = TimeSpan.FromHours(1);
+    public TimeSpan SweepInterval { get; set; } = TimeSpan.FromMinutes(15);
 }
 
 public sealed class RiderInboxRetentionService : BackgroundService
@@ -43,8 +44,10 @@ public sealed class RiderInboxRetentionService : BackgroundService
         var deletedMessages = await context.InboxMessages
             .Where(message => message.ProcessedAtUtc < cutoff)
             .ExecuteDeleteAsync(cancellationToken);
+        var imageCutoff = _timeProvider.GetUtcNow().UtcDateTime - _options.ImageRetentionPeriod;
         var deletedParts = await context.InboxImageParts
-            .Where(part => part.ReceivedAtUtc < cutoff)
+            .Where(part => context.InboxImageParts.Any(expired => expired.UserId == part.UserId
+                && expired.FileName == part.FileName && expired.ReceivedAtUtc < imageCutoff))
             .ExecuteDeleteAsync(cancellationToken);
         return deletedMessages + deletedParts;
     }

--- a/RiderManager/RiderManagerTests/Integration/PostgreSql/InboxProcessorTests.cs
+++ b/RiderManager/RiderManagerTests/Integration/PostgreSql/InboxProcessorTests.cs
@@ -119,6 +119,127 @@ public sealed class InboxProcessorTests : IAsyncLifetime
         Assert.Equal("current", (await verification.InboxMessages.SingleAsync()).MessageId);
     }
 
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task IndependentReplicas_AssembleOutOfOrderPartsExactlyOnce()
+    {
+        var manager = new Mock<IRiderManager>();
+        byte[]? uploaded = null;
+        manager.Setup(item => item.UpdateRiderImageAsync("replica-rider", It.IsAny<IFormFile>(), "replica.png"))
+            .Callback<string, IFormFile, string>((_, file, _) =>
+            {
+                using var memory = new MemoryStream();
+                file.CopyTo(memory);
+                uploaded = memory.ToArray();
+            });
+        async Task Append(int sequence, bool eof, byte value)
+        {
+            await using var context = new ApplicationDbContext(_options);
+            var handler = new RiderInboxMessageHandler(context, new RiderInboxProcessor(context), manager.Object);
+            await handler.HandleImagePartAsync(new AuthenticatedQueueMessage<ImagePart>(
+                Guid.NewGuid().ToString("N"), new ImagePart
+                {
+                    UserId = "replica-rider",
+                    FileName = "replica.png",
+                    SequenceNumber = sequence,
+                    EndOfFile = eof,
+                    Content = [value]
+                }));
+        }
+
+        await Append(2, true, 3);
+        await Task.WhenAll(Append(0, false, 1), Append(1, false, 2));
+        await Append(0, false, 1); // A late duplicate cannot recreate a completed upload.
+        Assert.Equal(new byte[] { 1, 2, 3 }, uploaded);
+        manager.Verify(item => item.UpdateRiderImageAsync("replica-rider", It.IsAny<IFormFile>(), "replica.png"), Times.Once);
+        await using var verification = new ApplicationDbContext(_options);
+        Assert.Empty(await verification.InboxImageParts.ToListAsync());
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ConcurrentReplicas_CannotBothCrossTheUploadSizeLimit()
+    {
+        await using (var seed = new ApplicationDbContext(_options))
+        {
+            seed.InboxImageParts.Add(new InboxImagePart
+            {
+                UserId = "bounded",
+                FileName = "bounded.png",
+                SequenceNumber = 0,
+                Content = new byte[RiderInboxMessageHandler.MaximumUploadBytes - 1]
+            });
+            await seed.SaveChangesAsync();
+        }
+        async Task<bool> Append(int sequence)
+        {
+            await using var context = new ApplicationDbContext(_options);
+            var handler = new RiderInboxMessageHandler(context, new RiderInboxProcessor(context), Mock.Of<IRiderManager>());
+            try
+            {
+                return await handler.HandleImagePartAsync(new AuthenticatedQueueMessage<ImagePart>(
+                    Guid.NewGuid().ToString("N"), new ImagePart
+                    {
+                        UserId = "bounded",
+                        FileName = "bounded.png",
+                        SequenceNumber = sequence,
+                        Content = [1]
+                    }));
+            }
+            catch (InvalidDataException) { return false; }
+        }
+        var results = await Task.WhenAll(Append(1), Append(2));
+        Assert.Single(results, result => result);
+        Assert.Single(results, result => !result);
+        await using var verification = new ApplicationDbContext(_options);
+        Assert.Equal(RiderInboxMessageHandler.MaximumUploadBytes,
+            await verification.InboxImageParts.SumAsync(part => (long)part.Content.Length));
+        Assert.Single(await verification.InboxMessages.ToListAsync());
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task IncompleteUpload_ExpiresAsAWhole_WhileRecentUploadRemains()
+    {
+        await using (var seed = new ApplicationDbContext(_options))
+        {
+            seed.InboxImageParts.AddRange(
+                new InboxImagePart
+                {
+                    UserId = "old",
+                    FileName = "old.png",
+                    SequenceNumber = 0,
+                    Content = [1],
+                    ReceivedAtUtc = DateTime.UtcNow.AddHours(-2)
+                },
+                new InboxImagePart
+                {
+                    UserId = "old",
+                    FileName = "old.png",
+                    SequenceNumber = 1,
+                    Content = [2],
+                    ReceivedAtUtc = DateTime.UtcNow
+                },
+                new InboxImagePart
+                {
+                    UserId = "recent",
+                    FileName = "recent.png",
+                    SequenceNumber = 0,
+                    Content = [3],
+                    ReceivedAtUtc = DateTime.UtcNow
+                });
+            await seed.SaveChangesAsync();
+        }
+        using var services = new ServiceCollection()
+            .AddDbContext<ApplicationDbContext>(options => options.UseNpgsql(_database.GetConnectionString()))
+            .BuildServiceProvider();
+        var retention = new RiderInboxRetentionService(services.GetRequiredService<IServiceScopeFactory>(),
+            new RiderInboxRetentionOptions(), TimeProvider.System);
+        Assert.Equal(2, await retention.DeleteExpiredAsync());
+        await using var verification = new ApplicationDbContext(_options);
+        Assert.Equal("recent", (await verification.InboxImageParts.SingleAsync()).UserId);
+    }
+
     private async Task<bool> ProcessRegistrationAsync(string messageId, string email)
     {
         await using var context = new ApplicationDbContext(_options);

--- a/docs/shared-consumer-state.md
+++ b/docs/shared-consumer-state.md
@@ -1,0 +1,40 @@
+# Shared consumer state
+
+Task #70 completes the existing PostgreSQL inbox introduced by ADR 0009. Upload
+parts and deduplication records were already in PostgreSQL; moving them again to
+Redis would split the transaction that protects the consumer's database effect.
+Retry state remains in the durable RabbitMQ message introduced by #69.
+
+Each image is bounded to 8 MiB, 2,048 sequence positions and 64 KiB per part.
+A PostgreSQL transaction-scoped advisory lock serializes handlers for one rider,
+so two consumer instances cannot both pass a stale size check. Invalid or
+oversized parts are quarantined without retry. An EOF can arrive first:
+the part that completes the contiguous sequence performs the upload. A completion
+receipt prevents late duplicate envelopes from recreating a completed buffer.
+
+Incomplete uploads expire one hour after their oldest part. A sweep every
+15 minutes removes the entire expired upload, including newer parts of that
+same upload. Inbox and completion receipts retain the existing seven-day
+retention. This bounds retained state without expiring a partial upload one
+chunk at a time.
+
+Validation:
+
+- Independent handler instances and database contexts assemble out-of-order
+  parts once, including EOF first and a late duplicate.
+- Concurrent instances competing for the last byte of an upload admit exactly
+  one part and roll back the rejected part and its inbox record.
+- Expiry removes an incomplete upload while retaining a recent one.
+- The real outbox publisher performs 3,000 publications against RabbitMQ; after
+  each batch the broker reports zero leaked channels and all messages remain
+  queued. Request-scoped publishers only enqueue outbox records.
+
+Reproduce:
+
+```sh
+dotnet test RiderManager/RiderManagerTests/RiderManagerTests.csproj --filter FullyQualifiedName~InboxProcessorTests
+dotnet test MotoHub/MotoHubTests/MotoHubTests.csproj --filter FullyQualifiedName~PublisherChannelSoakTests
+```
+
+These are integration proofs of shared state and channel lifetime. They do not
+measure long-running production capacity or provide a multi-node database SLA.


### PR DESCRIPTION
Completes the existing PostgreSQL inbox implementation with per-upload size/part bounds, transaction-scoped serialization across replicas, completion receipts and whole-upload expiry. EOF can arrive before the other chunks; whichever instance completes the sequence uploads once. Oversized/invalid parts go directly to quarantine.

State remains in the existing transactional PostgreSQL inbox and durable RabbitMQ messages from #69, preserving the transaction boundary instead of adding a second Redis counter.

Validation:
- RiderManager: 34 tests passed, including independent instances assembling out-of-order chunks, a concurrent race for the last allowed byte, late duplicates and incomplete-upload expiry.
- The real outbox transport published 3,000 messages to RabbitMQ; broker channel count returned to zero after each batch and all 3,000 messages remained queued.
- dotnet format and git diff --check passed.

Refs #70. Parent #9. Depends on #154 (already merged into the epic). Details: docs/shared-consumer-state.md.