### PR TITLE
feat(resilience): expose active chaos drills in Tilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,5 @@ the scans that run before publication.
 - [Six-part article series](https://github.com/iVega123/ProjectY/issues/13)
 
 Dependency fault injection in the active development stack: [commands and recovery contract](docs/dependency-fault-injection.md).
+
+[Tilt chaos drills: injection, expected behavior and observation points](docs/chaos-drills.md).

--- a/Tiltfile
+++ b/Tiltfile
@@ -118,3 +118,23 @@ dc_resource(
 print('Tilt UI:  http://localhost:10350')
 print('Gateway:  http://localhost:8090')
 print('Grafana:  http://localhost:3000')
+
+# Keep unavailable target-service drills visible and explicitly disabled.
+load('ext://uibutton', 'cmd_button')
+chaos_shell = 'powershell' if os.name == 'nt' else 'pwsh'
+chaos_prefix = [chaos_shell, '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', 'scripts/Invoke-ChaosDrill.ps1']
+for drill in read_json('deploy/chaos/drills.json'):
+    cmd_button(
+        'chaos-' + drill['id'],
+        resource = 'toxiproxy',
+        argv = chaos_prefix + [drill['id']],
+        text = drill['label'],
+        disabled = not drill['available'],
+    )
+    cmd_button(
+        'chaos-clear-' + drill['id'],
+        resource = 'toxiproxy',
+        argv = chaos_prefix + [drill['id'], '-Clear'],
+        text = 'Clear: ' + drill['label'],
+        disabled = not drill['available'],
+    )

--- a/deploy/chaos/drills.json
+++ b/deploy/chaos/drills.json
@@ -1,0 +1,85 @@
+[
+  {
+    "id": "slow-db",
+    "label": "Slow database",
+    "available": true,
+    "proxy": "mongodb",
+    "toxics": [
+      {
+        "name": "slow-db",
+        "type": "latency",
+        "value": 500
+      }
+    ],
+    "expectation": "Latency should rise. Compare p95/p99 and 503s with baseline; the original no-5xx target is not yet proven.",
+    "observe": "Grafana rental SLO and MongoDB spans in Tempo."
+  },
+  {
+    "id": "db-down",
+    "label": "Database down",
+    "available": true,
+    "proxy": "mongodb",
+    "toxics": [
+      {
+        "name": "db-down",
+        "type": "timeout",
+        "value": 0
+      }
+    ],
+    "expectation": "Rental creation refuses with 503 and Retry-After; repeated failures open the gateway breaker.",
+    "observe": "Gateway /metrics, rental SLO, and trace projecty.degradation."
+  },
+  {
+    "id": "redis-down",
+    "label": "Redis down",
+    "available": true,
+    "proxy": "redis",
+    "toxics": [
+      {
+        "name": "redis-down",
+        "type": "timeout",
+        "value": 0
+      }
+    ],
+    "expectation": "Rate limiting degrades open; high-value revocation and idempotency refuse closed.",
+    "observe": "gateway_ratelimit_degraded_total and gateway 503 traces."
+  },
+  {
+    "id": "kafka-down",
+    "label": "Kafka down (blocked)",
+    "available": false,
+    "proxy": "kafka",
+    "toxics": [],
+    "expectation": "Blocked: the active rental service has no Kafka producer/outbox; requires #130 and event-service work.",
+    "observe": "No active Kafka drill evidence exists."
+  },
+  {
+    "id": "bad-network",
+    "label": "Bad network",
+    "available": true,
+    "proxy": "mongodb",
+    "toxics": [
+      {
+        "name": "bad-network-slicer",
+        "type": "slicer",
+        "value": 100
+      },
+      {
+        "name": "bad-network-limit",
+        "type": "limit_data",
+        "value": 60000
+      }
+    ],
+    "expectation": "Fragment responses and interrupt long connections. Measure client retries and errors; unchanged error rate is not yet proven.",
+    "observe": "MongoDB client spans, gateway resilience metrics and k6 error rate."
+  },
+  {
+    "id": "service-killed",
+    "label": "Tracking stopped (blocked)",
+    "available": false,
+    "proxy": "telemetry",
+    "toxics": [],
+    "expectation": "Blocked: live tracking and the map are not present; requires #10.",
+    "observe": "No active map-freeze drill evidence exists."
+  }
+]

--- a/docs/chaos-drills.md
+++ b/docs/chaos-drills.md
@@ -1,0 +1,31 @@
+# Tilt chaos drills
+
+Tilt exposes the following drill/clear pairs on the Toxiproxy resource. Every
+command prints the expected effect and where to inspect it. Clear removes only
+that drill's named toxics; it does not restart a container or clear other drills.
+`Invoke-Chaos.ps1 reset` is the explicit global recovery command.
+
+| Drill | Injection | Expected / acceptance status | Observe |
+|---|---|---|---|
+| Slow database | 500 ms on the active MongoDB proxy | Measure increased p99. The target “no 5xx” promise remains unverified with the current multi-call rental flow. | Grafana rental SLO, Mongo spans |
+| Database down | MongoDB downstream timeout | 503 with Retry-After; gateway breaker opens after repeated failures | Gateway metrics and degraded traces |
+| Redis down | Redis downstream timeout | Limiter fails open; revocation and idempotency fail closed | Degradation counter and response status |
+| Kafka down | Disabled until the rental Kafka path exists | Target: rental writes continue, outbox accumulates and drains | Blocked by #130 / event-service work |
+| Bad network | MongoDB slicer + 60,000-byte connection limit | Measure reconnects/retries and errors; unchanged error rate is not yet demonstrated | Client spans and k6 |
+| Service killed | Disabled until tracking/map exists | Target: map freezes, other services continue | Blocked by #10 |
+
+The two unavailable pairs are intentionally disabled in Tilt and refuse CLI
+execution with the prerequisite explanation. They are not demonstrations of
+resilience. Task #68 stays open until all six original acceptance criteria are
+observed. Do not substitute a stopped unrelated service for a live-map drill.
+
+```powershell
+powershell -File scripts/Invoke-ChaosDrill.ps1 db-down
+powershell -File scripts/Invoke-ChaosDrill.ps1 db-down -Clear
+powershell -File scripts/Invoke-ChaosDrill.ps1 redis-down
+powershell -File scripts/Invoke-ChaosDrill.ps1 redis-down -Clear
+```
+
+Linux/macOS use `pwsh`. The catalog is `deploy/chaos/drills.json` and is shared by
+the CLI and Tilt, so a disabled prerequisite cannot silently become an active
+button. The API URL can be overridden for an isolated validation stack.

--- a/scripts/Invoke-ChaosDrill.ps1
+++ b/scripts/Invoke-ChaosDrill.ps1
@@ -1,0 +1,28 @@
+#requires -Version 5.1
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position=0)][string]$Drill,
+    [switch]$Clear,
+    [string]$Url = 'http://127.0.0.1:8474'
+)
+$ErrorActionPreference = 'Stop'
+$catalog = Get-Content (Join-Path $PSScriptRoot '../deploy/chaos/drills.json') -Raw | ConvertFrom-Json
+$entry = $catalog | Where-Object { $_.id -eq $Drill }
+if (-not $entry) { throw "Unknown drill: $Drill" }
+if (-not $entry.available) { throw $entry.expectation }
+Write-Host $entry.expectation
+Write-Host "Observe: $($entry.observe) Grafana: http://localhost:3000"
+$action = if ($Clear) { 'remove' } else { 'add' }
+try {
+    foreach ($toxic in $entry.toxics) {
+        & "$PSScriptRoot/Invoke-Chaos.ps1" $action $entry.proxy $toxic.name -Type $toxic.type -Value $toxic.value -Url $Url
+    }
+} catch {
+    if (-not $Clear) {
+        foreach ($toxic in $entry.toxics) {
+            try { & "$PSScriptRoot/Invoke-Chaos.ps1" remove $entry.proxy $toxic.name -Url $Url }
+            catch { Write-Warning "Could not clear $($toxic.name); use Invoke-Chaos.ps1 reset." }
+        }
+    }
+    throw
+}

