### PR TITLE
feat(resilience): refuse unavailable rental dependencies with retry guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,5 @@ the scans that run before publication.
 - [Six-part article series](https://github.com/iVega123/ProjectY/issues/13)
 
 Dependency fault injection in the active development stack: [commands and recovery contract](docs/dependency-fault-injection.md).
+
+See the [active degradation contract and prerequisite gaps](docs/degradation-contract.md) for what each dependency failure does today.

--- a/RentalOperations/RentalOperations/Controllers/RentalController.cs
+++ b/RentalOperations/RentalOperations/Controllers/RentalController.cs
@@ -14,6 +14,17 @@ namespace RentalOperations.Controllers
     {
         private readonly IRentalService _rentalService;
 
+        private ObjectResult Unavailable(Exception exception)
+        {
+            DependencyFailure.Record(exception);
+            Response.Headers.RetryAfter = "1";
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new ProblemDetails
+            {
+                Status = StatusCodes.Status503ServiceUnavailable,
+                Title = "Dependency unavailable",
+                Detail = "A required dependency is temporarily unavailable. Retry later."
+            });
+        }
         public RentalController(IRentalService rentalService)
         {
             _rentalService = rentalService;
@@ -50,6 +61,10 @@ namespace RentalOperations.Controllers
                     Detail = ex.Message
                 });
             }
+            catch (Exception ex) when (DependencyFailure.IsUnavailable(ex))
+            {
+                return Unavailable(ex);
+            }
             catch (Exception ex)
             {
                 return BadRequest(ex.Message);
@@ -73,6 +88,10 @@ namespace RentalOperations.Controllers
                     cursor,
                     pageSize));
             }
