### PR TITLE
feat(resilience): gate real rental load with measured thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
             --user "$grafana_user:$grafana_password" \
             'http://localhost:3000/api/search?type=dash-db' \
             | jq --exit-status \
-              '[.[] | select(.folderTitle == "ProjectY")] | length == 2' >/dev/null
+              '[.[] | select(.folderTitle == "ProjectY")] | length == 3' >/dev/null
 
       - name: Print observability logs on failure
         if: failure()

--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -1,0 +1,38 @@
+name: Rental load gate
+on:
+  pull_request:
+    paths:
+      - 'AuthGate/**'
+      - 'MotoHub/**'
+      - 'RiderManager/**'
+      - 'RentalOperations/**'
+      - 'Shared/**'
+      - 'services/api-gateway/**'
+      - 'docker-compose*.yml'
+      - 'deploy/**'
+      - 'load/**'
+      - 'scripts/Run-LoadTest.ps1'
+      - 'scripts/New-LocalSecrets.ps1'
+      - '.github/workflows/load.yml'
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: rental-load-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  measured-rental-flow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build isolated stack and enforce rental thresholds
+        shell: pwsh
+        run: ./scripts/Run-LoadTest.ps1
+      - name: Upload measured results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rental-load-results
+          path: load/results/*.json
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ msbuild.wrn
 .env.*
 !.env.example
 .rabbitmq-definitions.json
+
+# Generated benchmark summaries (published evidence lives in docs/measurements)
+load/results/

--- a/README.md
+++ b/README.md
@@ -158,3 +158,35 @@ Dependency fault injection in the active development stack: [commands and recove
 
 [Tilt chaos drills: injection, expected behavior and observation points](docs/chaos-drills.md).
 See the [active degradation contract and prerequisite gaps](docs/degradation-contract.md) for what each dependency failure does today.
+
+## Measured load and chaos
+
+Measured 2026-09-05 on AMD Ryzen 9 9950X3D2, Docker 29.7.2 with 32 logical CPUs
+and 61.55 GiB RAM; 5 VUs for 30 seconds using one seeded rider and the default limiter.
+
+| Scenario | Created | Rate limited (429) | Unexpected errors | Successful p95 / p99 |
+|---|---:|---:|---:|---:|
+| Normal | 179 | 1,220 | 0% | 37.8 / 87.2 ms |
+| MongoDB +500 ms | 88 | 0 | 4.35% | 1,528.8 / 2,533.0 ms |
+| MongoDB down | 0 | 957 | 15.76% | N/A |
+| RabbitMQ down | 179 | 1,231 | 0% | 26.9 / 33.2 ms |
+
+Reproduce: `powershell -File scripts/Run-LoadTest.ps1`; append
+`-Mode slow-db`, `-Mode db-down` or `-Mode rabbit-down` for fault runs.
+Both MongoDB fault runs fail the unchanged k6 thresholds. These measurements
+include rate limiting and do not estimate maximum capacity.
+[Raw results and caveats](docs/measurements/epic-9/README.md).
+
+| Tilt drill | Injection | Acceptance / observation |
+|---|---|---|
+| Slow database | MongoDB +500 ms | No-errors criterion failed: [#160](https://github.com/iVega123/ProjectY/issues/160) |
+| Database down | MongoDB timeout | Bounded refusals and gateway breaker; inspect traces and metrics |
+| Redis down | Redis timeout | Limiter open; revocation/idempotency closed |
+| Kafka down | Disabled | Waiting for Kafka rental path, #130 |
+| Bad network | MongoDB slicer + connection byte limit | Error-rate acceptance still open |
+| Service killed | Disabled | Waiting for live tracking/map, #10 |
+
+Each Tilt drill has a clear button. [Detailed commands](docs/chaos-drills.md).
+[Load and resilience dashboard](http://localhost:3000/d/projecty-load-resilience)
+uses port 13000 with the isolated load runner's `-KeepStack` option.
+

--- a/deploy/observability/grafana/dashboards/load-resilience.json
+++ b/deploy/observability/grafana/dashboards/load-resilience.json
@@ -1,0 +1,237 @@
+{
+  "uid": "projecty-load-resilience",
+  "title": "ProjectY — load and resilience",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5s",
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "tags": [
+    "projecty",
+    "resilience",
+    "k6"
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "title": "Successful rental creation latency (ms)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "k6_projecty_rental_create_ms_p95",
+          "legendFormat": "{{__name__}} {{service}} {{queue}} {{upstream}}"
+        },
+        {
+          "refId": "B",
+          "expr": "k6_projecty_rental_create_ms_p99",
+          "legendFormat": "{{__name__}} {{service}} {{queue}} {{upstream}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Created rentals and rate-limit rejections",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(k6_projecty_rentals_created_total[1m])",
+          "legendFormat": "{{__name__}} {{service}} {{queue}} {{upstream}}"
+        },
+        {
+          "refId": "B",
+          "expr": "rate(k6_projecty_rate_limited_total[1m])",
+          "legendFormat": "{{__name__}} {{service}} {{queue}} {{upstream}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Unexpected rental response rate",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "k6_http_req_failed_rate{name=\"rental-create\"}",
+          "legendFormat": "{{__name__}} {{service}} {{queue}} {{upstream}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Service availability",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 8,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "up{job=~\"projecty-services|otel-collector|rabbitmq-queues\"}",
+          "legendFormat": "{{__name__}} {{service}} {{queue}} {{upstream}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Gateway breaker and dependency refusals",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "gateway_upstream_circuit_breaker_state",
+          "legendFormat": "{{__name__}} {{service}} {{queue}} {{upstream}}"
+        },
+        {
+          "refId": "B",
+          "expr": "rate(dependency_refusals_total[1m])",
+          "legendFormat": "{{__name__}} {{service}} {{queue}} {{upstream}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Durable dead-letter queue depth",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rabbitmq_detailed_queue_messages{queue=~\".*_poison_queue\"}",
+          "legendFormat": "{{__name__}} {{service}} {{queue}} {{upstream}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    }
+  ]
+}

--- a/docs/chaos-drills.md
+++ b/docs/chaos-drills.md
@@ -7,7 +7,7 @@ that drill's named toxics; it does not restart a container or clear other drills
 
 | Drill | Injection | Expected / acceptance status | Observe |
 |---|---|---|---|
-| Slow database | 500 ms on the active MongoDB proxy | Measure increased p99. The target “no 5xx” promise remains unverified with the current multi-call rental flow. | Grafana rental SLO, Mongo spans |
+| Slow database | 500 ms on the active MongoDB proxy | Measure increased p99. Measured 4.35% unexpected responses; acceptance failed, tracked in [#160](https://github.com/iVega123/ProjectY/issues/160). | Grafana rental SLO, Mongo spans |
 | Database down | MongoDB downstream timeout | 503 with Retry-After; gateway breaker opens after repeated failures | Gateway metrics and degraded traces |
 | Redis down | Redis downstream timeout | Limiter fails open; revocation and idempotency fail closed | Degradation counter and response status |
 | Kafka down | Disabled until the rental Kafka path exists | Target: rental writes continue, outbox accumulates and drains | Blocked by #130 / event-service work |

--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -1,0 +1,65 @@
+# Reproducing the rental load gate
+
+Run from the repository root with Docker and PowerShell 5.1 (Windows) or 7
+(Linux/macOS):
+
+```powershell
+powershell -File scripts/Run-LoadTest.ps1
+# On Linux/macOS: pwsh -File scripts/Run-LoadTest.ps1
+```
+
+The runner generates ignored credentials and a dedicated `projecty-load` Compose
+model. It uses separately named volumes/images, loopback-only ports, a release
+gateway build, real .NET services, PostgreSQL, MongoDB, Redis, RabbitMQ and LGTM.
+It seeds one rider and 10,000 motorcycles, warms up one creation, then sends
+five concurrent users for 30 seconds with 100 ms think time.
+
+A test-only in-network issuer supplies short-lived Ed25519 tokens. Requests
+still traverse the real gateway's JWT validation, signed identity, revocation,
+rate limiting and the real rental creation flow. This does not benchmark signup,
+login or the future Go identity service. The issuer is never present in the
+application or production Compose models.
+
+The default limiter remains enabled (120-token burst, 120 tokens/minute), shared
+by the seeded rider. Report created rentals and 429s separately: this is a bounded
+smoke/performance gate under the configured policy, not a maximum-capacity claim.
+Each accepted request gets a fresh motorcycle and idempotency key. Repeated 409s,
+401s or fast 503s cannot masquerade as successful throughput.
+
+The build fails when any of these conditions fails:
+
+- successful-creation p95 < 800 ms and p99 < 2,000 ms;
+- unexpected response rate < 1%, calculated over **all** rental requests;
+- at least 100 successful creations;
+- more than 99% of checks pass.
+
+429 is registered with k6's expected-status callback and counted separately.
+Latency contains only successful creations. The former filtered error threshold
+could exclude the very failures it was meant to detect; the gate no longer
+filters by `expected_response:true`.
+
+Results and environment metadata are written to `load/results/`. The GitHub
+`Rental load gate` workflow builds the ephemeral stack, runs the same command,
+and uploads JSON artifacts even when thresholds fail. Ordinary runs remove only
+the generated benchmark containers and volumes. `-KeepStack` retains them for
+inspection at Grafana `http://localhost:13000/d/projecty-load-resilience`;
+`-NoBuild` reuses already built benchmark images.
+
+To compare faults against the same workload:
+
+```powershell
+powershell -File scripts/Run-LoadTest.ps1 -KeepStack
+powershell -File scripts/Run-LoadTest.ps1 -Mode slow-db -KeepStack -NoBuild
+powershell -File scripts/Run-LoadTest.ps1 -Mode db-down -KeepStack -NoBuild
+powershell -File scripts/Run-LoadTest.ps1 -Mode rabbit-down -KeepStack -NoBuild
+```
+
+Each run resets only its isolated fixture data, warms up, then injects the toxic.
+k6 clears its toxic in teardown. Threshold failures during a deliberate outage
+remain nonzero exits and are evidence of the measured failure, not a waived gate.
+A later run starts with an explicit proxy reset. Kafka resilience is not inferred
+from the RabbitMQ scenario; its target acceptance criteria remain open.
+
+The `ProjectY — load and resilience` dashboard overlays the k6 percentiles,
+creation/rejection rates, error rate, service health, gateway breaker state and
+durable DLQ depth. k6 remote-writes into the same Prometheus as the application.

--- a/docs/measurements/epic-9/README.md
+++ b/docs/measurements/epic-9/README.md
@@ -1,0 +1,49 @@
+﻿# Measured rental load — 2026-09-05
+
+Five constant VUs for 30 seconds, one seeded rider, default per-subject rate limiter.
+Host: AMD Ryzen 9 9950X3D2 (16 cores/32 threads), Windows with Linux Docker 29.7.2;
+Docker allocation: 32 logical CPUs and 66,091,401,216 bytes RAM (~61.55 GiB).
+These are limited-subject acceptance measurements, not maximum system capacity.
+
+| Mode | Created | HTTP 429 | Unexpected responses | Successful p95 / p99 (ms) | k6 exit |
+|---|---:|---:|---:|---:|---:|
+| baseline | 179 | 1,220 | 0 / 1,399 (0%) | 37.78 / 87.16 | 0 |
+| slow-db (MongoDB +500 ms) | 88 | 0 | 4 / 92 (4.35%) | 1,528.78 / 2,533.04 | 99 |
+| db-down (MongoDB timeout) | 0 | 957 | 179 / 1,136 (15.76%) | N/A: no successful creation | 99 |
+| rabbit-down (RabbitMQ timeout) | 179 | 1,231 | 0 / 1,410 (0%) | 26.95 / 33.16 | 0 |
+
+The database outage's observed HTTP 503 latency was median 3.52 ms,
+p95 1,056.41 ms, p99 2,063.89 ms, maximum 2,096.70 ms. Initial requests and
+half-open probes still incur dependency timeouts; a fast median does not mean
+every refusal is instantaneous. The aggregate unexpected-response metric is
+not a status-code breakdown, so it does not prove every failed request was 503.
+
+The slow database experiment fails the original no-errors criterion:
+[bug #160](https://github.com/iVega123/ProjectY/issues/160).
+The same unchanged thresholds correctly reject both database fault runs.
+RabbitMQ is not on the current synchronous rental-write path; its passing result
+does not prove Kafka delivery, accumulation or recovery.
+
+Reproduce from repository root:
+```powershell
+powershell -File scripts/Run-LoadTest.ps1
+powershell -File scripts/Run-LoadTest.ps1 -Mode slow-db
+powershell -File scripts/Run-LoadTest.ps1 -Mode db-down
+powershell -File scripts/Run-LoadTest.ps1 -Mode rabbit-down
+```
+
+Each command builds an isolated project, seeds fixtures and removes its own
+containers and volumes afterwards. Add -KeepStack to inspect Grafana on port
+13000; the normal Tilt dashboard is on port 3000. See
+[runner details](../../load-testing.md).
+
+Raw k6 summaries and environment metadata are adjacent. The metadata commit is
+the application checkout at measurement time, not a claim that the runner had
+no working-tree edits: baseline/slow-db were measured while task #72 was being
+implemented; db-down/rabbit-down include the subsequently committed refusal
+metric and warmup recovery change. Final runner revision before publication
+of these results: 8518121. Application code was unchanged across these runs.
+Dashboard provisioning (six panels) and actual Prometheus series for creation
+latency, rate limiting, breaker state and dependency refusals were verified.
+The ephemeral-stack baseline also passed GitHub Actions in PR #159.
+

--- a/docs/measurements/epic-9/baseline-environment.json
+++ b/docs/measurements/epic-9/baseline-environment.json
@@ -1,0 +1,10 @@
+﻿{
+    "cpus":  "32",
+    "duration":  "30s",
+    "commit":  "f212abf8acae006d9eaeb670c1399f6663e732d1",
+    "memoryBytes":  "66091401216",
+    "docker":  "29.7.2",
+    "mode":  "baseline",
+    "measuredAt":  "2026-09-05T14:43:20.9074600Z",
+    "vus":  5
+}

--- a/docs/measurements/epic-9/baseline.json
+++ b/docs/measurements/epic-9/baseline.json
@@ -1,0 +1,244 @@
+{
+  "measuredAt": "2026-09-05T14:43:52.886Z",
+  "vus": 5,
+  "duration": "30s",
+  "mode": "baseline",
+  "metrics": {
+    "data_received": {
+      "values": {
+        "count": 500292,
+        "rate": 16310.808150986008
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 7.054526411848667,
+        "min": 2.04682,
+        "med": 3.587148,
+        "max": 563.39502,
+        "p(95)": 25.252278,
+        "p(99)": 33.144278
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 981771,
+        "rate": 32008.264032208557
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.023743502498215618,
+        "min": 0.0078,
+        "med": 0.014552,
+        "max": 0.616063,
+        "p(95)": 0.049334,
+        "p(99)": 0.084407
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 0.345346,
+        "p(95)": 0,
+        "p(99)": 0,
+        "avg": 0.0011149564596716632,
+        "min": 0,
+        "med": 0
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 0,
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "max": 0,
+        "p(95)": 0
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1401,
+        "rate": 45.6762095326957
+      }
+    },
+    "vus": {
+      "contains": "default",
+      "values": {
+        "value": 5,
+        "min": 5,
+        "max": 5
+      },
+      "type": "gauge"
+    },
+    "projecty_rentals_created": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 179,
+        "rate": 5.835861175126717
+      },
+      "thresholds": {
+        "count>=100": {
+          "ok": true
+        }
+      }
+    },
+    "projecty_rate_limited": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1220,
+        "rate": 39.775143204774274
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "passes": 0,
+        "fails": 1401,
+        "rate": 0
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 0.878687,
+        "p(95)": 0.116039,
+        "p(99)": 0.187405,
+        "avg": 0.06509947394718049,
+        "min": 0.01096,
+        "med": 0.056545
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 107.48120451608293,
+        "min": 103.061727,
+        "med": 104.483597,
+        "max": 190.119824,
+        "p(95)": 126.0467111,
+        "p(99)": 134.10340724
+      }
+    },
+    "http_req_failed{name:rental-create}": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 1399
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1399,
+        "rate": 45.61100437990099
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "contains": "time",
+      "values": {
+        "avg": 7.14336938829408,
+        "min": 2.220484,
+        "med": 3.675074,
+        "max": 563.712924,
+        "p(95)": 25.380787,
+        "p(99)": 33.257308
+      },
+      "type": "trend"
+    },
+    "http_req_blocked": {
+      "contains": "time",
+      "values": {
+        "p(95)": 0.006101,
+        "p(99)": 0.026592,
+        "avg": 0.006622088508208436,
+        "min": 0.00182,
+        "med": 0.00333,
+        "max": 1.532302
+      },
+      "type": "trend"
+    },
+    "projecty_rental_create_ms": {
+      "type": "trend",
+      "contains": "default",
+      "values": {
+        "avg": 26.799498821229037,
+        "min": 19.003898,
+        "med": 24.848444,
+        "max": 89.172017,
+        "p(95)": 37.7795264,
+        "p(99)": 87.15837218
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        },
+        "p(99)<2000": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_duration": {
+      "values": {
+        "p(95)": 25.380787,
+        "p(99)": 33.257308,
+        "avg": 7.14336938829408,
+        "min": 2.220484,
+        "med": 3.675074,
+        "max": 563.712924
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "vus_max": {
+      "values": {
+        "value": 5,
+        "min": 5,
+        "max": 5
+      },
+      "type": "gauge",
+      "contains": "default"
+    },
+    "checks": {
+      "values": {
+        "rate": 1,
+        "passes": 1399,
+        "fails": 0
+      },
+      "thresholds": {
+        "rate>0.99": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default"
+    }
+  }
+}

--- a/docs/measurements/epic-9/db-down-environment.json
+++ b/docs/measurements/epic-9/db-down-environment.json
@@ -1,0 +1,10 @@
+﻿{
+    "cpus":  "32",
+    "duration":  "30s",
+    "commit":  "765897664c7479a8d8444522aadd53440192b83e",
+    "memoryBytes":  "66091401216",
+    "docker":  "29.7.2",
+    "mode":  "db-down",
+    "measuredAt":  "2026-09-05T15:05:48.8650152Z",
+    "vus":  5
+}

--- a/docs/measurements/epic-9/db-down.json
+++ b/docs/measurements/epic-9/db-down.json
@@ -1,0 +1,256 @@
+{
+  "measuredAt": "2026-09-05T15:06:20.145Z",
+  "vus": 5,
+  "duration": "30s",
+  "mode": "db-down",
+  "metrics": {
+    "http_req_failed{name:rental-create}": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0.15757042253521128,
+        "passes": 179,
+        "fails": 957
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": false
+        }
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 435178,
+        "rate": 14446.364977696552
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0.1570175438596491,
+        "passes": 179,
+        "fails": 961
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 33.797913,
+        "p(95)": 4.541564,
+        "p(99)": 5.1840442,
+        "avg": 3.584372356919873,
+        "min": 0.362458,
+        "med": 3.40531
+      }
+    },
+    "http_req_blocked": {
+      "values": {
+        "min": 0.00172,
+        "med": 0.002761,
+        "max": 1.106895,
+        "p(95)": 0.0059815,
+        "p(99)": 0.026773399999999427,
+        "avg": 0.006610999999999998
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_reqs": {
+      "values": {
+        "count": 1140,
+        "rate": 37.84395368004373
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 4.6437445,
+        "p(99)": 1062.2516408299996,
+        "avg": 31.566636795613974,
+        "min": 0.362458,
+        "med": 3.4319635,
+        "max": 2532.925459
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 797497,
+        "rate": 26474.069761380557
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1136,
+        "rate": 37.71116787765761
+      }
+    },
+    "http_req_connecting": {
+      "values": {
+        "min": 0,
+        "med": 0,
+        "max": 0.25906,
+        "p(95)": 0,
+        "p(99)": 0,
+        "avg": 0.0015578184210526317
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "projecty_rate_limited": {
+      "contains": "default",
+      "values": {
+        "count": 957,
+        "rate": 31.769003220878815
+      },
+      "type": "counter"
+    },
+    "projecty_rental_create_ms": {
+      "contains": "default",
+      "values": {
+        "p(99)": 0,
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "max": 0,
+        "p(95)": 0
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        },
+        "p(99)<2000": {
+          "ok": true
+        }
+      },
+      "type": "trend"
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0.8425681618293756,
+        "passes": 958,
+        "fails": 179
+      },
+      "thresholds": {
+        "rate>0.99": {
+          "ok": false
+        }
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 0.07882589999999974,
+        "avg": 0.02164411666666666,
+        "min": 0.00722,
+        "med": 0.012006,
+        "max": 0.563003,
+        "p(95)": 0.047734549999999994
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.241192,
+        "med": 3.3527639999999996,
+        "max": 2532.779457,
+        "p(95)": 4.572093399999999,
+        "p(99)": 1062.1470656999995,
+        "avg": 31.48843646228065
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 0.13831728999999987,
+        "avg": 0.05655621666666668,
+        "min": 0.012301,
+        "med": 0.0474185,
+        "max": 0.466307,
+        "p(95)": 0.10556349999999999
+      }
+    },
+    "vus": {
+      "values": {
+        "value": 5,
+        "min": 5,
+        "max": 5
+      },
+      "type": "gauge",
+      "contains": "default"
+    },
+    "projecty_rentals_created": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 0,
+        "rate": 0
+      },
+      "thresholds": {
+        "count>=100": {
+          "ok": false
+        }
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "max": 0,
+        "p(95)": 0,
+        "p(99)": 0
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 2633.691046,
+        "p(95)": 105.51961725,
+        "p(99)": 1163.1284342500005,
+        "avg": 132.37289953081012,
+        "min": 102.998726,
+        "med": 104.211388
+      }
+    },
+    "projecty_rental_refusal_ms": {
+      "type": "trend",
+      "contains": "default",
+      "values": {
+        "med": 3.517143,
+        "max": 2096.70315,
+        "p(95)": 1056.4126872,
+        "p(99)": 2063.89482688,
+        "avg": 100.48445749710997,
+        "min": 2.971053
+      }
+    },
+    "vus_max": {
+      "contains": "default",
+      "values": {
+        "value": 5,
+        "min": 5,
+        "max": 5
+      },
+      "type": "gauge"
+    }
+  }
+}

--- a/docs/measurements/epic-9/rabbit-down-environment.json
+++ b/docs/measurements/epic-9/rabbit-down-environment.json
@@ -1,0 +1,10 @@
+﻿{
+    "cpus":  "32",
+    "duration":  "30s",
+    "commit":  "765897664c7479a8d8444522aadd53440192b83e",
+    "memoryBytes":  "66091401216",
+    "docker":  "29.7.2",
+    "mode":  "rabbit-down",
+    "measuredAt":  "2026-09-05T15:14:34.2363854Z",
+    "vus":  5
+}

--- a/docs/measurements/epic-9/rabbit-down.json
+++ b/docs/measurements/epic-9/rabbit-down.json
@@ -1,0 +1,244 @@
+{
+  "measuredAt": "2026-09-05T15:15:05.444Z",
+  "vus": 5,
+  "duration": "30s",
+  "mode": "rabbit-down",
+  "metrics": {
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 1411,
+        "fails": 0
+      },
+      "thresholds": {
+        "rate>0.99": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_connecting": {
+      "contains": "time",
+      "values": {
+        "avg": 0.0011241534653465349,
+        "min": 0,
+        "med": 0,
+        "max": 0.278644,
+        "p(95)": 0,
+        "p(99)": 0
+      },
+      "type": "trend"
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.051304,
+        "max": 0.331469,
+        "p(95)": 0.10568149999999997,
+        "p(99)": 0.15644228999999937,
+        "avg": 0.05912361598302689,
+        "min": 0.011961
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 102.949293,
+        "med": 104.24336,
+        "max": 142.471186,
+        "p(95)": 122.8044361,
+        "p(99)": 126.36303451000008,
+        "avg": 106.64331329219873
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 5.946712954738336,
+        "min": 0.526958,
+        "med": 3.4707965,
+        "max": 40.953554,
+        "p(95)": 21.982799349999997,
+        "p(99)": 25.33191420999997
+      }
+    },
+    "projecty_rental_create_ms": {
+      "type": "trend",
+      "contains": "default",
+      "values": {
+        "avg": 21.694335659217877,
+        "min": 16.175921,
+        "med": 21.189871,
+        "max": 40.953554,
+        "p(95)": 26.948342899999997,
+        "p(99)": 33.16015599999999
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        },
+        "p(99)<2000": {
+          "ok": true
+        }
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 5,
+        "min": 5,
+        "max": 5
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 3.4707965,
+        "max": 40.953554,
+        "p(95)": 21.982799349999997,
+        "p(99)": 25.33191420999997,
+        "avg": 5.946712954738336,
+        "min": 0.526958
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 989847,
+        "rate": 32834.64427347397
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 5,
+        "min": 5,
+        "max": 5
+      }
+    },
+    "projecty_rate_limited": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1231,
+        "rate": 40.834035058596385
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1414,
+        "rate": 46.904407451547755
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "rate": 16746.067631820835,
+        "count": 504834
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 1414
+      }
+    },
+    "projecty_rentals_created": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 179,
+        "rate": 5.9376866575863145
+      },
+      "thresholds": {
+        "count>=100": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_failed{name:rental-create}": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 1410
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.00590908628005658,
+        "min": 0.00173,
+        "med": 0.00279,
+        "max": 1.008154,
+        "p(95)": 0.005707649999999999,
+        "p(99)": 0.02069469999999951
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1410,
+        "rate": 46.7717217161827
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 3.380588,
+        "max": 40.842436,
+        "p(95)": 21.877799199999995,
+        "p(99)": 25.157111819999958,
+        "avg": 5.868644355021217,
+        "min": 0.370102
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "max": 0,
+        "p(95)": 0,
+        "p(99)": 0
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.011601,
+        "max": 0.215765,
+        "p(95)": 0.04454849999999997,
+        "p(99)": 0.06372892999999999,
+        "avg": 0.01894498373408767,
+        "min": 0.00715
+      }
+    }
+  }
+}

--- a/docs/measurements/epic-9/slow-db-environment.json
+++ b/docs/measurements/epic-9/slow-db-environment.json
@@ -1,0 +1,10 @@
+﻿{
+    "cpus":  "32",
+    "duration":  "30s",
+    "commit":  "f212abf8acae006d9eaeb670c1399f6663e732d1",
+    "memoryBytes":  "66091401216",
+    "docker":  "29.7.2",
+    "mode":  "slow-db",
+    "measuredAt":  "2026-09-05T14:57:13.2854225Z",
+    "vus":  5
+}

--- a/docs/measurements/epic-9/slow-db.json
+++ b/docs/measurements/epic-9/slow-db.json
@@ -1,0 +1,244 @@
+{
+  "measuredAt": "2026-09-05T14:57:45.851Z",
+  "vus": 5,
+  "duration": "30s",
+  "mode": "slow-db",
+  "metrics": {
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 92,
+        "rate": 2.9242604867406254
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 2537.17041,
+        "p(95)": 2145.58893625,
+        "p(99)": 2532.6645695,
+        "avg": 1513.7489080416665,
+        "min": 0.453827,
+        "med": 1523.6204335
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.1155934375,
+        "min": 0.028982,
+        "med": 0.110423,
+        "max": 0.244358,
+        "p(95)": 0.186838,
+        "p(99)": 0.2157506499999999
+      }
+    },
+    "data_received": {
+      "contains": "data",
+      "values": {
+        "rate": 647.6919123729753,
+        "count": 20377
+      },
+      "type": "counter"
+    },
+    "http_req_blocked": {
+      "values": {
+        "avg": 0.05518809375000001,
+        "min": 0.00246,
+        "med": 0.0051305,
+        "max": 1.68208,
+        "p(95)": 0.31275224999999995,
+        "p(99)": 0.7777379499999973
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "projecty_rate_limited": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "count": 0
+      }
+    },
+    "projecty_rental_create_ms": {
+      "contains": "default",
+      "values": {
+        "p(99)": 2533.0440087,
+        "avg": 1552.336628454546,
+        "min": 1520.089994,
+        "med": 1523.6418615,
+        "max": 2537.17041,
+        "p(95)": 1528.78064925
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": false
+        },
+        "p(99)<2000": {
+          "ok": false
+        }
+      },
+      "type": "trend"
+    },
+    "http_req_sending": {
+      "values": {
+        "avg": 0.04076401041666668,
+        "min": 0.011431,
+        "med": 0.0389225,
+        "max": 0.123449,
+        "p(95)": 0.083416,
+        "p(99)": 0.10171584999999993
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0.18146375,
+        "p(99)": 0.26235709999999995,
+        "avg": 0.01913494791666667,
+        "min": 0,
+        "med": 0,
+        "max": 0.269237
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 2532.52972305,
+        "avg": 1513.5925505937505,
+        "min": 0.359731,
+        "med": 1523.457143,
+        "max": 2536.940232,
+        "p(95)": 2145.4121675
+      }
+    },
+    "iteration_duration": {
+      "contains": "time",
+      "values": {
+        "p(95)": 2345.5240374000014,
+        "p(99)": 2634.3319429000003,
+        "avg": 1680.0899940000004,
+        "min": 1201.314633,
+        "med": 1624.72296,
+        "max": 2638.545616
+      },
+      "type": "trend"
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0.956989247311828,
+        "passes": 89,
+        "fails": 4
+      },
+      "thresholds": {
+        "rate>0.99": {
+          "ok": false
+        }
+      }
+    },
+    "projecty_rentals_created": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 88,
+        "rate": 2.7971187264475548
+      },
+      "thresholds": {
+        "count>=100": {
+          "ok": false
+        }
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "fails": 92,
+        "rate": 0.041666666666666664,
+        "passes": 4
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 1485.3449632391307,
+        "min": 0.453827,
+        "med": 1523.6050705,
+        "max": 2537.17041,
+        "p(95)": 1528.58979625,
+        "p(99)": 2532.8542891
+      }
+    },
+    "vus": {
+      "values": {
+        "value": 3,
+        "min": 3,
+        "max": 5
+      },
+      "type": "gauge",
+      "contains": "default"
+    },
+    "vus_max": {
+      "values": {
+        "value": 5,
+        "min": 5,
+        "max": 5
+      },
+      "type": "gauge",
+      "contains": "default"
+    },
+    "http_req_failed{name:rental-create}": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0.043478260869565216,
+        "passes": 4,
+        "fails": 88
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": false
+        }
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "max": 0,
+        "p(95)": 0,
+        "p(99)": 0
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 96,
+        "rate": 3.051402247033696
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 65538,
+        "rate": 2083.1541715218164
+      }
+    }
+  }
+}

--- a/load/fixtures/identity.mjs
+++ b/load/fixtures/identity.mjs
@@ -1,0 +1,19 @@
+// Test-only issuer. Never included by the application or production Compose.
+import http from "node:http";
+import { generateKeyPairSync, sign, randomUUID } from "node:crypto";
+const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+const key = { ...publicKey.export({ format: "jwk" }), kid: "load-only", alg: "EdDSA", use: "sig" };
+const encode = value => Buffer.from(JSON.stringify(value)).toString("base64url");
+http.createServer((request, response) => {
+  response.setHeader("content-type", "application/json");
+  if (request.url === "/jwks") return response.end(JSON.stringify({ keys: [key] }));
+  if (request.url === "/token") {
+    const now = Math.floor(Date.now() / 1000);
+    const body = encode({ alg: "EdDSA", kid: key.kid, typ: "JWT" }) + "." +
+      encode({ iss: "projecty.identity", aud: "projecty.rental-operations", sub: "load-rider",
+        roles: ["Rider"], iat: now, exp: now + 300, jti: randomUUID() });
+    return response.end(JSON.stringify({ token: body + "." + sign(null, Buffer.from(body), privateKey).toString("base64url") }));
+  }
+  response.statusCode = request.url === "/health" ? 200 : 404;
+  response.end("{}");
+}).listen(8080, "0.0.0.0");

--- a/load/fixtures/reset-rentals.js
+++ b/load/fixtures/reset-rentals.js
@@ -1,0 +1,5 @@
+// This file is mounted only in the dedicated benchmark stack.
+const rentalDatabase = db.getSiblingDB("RentalOperationsDB");
+for (const collection of rentalDatabase.getCollectionNames()) {
+  rentalDatabase.getCollection(collection).deleteMany({});
+}

--- a/load/fixtures/seed-motorcycles.sql
+++ b/load/fixtures/seed-motorcycles.sql
@@ -1,0 +1,4 @@
+INSERT INTO "Motorcycles" ("Id", "Year", "Model", "LicensePlate", "RegistrationDate")
+SELECT 'load-moto-' || n, 2025, 'Load fixture', 'KAA' || lpad(n::text, 4, '0'), now()
+FROM generate_series(0, 9999) n
+ON CONFLICT ("LicensePlate") DO NOTHING;

--- a/load/fixtures/seed-rider.sql
+++ b/load/fixtures/seed-rider.sql
@@ -1,0 +1,3 @@
+INSERT INTO "Riders" ("Id", "UserId", "Email", "Name", "CNPJ", "DateOfBirth", "CNHNumber", "CNHType")
+VALUES ('load-rider', 'load-rider', 'load@example.test', 'Load rider', '11444777000161', '1990-01-01', '12345678901', 'A')
+ON CONFLICT ("Id") DO NOTHING;

--- a/load/k6/rental-flow.js
+++ b/load/k6/rental-flow.js
@@ -1,98 +1,85 @@
-// Carga sobre o fluxo real de aluguel, atravessando gateway → rental-core → Cockroach.
-//
-// As métricas vão para o Prometheus por remote-write, então o mesmo painel do
-// Grafana que mostra a saúde do sistema mostra a carga que você está aplicando.
-// É essa sobreposição que torna o teste demonstrável: dá para ver o limite de
-// taxa entrando em ação e o p99 subindo, na mesma tela, ao vivo.
-
 import http from "k6/http";
-import { check, sleep } from "k6";
+import { check, sleep, fail } from "k6";
+import execution from "k6/execution";
 import { Counter, Trend } from "k6/metrics";
 
-const BASE = __ENV.BASE_URL || "http://localhost:8090";
-const VUS = parseInt(__ENV.VUS || "20", 10);
-const DURATION = __ENV.DURATION || "30s";
-
-const rateLimited = new Counter("projecty_rate_limited_total");
-const rentalLatency = new Trend("projecty_rental_create_ms", true);
+const base = __ENV.BASE_URL || "http://api-gateway:8090";
+const accepted = new Counter("projecty_rentals_created");
+const limited = new Counter("projecty_rate_limited");
+const latency = new Trend("projecty_rental_create_ms");
+const expected = http.expectedStatuses(200, 201, 429);
 
 export const options = {
-  scenarios: {
-    steady: {
-      executor: "constant-vus",
-      vus: VUS,
-      duration: DURATION,
-      gracefulStop: "10s",
-    },
-  },
-  // Limiares fazem o k6 sair com código != 0 quando o sistema não cumpre o
-  // acordo — o teste de carga vira um portão de CI, não só um gráfico bonito.
+  scenarios: { steady: { executor: "constant-vus", vus: Number(__ENV.VUS || 5),
+    duration: __ENV.DURATION || "30s", gracefulStop: "5s" } },
   thresholds: {
-    "http_req_failed{expected_response:true}": ["rate<0.01"],
-    "projecty_rental_create_ms": ["p(95)<800", "p(99)<2000"],
-    checks: ["rate>0.95"],
+    "http_req_failed{name:rental-create}": ["rate<0.01"],
+    projecty_rental_create_ms: ["p(95)<800", "p(99)<2000"],
+    projecty_rentals_created: ["count>=100"],
+    checks: ["rate>0.99"],
   },
-  discardResponseBodies: false,
+  summaryTrendStats: ["avg", "min", "med", "max", "p(95)", "p(99)"],
 };
 
-const PLATES = ["ABC1D23", "XYZ9K88", "QRS4T56", "JKL7M01", "PQR2N45"];
-
-function plate() {
-  return PLATES[Math.floor(Math.random() * PLATES.length)];
+function create(token, plate, key, name) {
+  return http.post(base + "/api/Rental/create", JSON.stringify({
+    motocycleLicencePlate: plate,
+    startDate: "2026-10-01T00:00:00Z",
+    predictedEndDate: "2026-10-08T00:00:00Z",
+  }), {
+    headers: { Authorization: "Bearer " + token, "Content-Type": "application/json", "Idempotency-Key": key },
+    responseCallback: expected, timeout: "5s", tags: { name },
+  });
 }
 
-function isoDaysFromNow(days) {
-  return new Date(Date.now() + days * 86400000).toISOString();
-}
-
-export default function () {
-  const headers = {
-    "Content-Type": "application/json",
-    // O gateway usa esta chave para tornar a repetição segura: reenviar a mesma
-    // requisição não cria um segundo aluguel.
-    "Idempotency-Key": `${__VU}-${__ITER}-${Date.now()}`,
-  };
-
-  const payload = JSON.stringify({
-    licensePlate: plate(),
-    startsAt: isoDaysFromNow(1),
-    predictedEndsAt: isoDaysFromNow(8),
-  });
-
-  const res = http.post(`${BASE}/api/rentals`, payload, {
-    headers,
-    tags: { name: "POST /api/rentals" },
-  });
-
-  rentalLatency.add(res.timings.duration);
-
-  if (res.status === 429) {
-    // Não é falha: é o limite de taxa funcionando. Contabilizar à parte evita
-    // que a proteção que está funcionando apareça como erro no painel.
-    rateLimited.add(1);
-  } else {
-    check(res, {
-      "aceito ou recusado por regra de negócio": (r) =>
-        r.status === 201 || r.status === 200 || r.status === 409 || r.status === 422,
-      "sem erro de servidor": (r) => r.status < 500,
-    });
+export function setup() {
+  const response = http.get((__ENV.IDENTITY_URL || "http://load-identity:8080") + "/token", { tags: { name: "fixture-token" } });
+  if (response.status !== 200) fail("Test identity fixture unavailable");
+  const token = response.json("token");
+  const run = Date.now().toString();
+  const warmup = create(token, "KAA9999", "warmup-" + run, "warmup");
+  if (warmup.status !== 200 && warmup.status !== 201) fail("Rental warmup failed: " + warmup.status + " " + warmup.body);
+  const mode = __ENV.MODE || "baseline";
+  if (mode !== "baseline") {
+    const proxy = mode === "rabbit-down" ? "rabbitmq" : "mongodb";
+    const attributes = mode === "slow-db" ? { latency: 500, jitter: 0 } : { timeout: 0 };
+    const injection = http.post("http://toxiproxy:8474/proxies/" + proxy + "/toxics",
+      JSON.stringify({ name: "load-drill", type: mode === "slow-db" ? "latency" : "timeout",
+        stream: "downstream", toxicity: 1, attributes }),
+      { headers: { "Content-Type": "application/json" }, tags: { name: "chaos-injection" } });
+    if (injection.status !== 200) fail("Could not inject benchmark fault: " + injection.status);
   }
+  return { token, run };
+}
 
-  sleep(Math.random() * 0.5);
+export default function(data) {
+  const index = execution.scenario.iterationInTest;
+  if (index >= 9999) fail("Fixture capacity exceeded; increase the seeded range before increasing the workload");
+  const response = create(data.token, "KAA" + String(index).padStart(4, "0"),
+    data.run + "-" + index, "rental-create");
+  const created = response.status === 200 || response.status === 201;
+  accepted.add(created ? 1 : 0);
+  if (created) latency.add(response.timings.duration);
+  limited.add(response.status === 429 ? 1 : 0);
+  check(response, { "created or explicitly rate limited": () => created || response.status === 429 });
+  sleep(0.1);
 }
 
 export function handleSummary(data) {
-  const m = data.metrics;
-  const line = (k) => (m[k] ? m[k].values : {});
-  return {
-    stdout:
-      "\n" +
-      "  ProjectY — resumo da carga\n" +
-      "  ─────────────────────────────────────────\n" +
-      `  requisições .............. ${line("http_reqs").count ?? 0}\n` +
-      `  barradas pelo rate limit . ${line("projecty_rate_limited_total").count ?? 0}\n` +
-      `  p95 criação de aluguel ... ${Math.round(line("projecty_rental_create_ms")["p(95)"] ?? 0)} ms\n` +
-      `  p99 criação de aluguel ... ${Math.round(line("projecty_rental_create_ms")["p(99)"] ?? 0)} ms\n` +
-      "\n  Painel: http://localhost:3001/d/projecty-plataforma\n\n",
+  const summary = {
+    measuredAt: new Date().toISOString(), vus: Number(__ENV.VUS || 5),
+    duration: __ENV.DURATION || "30s", mode: __ENV.MODE || "baseline",
+    metrics: data.metrics,
   };
+  return { stdout: JSON.stringify(summary, null, 2) + "\n",
+    [__ENV.SUMMARY_PATH || "/results/baseline.json"]: JSON.stringify(summary, null, 2) + "\n" };
+}
+
+export function teardown() {
+  if ((__ENV.MODE || "baseline") !== "baseline") {
+    const proxy = __ENV.MODE === "rabbit-down" ? "rabbitmq" : "mongodb";
+    const response = http.del("http://toxiproxy:8474/proxies/" + proxy + "/toxics/load-drill",
+      null, { tags: { name: "chaos-clear" } });
+    check(response, { "benchmark toxic cleared": r => r.status === 204 });
+  }
 }

--- a/load/k6/rental-flow.js
+++ b/load/k6/rental-flow.js
@@ -7,6 +7,7 @@ const base = __ENV.BASE_URL || "http://api-gateway:8090";
 const accepted = new Counter("projecty_rentals_created");
 const limited = new Counter("projecty_rate_limited");
 const latency = new Trend("projecty_rental_create_ms");
+const refusalLatency = new Trend("projecty_rental_refusal_ms");
 const expected = http.expectedStatuses(200, 201, 429);
 
 export const options = {
@@ -37,7 +38,13 @@ export function setup() {
   if (response.status !== 200) fail("Test identity fixture unavailable");
   const token = response.json("token");
   const run = Date.now().toString();
-  const warmup = create(token, "KAA9999", "warmup-" + run, "warmup");
+  const readyUntil = Date.now() + 40000;
+  let warmup;
+  do {
+    warmup = create(token, "KAA9999", "warmup-" + run, "warmup");
+    if (warmup.status === 200 || warmup.status === 201) break;
+    sleep(1); // Allow a previously opened breaker to enter half-open after a cleared drill.
+  } while (Date.now() < readyUntil);
   if (warmup.status !== 200 && warmup.status !== 201) fail("Rental warmup failed: " + warmup.status + " " + warmup.body);
   const mode = __ENV.MODE || "baseline";
   if (mode !== "baseline") {
@@ -61,6 +68,7 @@ export default function(data) {
   accepted.add(created ? 1 : 0);
   if (created) latency.add(response.timings.duration);
   limited.add(response.status === 429 ? 1 : 0);
+  if (response.status === 503) refusalLatency.add(response.timings.duration);
   check(response, { "created or explicitly rate limited": () => created || response.status === 429 });
   sleep(0.1);
 }

--- a/scripts/Run-LoadTest.ps1
+++ b/scripts/Run-LoadTest.ps1
@@ -1,0 +1,107 @@
+#requires -Version 5.1
+[CmdletBinding()]
+param(
+    [ValidateSet('baseline','slow-db','db-down','rabbit-down')][string]$Mode = 'baseline',
+    [ValidateRange(1, 20)][int]$Vus = 5,
+    [string]$Duration = '30s',
+    [switch]$KeepStack,
+    [switch]$PrepareOnly,
+    [switch]$NoBuild
+)
+$ErrorActionPreference = 'Stop'
+$root = Split-Path $PSScriptRoot -Parent
+Push-Location $root
+$fixture = Join-Path $root '.env.load-compose.json'
+$project = 'projecty-load'
+$exitCode = 1
+function Set-Field($Object, [string]$Name, $Value) {
+    $Object | Add-Member -NotePropertyName $Name -NotePropertyValue $Value -Force
+}
+function Compose {
+    & docker compose -p $project -f $fixture @args
+    if ($LASTEXITCODE) { throw "Benchmark Compose command failed ($LASTEXITCODE)." }
+}
+try {
+    if (-not (Test-Path '.env.load')) {
+        & "$PSScriptRoot/New-LocalSecrets.ps1" -OutputPath (Join-Path $root '.env.load') -RabbitMqDefinitionsPath (Join-Path $root '.env.load-rabbitmq.json')
+    }
+    New-Item -ItemType Directory -Force load/results | Out-Null
+    $json = docker compose --env-file .env.load -f docker-compose.yml -f docker-compose.chaos.yml config --format json
+    if ($LASTEXITCODE) { throw 'Benchmark model generation failed.' }
+    $model = $json | ConvertFrom-Json
+    $model.name = $project
+    foreach ($property in $model.services.PSObject.Properties) {
+        $service = $property.Value
+        $service.PSObject.Properties.Remove('container_name')
+        $service.PSObject.Properties.Remove('ports')
+        if ($service.build) {
+            Set-Field $service 'image' ("projecty-load/" + $property.Name.Replace('-migrations', '') + ':local')
+        }
+    }
+    foreach ($volume in $model.volumes.PSObject.Properties.Value) { $volume.PSObject.Properties.Remove('name') }
+    foreach ($network in $model.networks.PSObject.Properties.Value) { $network.PSObject.Properties.Remove('name') }
+    foreach ($mount in $model.services.rabbitmq.volumes) {
+        if ($mount.target -eq '/etc/rabbitmq/definitions.json') {
+            $mount.source = Join-Path $root '.env.load-rabbitmq.json'
+        }
+    }
+    $fixtureMount = @{type='bind';source=(Join-Path $root 'load/fixtures');target='/load';read_only=$true}
+    $model.services.mongodb.volumes += $fixtureMount
+    $model.services.'api-gateway'.build.target = 'final'
+    $model.services.'api-gateway'.healthcheck.test = @('CMD','/app/api-gateway','--healthcheck')
+    $model.services.'api-gateway'.environment.GATEWAY_JWKS_URL = 'http://load-identity:8080/jwks'
+    Set-Field $model.services.'api-gateway'.depends_on 'load-identity' @{condition='service_healthy'}
+    Set-Field $model.services 'load-identity' @{
+        image='node:24-alpine'; command=@('node','/load/identity.mjs'); networks=@('projecty')
+        volumes=@($fixtureMount)
+        healthcheck=@{test=@('CMD','node','-e','fetch("http://127.0.0.1:8080/health").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))');interval='2s';timeout='2s';retries=15}
+    }
+    foreach ($port in @(
+        @('api-gateway',8090,18090), @('toxiproxy',8474,18474),
+        @('grafana',3000,13000), @('prometheus',9090,19090))) {
+        Set-Field $model.services.($port[0]) 'ports' @(@{target=$port[1];published=[string]$port[2];host_ip='127.0.0.1';protocol='tcp'})
+    }
+    Set-Field $model.services 'k6-load' @{
+        image='grafana/k6:2.2.0'; user='0:0'; profiles=@('load'); networks=@('projecty')
+        command=@('run','--out','experimental-prometheus-rw','/scripts/rental-flow.js')
+        environment=@{
+            BASE_URL='http://api-gateway:8090'; IDENTITY_URL='http://load-identity:8080'
+            MODE=$Mode; VUS=[string]$Vus; DURATION=$Duration; SUMMARY_PATH="/results/$Mode.json"
+            K6_PROMETHEUS_RW_SERVER_URL='http://prometheus:9090/api/v1/write'
+            K6_PROMETHEUS_RW_TREND_STATS='p(95),p(99),min,max'
+        }
+        volumes=@(
+            @{type='bind';source=(Join-Path $root 'load/k6');target='/scripts';read_only=$true},
+            @{type='bind';source=(Join-Path $root 'load/results');target='/results'})
+    }
+    $model | ConvertTo-Json -Depth 100 | Set-Content -LiteralPath $fixture -Encoding utf8
+    [string[]]$build = if ($NoBuild) { @() } else { @('--build') }
+    Compose up @build -d --wait --wait-timeout 300 api-gateway grafana minio
+    # Only this generated project and its fresh, separately named volumes are touched.
+    Get-Content load/fixtures/seed-rider.sql -Raw | docker compose -p $project -f $fixture exec -T postgres sh -c 'exec psql -U "$POSTGRES_USER" -d "$RIDER_MANAGER_POSTGRES_DB" -v ON_ERROR_STOP=1'
+    if ($LASTEXITCODE) { throw 'Rider fixture failed.' }
+    Get-Content load/fixtures/seed-motorcycles.sql -Raw | docker compose -p $project -f $fixture exec -T postgres sh -c 'exec psql -U "$POSTGRES_USER" -d "$MOTO_HUB_POSTGRES_DB" -v ON_ERROR_STOP=1'
+    if ($LASTEXITCODE) { throw 'Motorcycle fixture failed.' }
+    Compose exec -T mongodb sh -c 'exec mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME" --password "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin /load/reset-rentals.js'
+    Compose exec -T redis redis-cli FLUSHDB
+    & "$PSScriptRoot/Invoke-Chaos.ps1" reset -Url 'http://127.0.0.1:18474'
+    if ($PrepareOnly) { $exitCode = 0; return }
+    $metadata = @{
+        measuredAt=[DateTime]::UtcNow.ToString('o'); commit=(git rev-parse HEAD)
+        docker=(docker info --format '{{.ServerVersion}}'); cpus=(docker info --format '{{.NCPU}}')
+        memoryBytes=(docker info --format '{{.MemTotal}}'); mode=$Mode; vus=$Vus; duration=$Duration
+    }
+    $metadata | ConvertTo-Json | Set-Content "load/results/$Mode-environment.json" -Encoding utf8
+    docker compose -p $project -f $fixture run --rm k6-load
+    $exitCode = $LASTEXITCODE
+} finally {
+    if (Test-Path -LiteralPath $fixture) {
+        if ($KeepStack -or $PrepareOnly) { Write-Host "Benchmark stack retained: $fixture (Grafana http://localhost:13000)." }
+        else {
+            docker compose -p $project -f $fixture down --volumes
+            Remove-Item -LiteralPath $fixture -Force
+        }
+    }
+    Pop-Location
+}
+exit $exitCode


### PR DESCRIPTION
﻿Refs #72. Parent epic #9; targets epic/9-demonstrable-fault-tolerance.

Adds an isolated Compose benchmark for real rental creation through the release gateway, seeded fixtures, test-only JWT issuer and k6 Prometheus remote-write. CI rejects successful creation p95 >=800 ms, p99 >=2 s, unexpected responses >=1%, or fewer than 100 creations. HTTP 429 is counted separately. A Grafana dashboard combines load and health metrics.

Measured 5 VUs / 30 seconds: baseline 179 creations, 1220 HTTP 429, zero unexpected responses, p95 37.78 ms / p99 87.16 ms. MongoDB +500 ms fails with 4.35% errors and p99 2533.04 ms (bug #160). MongoDB down fails; RabbitMQ down passes the current synchronous rental path, without claiming Kafka outbox validation.

Hardware, reproduction, raw summaries and revision caveats are published in README.md and docs/measurements/epic-9. Ephemeral-stack baseline passed CI. Dashboard provisioning and actual Prometheus metric names verified. Does not close prerequisite-dependent acceptance criteria or #160.