--- a/scripts/Test-Chaos.ps1
+++ b/scripts/Test-Chaos.ps1
@@ -48,7 +48,22 @@ try {
     & "$PSScriptRoot/Invoke-Chaos.ps1" add redis test-timeout -Type timeout -Value 0 -Url $api
     & "$PSScriptRoot/Invoke-Chaos.ps1" reset -Url $api
     $null = PingProxy
-    Write-Host "PASS: proxy latency baseline=$before ms injected=$during ms recovered=$after ms; reset restored traffic."
+    $catalog = Get-Content 'deploy/chaos/drills.json' -Raw | ConvertFrom-Json
+    foreach ($drill in $catalog) {
+        if (-not $drill.available) {
+            $rejected = $false
+            try { & "$PSScriptRoot/Invoke-ChaosDrill.ps1" $drill.id -Url $api }
+            catch { $rejected = $true }
+            if (-not $rejected) { throw "Unavailable drill was executable: $($drill.id)" }
+            continue
+        }
+        & "$PSScriptRoot/Invoke-ChaosDrill.ps1" $drill.id -Url $api
+        $proxy = Invoke-RestMethod "$api/proxies/$($drill.proxy)" -UserAgent 'ProjectY-Chaos-Test/1.0'
+        if (@($proxy.toxics).Count -ne @($drill.toxics).Count) { throw "Drill did not inject every toxic: $($drill.id)" }
+        & "$PSScriptRoot/Invoke-ChaosDrill.ps1" $drill.id -Clear -Url $api
+        $proxy = Invoke-RestMethod "$api/proxies/$($drill.proxy)" -UserAgent 'ProjectY-Chaos-Test/1.0'
+        if (@($proxy.toxics).Count -ne 0) { throw "Drill did not clear: $($drill.id)" }
+    }    Write-Host "PASS: proxy latency baseline=$before ms injected=$during ms recovered=$after ms; reset restored traffic."
 } finally {
     if (Test-Path -LiteralPath $fixture) {
         docker compose -p $project -f $fixture down


### PR DESCRIPTION
Adds a shared drill catalog, CLI and six Tilt drill/clear pairs. MongoDB latency/outage, Redis outage and network fragmentation are executable; Kafka and live-tracking pairs remain visibly disabled with their prerequisite explanation. Individual clears remove only their own toxics, and failed multi-toxic injection attempts clean up.

Validation: Tilt graph evaluation passed. Integration tests applied and cleared every active drill against the Toxiproxy API, rejected unavailable drills, and verified Redis latency/recovery (149 ms baseline, 659 ms injected, 154 ms recovered).

Refs #68; parent #9. Keep #68 open: Kafka/tracking require #10/#130, and the original no-5xx/unchanged-error-rate promises need workload evidence. This PR verifies the controls and recovery API, not every application-level outcome.