+            catch (Exception ex) when (DependencyFailure.IsUnavailable(ex))
+            {
+                return Unavailable(ex);
+            }
             catch (Exception ex)
             {
                 return BadRequest(ex.Message);
@@ -89,6 +108,10 @@ namespace RentalOperations.Controllers
             try
             {
                 return Ok(await _rentalService.GetRentalsByUserIdAsync(userId, cursor, pageSize));
+            }
+            catch (Exception ex) when (DependencyFailure.IsUnavailable(ex))
+            {
+                return Unavailable(ex);
             }
             catch (Exception ex)
             {
@@ -113,6 +136,10 @@ namespace RentalOperations.Controllers
             {
                 return Forbid();
             }
+            catch (Exception ex) when (DependencyFailure.IsUnavailable(ex))
+            {
+                return Unavailable(ex);
+            }
             catch (Exception ex)
             {
                 return BadRequest(ex.Message);
@@ -126,6 +153,10 @@ namespace RentalOperations.Controllers
             {
                 bool isRented = await _rentalService.IsMotorcycleCurrentlyRentedAsync(licencePlate);
                 return Ok(isRented);
+            }
+            catch (Exception ex) when (DependencyFailure.IsUnavailable(ex))
+            {
+                return Unavailable(ex);
             }
             catch (Exception ex)
             {

--- a/RentalOperations/RentalOperations/CrossCutting/Services/MotorcycleService.cs
+++ b/RentalOperations/RentalOperations/CrossCutting/Services/MotorcycleService.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using RentalOperations.CrossCutting.Model;
 
 namespace RentalOperations.CrossCutting.Services
@@ -15,11 +15,11 @@ namespace RentalOperations.CrossCutting.Services
         {
             try
             {
-                var response = await _httpClient.GetAsync($"api/Motorcycles/{licensePlate}");
+                using var response = await _httpClient.GetAsync($"api/Motorcycles/{licensePlate}");
                 if (!response.IsSuccessStatusCode)
                 {
                     var errorContent = await response.Content.ReadAsStringAsync();
-                    throw new HttpRequestException($"Request failed with status {response.StatusCode}: {errorContent}");
+                    throw new HttpRequestException($"Request failed with status {response.StatusCode}: {errorContent}", null, response.StatusCode);
                 }
 
                 string responseBody = await response.Content.ReadAsStringAsync();
@@ -33,7 +33,7 @@ namespace RentalOperations.CrossCutting.Services
 
         public async Task EnsureHistoricalReferencesAsync(IEnumerable<string> licensePlates)
         {
-            var response = await _httpClient.PostAsJsonAsync(
+            using var response = await _httpClient.PostAsJsonAsync(
                 "api/Motorcycles/historical-references",
                 new { LicensePlates = licensePlates });
             if (!response.IsSuccessStatusCode)

--- a/RentalOperations/RentalOperations/CrossCutting/Services/RiderManagerService.cs
+++ b/RentalOperations/RentalOperations/CrossCutting/Services/RiderManagerService.cs
@@ -1,4 +1,4 @@
-﻿using RentalOperations.CrossCutting.Model;
+using RentalOperations.CrossCutting.Model;
 using System.Text.Json;
 
 namespace RentalOperations.CrossCutting.Services
@@ -15,7 +15,7 @@ namespace RentalOperations.CrossCutting.Services
         {
             try
             {
-                var response = await _httpClient.GetAsync($"api/Riders/{riderId}");
+                using var response = await _httpClient.GetAsync($"api/Riders/{riderId}");
                 response.EnsureSuccessStatusCode();
                 var responseBody = await response.Content.ReadAsStringAsync();
                 return JsonSerializer.Deserialize<Rider>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });

--- a/RentalOperations/RentalOperations/Data/MongoDbContext.cs
+++ b/RentalOperations/RentalOperations/Data/MongoDbContext.cs
@@ -1,4 +1,4 @@
-﻿using MongoDB.Driver;
+using MongoDB.Driver;
 
 namespace RentalOperations.Data
 {
@@ -8,7 +8,12 @@ namespace RentalOperations.Data
 
         public MongoDbContext(string connectionString, string dbName)
         {
-            var client = new MongoClient(connectionString);
+            var settings = MongoClientSettings.FromConnectionString(connectionString);
+            settings.ServerSelectionTimeout = TimeSpan.FromSeconds(1);
+            settings.ConnectTimeout = TimeSpan.FromSeconds(1);
+            settings.SocketTimeout = TimeSpan.FromSeconds(1);
+            settings.WaitQueueTimeout = TimeSpan.FromSeconds(1);
+            var client = new MongoClient(settings);
             Database = client.GetDatabase(dbName);
         }
     }

--- a/RentalOperations/RentalOperations/Program.cs
+++ b/RentalOperations/RentalOperations/Program.cs
@@ -76,6 +76,7 @@ builder.Services.AddSwaggerGen(c =>
 builder.Services
     .AddHttpClient("rider-manager", client =>
     {
+        client.Timeout = TimeSpan.FromSeconds(1);
         client.BaseAddress = new Uri(
             builder.Configuration["RiderManagerSettings:BaseUrl"]
                 ?? throw new InvalidOperationException(
@@ -85,6 +86,7 @@ builder.Services
 builder.Services
     .AddHttpClient("moto-hub", client =>
     {
+        client.Timeout = TimeSpan.FromSeconds(1);
         client.BaseAddress = new Uri(
             builder.Configuration["MotoHubSettings:BaseUrl"]
                 ?? throw new InvalidOperationException(

--- a/RentalOperations/RentalOperations/Services/DependencyFailure.cs
+++ b/RentalOperations/RentalOperations/Services/DependencyFailure.cs
@@ -1,0 +1,30 @@
+using MongoDB.Driver;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace RentalOperations.Services;
+
+public static class DependencyFailure
+{
+    private static readonly Meter Meter = new("ProjectY.Resilience");
+    private static readonly Counter<long> Refusals = Meter.CreateCounter<long>("dependency.refusals");
+
+    public static bool IsUnavailable(Exception exception)
+    {
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is MongoException or TimeoutException or TaskCanceledException) { return true; }
+            if (current is HttpRequestException http && (http.StatusCode is null || (int)http.StatusCode >= 500))
+            { return true; }
+        }
+        return false;
+    }
+
+    public static void Record(Exception exception)
+    {
+        var dependency = exception is MongoException ? "mongodb" : "upstream";
+        Refusals.Add(1, new KeyValuePair<string, object?>("dependency", dependency));
+        Activity.Current?.SetTag("projecty.degradation", dependency);
+        Activity.Current?.SetStatus(ActivityStatusCode.Error, "Dependency unavailable");
+    }
+}

--- a/RentalOperations/RentalOperationsTests/Unit/DependencyFailureTests.cs
+++ b/RentalOperations/RentalOperationsTests/Unit/DependencyFailureTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using MongoDB.Driver;
+using Moq;
+using RentalOperations.Controllers;
+using RentalOperations.DTOs;
+using RentalOperations.Services;
+using System.Net;
+using System.Security.Claims;
+
+namespace RentalOperationsTests.Unit;
+
+public sealed class DependencyFailureTests
+{
+    [Fact]
+    public async Task DatabaseFailure_RefusesWith503AndRetryAfter_WithoutLeakingException()
+    {
+        var controller = ControllerFor(new MongoException("private connection details"));
+        var response = Assert.IsType<ObjectResult>(await controller.CreateRental(Request()));
+        Assert.Equal(503, response.StatusCode);
+        Assert.Equal("1", controller.Response.Headers.RetryAfter.ToString());
+        Assert.DoesNotContain("private", Assert.IsType<ProblemDetails>(response.Value).Detail);
+    }
+
+    [Fact]
+    public async Task WrappedUpstreamFailure_RefusesWith503()
+    {
+        var controller = ControllerFor(new Exception("wrapper", new HttpRequestException(
+            "upstream", null, HttpStatusCode.ServiceUnavailable)));
+        Assert.Equal(503, Assert.IsType<ObjectResult>(await controller.CreateRental(Request())).StatusCode);
+    }
+
+    [Fact]
+    public async Task BusinessRejection_Remains400_AndDoesNotAdvertiseDependencyRetry()
+    {
+        var controller = ControllerFor(new ArgumentException("Rider does not exist."));
+        Assert.IsType<BadRequestObjectResult>(await controller.CreateRental(Request()));
+        Assert.False(controller.Response.Headers.ContainsKey("Retry-After"));
+        Assert.False(DependencyFailure.IsUnavailable(new HttpRequestException("missing", null, HttpStatusCode.NotFound)));
+    }
+
+    [Fact]
+    public async Task UnavailableMongoServer_FailsWithinThePublicGatewayDeadline()
+    {
+        var database = new RentalOperations.Data.MongoDbContext("mongodb://127.0.0.1:1", "unavailable");
+        var timer = System.Diagnostics.Stopwatch.StartNew();
+        var error = await Record.ExceptionAsync(() => database.Database
+            .GetCollection<MongoDB.Bson.BsonDocument>("probe")
+            .Find(FilterDefinition<MongoDB.Bson.BsonDocument>.Empty).AnyAsync());
+        Assert.NotNull(error);
+        Assert.True(DependencyFailure.IsUnavailable(error));
+        Assert.True(timer.Elapsed < TimeSpan.FromSeconds(2.5), $"Driver took {timer.Elapsed}");
+    }
+    private static RentalCreateDto Request() => new()
+    {
+        MotocycleLicencePlate = "ABC1D23",
+        StartDate = DateTime.UtcNow.AddDays(1),
+        PredictedEndDate = DateTime.UtcNow.AddDays(8)
+    };
+
+    private static RentalController ControllerFor(Exception failure)
+    {
+        var service = new Mock<IRentalService>();
+        service.Setup(item => item.CreateRentalAsync(It.IsAny<RentalCreateDto>(), "rider")).ThrowsAsync(failure);
+        return new RentalController(service.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, "rider")], "test"))
+                }
+            }
+        };
+    }
+}

--- a/Shared/Observability/ProjectYTelemetryExtensions.cs
+++ b/Shared/Observability/ProjectYTelemetryExtensions.cs
@@ -30,7 +30,7 @@ public static class ProjectYTelemetryExtensions
 
         services.AddOpenTelemetry()
             .ConfigureResource(resource => resource.AddService(serviceName))
-            .WithMetrics(metrics => metrics.AddMeter("ProjectY.Messaging").AddOtlpExporter(options =>
+            .WithMetrics(metrics => metrics.AddMeter("ProjectY.Messaging", "ProjectY.Resilience").AddOtlpExporter(options =>
             {
                 options.Endpoint = endpoint;
                 options.Protocol = protocol;

--- a/docs/degradation-contract.md
+++ b/docs/degradation-contract.md
@@ -1,0 +1,32 @@
+# Active degradation contract
+
+The target contract in ADR 0003 spans services that do not yet exist. This table
+separates current executable behavior from prerequisites; #71 remains open for
+the unfinished target rows. Do not interpret a missing service as a passing drill.
+
+| Dependency failure | Active behavior | Evidence / outstanding work |
+|---|---|---|
+| Redis rate limiter | The gateway admits traffic and increments `gateway_ratelimit_degraded_total`. | Existing gateway Redis failure tests. |
+| Redis revocation / idempotency | High-value rental creation and protected idempotent mutations refuse closed. Ordinary JWT verification uses cached JWKS. | ADR 0017 supersedes the earlier blanket “everything continues” row. |
+| MongoDB rental store | Rental endpoints return 503 with `Retry-After: 1`; driver connection, selection, socket and pool waits are bounded to one second each. | Driver deadline test plus controller failure tests; gateway retains its independent 2.5 s request budget. |
+| RiderManager / MotoHub dependency | Rental calls have a one-second HTTP deadline. Transport failures and upstream 5xx become 503, with a distinct refusal counter and a trace degradation tag. Business 4xx remain client errors. | Controller tests cover wrapped 503 versus 404 / business rejection. |
+| RabbitMQ | AuthGate and MotoHub transactional outboxes retain unpublished events and retry after recovery. Consumers use durable bounded retries and DLQ. | #69 / #154, outbox integration tests. This is the active broker; it is not Kafka evidence. |
+| Risk/pricing | Rental closure already uses the fixed daily-rate model. There is no dynamic-pricing service to fail over from. | Target fallback blocked by #10. |
+| Live tracking | No live map or last-position service exists in the active topology. | Blocked by #10. |
+| Read projections | Current reads use their primary stores. No projection fallback is implemented. | Blocked by #130 and target read services. |
+| Kafka | No active rental Kafka producer exists. | Transactional rental Kafka/outbox drill blocked by #130 and the event-service work. |
+| Cassandra | No active trip-history consumer exists. | Blocked by telemetry service in #10. |
+
+`dependency.refusals` is exported by OTel with a bounded dependency label. Its
+Prometheus name is `dependency_refusals_total`. A 503 trace carries
+`projecty.degradation`; exception details and connection strings are not returned
+to the caller. Individual driver waits are bounded; the gateway's request timeout
+is the overall public deadline, including retries. A timeout is a refusal, never
+proof that a mutation did not commit: retain the same idempotency key when retrying.
+
+Reproduce the current failure contracts:
+
+```sh
+dotnet test RentalOperations/RentalOperationsTests/RentalOperationsTests.csproj --filter FullyQualifiedName~DependencyFailureTests
+cargo test --manifest-path services/api-gateway/Cargo.toml --locked
+```


### PR DESCRIPTION
Rental endpoints now distinguish dependency failures from business rejections. MongoDB and upstream transport/5xx failures return sanitized 503 ProblemDetails with Retry-After: 1, a refusal metric and a trace degradation tag. Driver waits and the two outbound HTTP clients have explicit one-second bounds; the gateway retains its overall request budget. Business 4xx remain client errors.

Documents the current degradation contract, including Redis rate limiting versus revocation/idempotency, active RabbitMQ outboxes, and every target-service prerequisite.

Validation: the full RentalOperations suite passed (34 tests), followed by four focused failure-contract tests including an actual unavailable Mongo endpoint completing within 2.5 seconds. dotnet format and git diff --check passed.

Refs #71; parent #9. Keep #71 open: Kafka, risk/pricing, live tracking, read-projection and Cassandra acceptance criteria still require #10 / #130, as agreed.