### PR TITLE
fix(resilience): address retention, idempotency and load review findings

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -5,6 +5,7 @@ on:
       - 'docker-compose*.yml'
       - 'deploy/chaos/**'
       - 'scripts/*Chaos.ps1'
+      - 'scripts/Invoke-ChaosDrill.ps1'
       - 'scripts/chaos.sh'
       - '.github/workflows/chaos.yml'
   workflow_dispatch:

--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -12,6 +12,7 @@ on:
       - 'deploy/**'
       - 'load/**'
       - 'scripts/Run-LoadTest.ps1'
+      - 'scripts/Invoke-Chaos.ps1'
       - 'scripts/New-LocalSecrets.ps1'
       - '.github/workflows/load.yml'
   workflow_dispatch:
@@ -26,6 +27,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+      - name: Verify token refresh across long workloads
+        run: node --test load/tests/token-refresh.test.mjs
       - name: Build isolated stack and enforce rental thresholds
         shell: pwsh
         run: ./scripts/Run-LoadTest.ps1

--- a/RentalOperations/RentalOperations/Controllers/RentalController.cs
+++ b/RentalOperations/RentalOperations/Controllers/RentalController.cs
@@ -17,6 +17,10 @@ namespace RentalOperations.Controllers
         private ObjectResult Unavailable(Exception exception)
         {
             DependencyFailure.Record(exception);
+            if (exception is PreWriteDependencyException)
+            {
+                ProjectY.Shared.Idempotency.RedisIdempotencyMiddleware.AllowRetryBeforeSideEffects(HttpContext);
+            }
             Response.Headers.RetryAfter = "1";
             return StatusCode(StatusCodes.Status503ServiceUnavailable, new ProblemDetails
             {
@@ -168,15 +172,22 @@ namespace RentalOperations.Controllers
         [HttpPost("motorcycle-retirements/{licencePlate}")]
         public async Task<IActionResult> TryRetireMotorcycle(string licencePlate)
         {
-            var acquired = await _rentalService.TryRetireMotorcycleAsync(licencePlate);
-            return acquired
-                ? NoContent()
-                : Conflict(new ProblemDetails
-                {
-                    Status = StatusCodes.Status409Conflict,
-                    Title = "Active rental conflict",
-                    Detail = $"Motorcycle {licencePlate} has an active rental."
-                });
+            try
+            {
+                var acquired = await _rentalService.TryRetireMotorcycleAsync(licencePlate);
+                return acquired
+                    ? NoContent()
+                    : Conflict(new ProblemDetails
+                    {
+                        Status = StatusCodes.Status409Conflict,
+                        Title = "Active rental conflict",
+                        Detail = $"Motorcycle {licencePlate} has an active rental."
+                    });
+            }
+            catch (Exception ex) when (DependencyFailure.IsUnavailable(ex))
+            {
+                return Unavailable(ex);
+            }
         }
 
         [Authorize(Roles = "Admin")]
@@ -184,17 +195,24 @@ namespace RentalOperations.Controllers
         public async Task<IActionResult> TryReserveMotorcycleRename(
             [FromBody] MotorcycleRenameReservationDto request)
         {
-            var acquired = await _rentalService.TryReserveLicensePlateRenameAsync(
-                request.OldLicencePlate,
-                request.NewLicencePlate);
-            return acquired
-                ? NoContent()
-                : Conflict(new ProblemDetails
-                {
-                    Status = StatusCodes.Status409Conflict,
-                    Title = "Motorcycle claim conflict",
-                    Detail = $"Motorcycle {request.NewLicencePlate} is already claimed."
-                });
+            try
+            {
+                var acquired = await _rentalService.TryReserveLicensePlateRenameAsync(
+                    request.OldLicencePlate,
+                    request.NewLicencePlate);
+                return acquired
+                    ? NoContent()
+                    : Conflict(new ProblemDetails
+                    {
+                        Status = StatusCodes.Status409Conflict,
+                        Title = "Motorcycle claim conflict",
+                        Detail = $"Motorcycle {request.NewLicencePlate} is already claimed."
+                    });
+            }
+            catch (Exception ex) when (DependencyFailure.IsUnavailable(ex))
+            {
+                return Unavailable(ex);
+            }
         }
     }
 }

--- a/RentalOperations/RentalOperations/Services/DependencyFailure.cs
+++ b/RentalOperations/RentalOperations/Services/DependencyFailure.cs
@@ -22,7 +22,15 @@ public static class DependencyFailure
 
     public static void Record(Exception exception)
     {
-        var dependency = exception is MongoException ? "mongodb" : "upstream";
+        var dependency = "upstream";
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is MongoException)
+            {
+                dependency = "mongodb";
+                break;
+            }
+        }
         Refusals.Add(1, new KeyValuePair<string, object?>("dependency", dependency));
         Activity.Current?.SetTag("projecty.degradation", dependency);
         Activity.Current?.SetStatus(ActivityStatusCode.Error, "Dependency unavailable");

--- a/RentalOperations/RentalOperations/Services/PreWriteDependencyException.cs
+++ b/RentalOperations/RentalOperations/Services/PreWriteDependencyException.cs
@@ -1,0 +1,5 @@
+namespace RentalOperations.Services;
+
+// Only read-only preflight operations may use this signal; writes can have ambiguous outcomes.
+public sealed class PreWriteDependencyException(Exception innerException)
+    : Exception("Dependency failed before any side effect.", innerException);

--- a/RentalOperations/RentalOperations/Services/RentalService.cs
+++ b/RentalOperations/RentalOperations/Services/RentalService.cs
@@ -38,15 +38,15 @@ namespace RentalOperations.Services
                 throw new InvalidOperationException("The Rent time must at least one day");
             }
 
-            if (await _repository.HasOverlappingRentalAsync(
+            if (await BeforeWriteAsync(() => _repository.HasOverlappingRentalAsync(
                 createDto.MotocycleLicencePlate,
                 createDto.StartDate,
-                createDto.PredictedEndDate))
+                createDto.PredictedEndDate)))
             {
                 throw new ActiveRentalConflictException(createDto.MotocycleLicencePlate);
             }
 
-            var rider = await _riderManagerService.GetRiderByIdAsync(userId);
+            var rider = await BeforeWriteAsync(() => _riderManagerService.GetRiderByIdAsync(userId));
             if (rider == null)
             {
                 throw new ArgumentException("Rider does not exist.");
@@ -56,7 +56,7 @@ namespace RentalOperations.Services
                 throw new ArgumentException("Rider does not have the correct license type.");
             }
 
-            var motorcycle = await _motorcycleService.GetMotorcycleByIdAsync(createDto.MotocycleLicencePlate);
+            var motorcycle = await BeforeWriteAsync(() => _motorcycleService.GetMotorcycleByIdAsync(createDto.MotocycleLicencePlate));
             if (motorcycle == null)
             {
                 throw new ArgumentException("Motorcycle does not exist.");
@@ -98,7 +98,7 @@ namespace RentalOperations.Services
 
         public async Task<ResponseRentalDTO> CalculateFinalCostAsync(string rentalId, string userId, DateTime actualEndDate)
         {
-            var rental = await _repository.GetRentalByIdAsync(rentalId);
+            var rental = await BeforeWriteAsync(() => _repository.GetRentalByIdAsync(rentalId));
 
             if (rental == null)
                 throw new KeyNotFoundException($"No rental found with ID {rentalId}");
@@ -188,6 +188,15 @@ namespace RentalOperations.Services
             var result = await _repository.TryClaimRetirementAsync(
                 BrazilianLicensePlateAttribute.Normalize(licencePlate));
             return result is MotorcycleClaimResult.Acquired or MotorcycleClaimResult.Retired;
+        }
+
+        private static async Task<T> BeforeWriteAsync<T>(Func<Task<T>> read)
+        {
+            try { return await read(); }
+            catch (Exception ex) when (DependencyFailure.IsUnavailable(ex))
+            {
+                throw new PreWriteDependencyException(ex);
+            }
         }
 
         private decimal DetermineDailyRate(int days)

--- a/RentalOperations/RentalOperationsTests/Unit/DependencyFailureTests.cs
+++ b/RentalOperations/RentalOperationsTests/Unit/DependencyFailureTests.cs
@@ -51,6 +51,55 @@ public sealed class DependencyFailureTests
         Assert.True(DependencyFailure.IsUnavailable(error));
         Assert.True(timer.Elapsed < TimeSpan.FromSeconds(2.5), $"Driver took {timer.Elapsed}");
     }
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task AdminMutation_DependencyFailure_ReturnsSanitized503(bool rename, bool timeout)
+    {
+        var service = new Mock<IRentalService>();
+        Exception failure = timeout
+            ? new TimeoutException("private connection details")
+            : new MongoException("private connection details");
+        service.Setup(s => s.TryRetireMotorcycleAsync("OLD")).ThrowsAsync(failure);
+        service.Setup(s => s.TryReserveLicensePlateRenameAsync("OLD", "NEW")).ThrowsAsync(failure);
+        var controller = new RentalController(service.Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+        var result = rename
+            ? await controller.TryReserveMotorcycleRename(new MotorcycleRenameReservationDto { OldLicencePlate = "OLD", NewLicencePlate = "NEW" })
+            : await controller.TryRetireMotorcycle("OLD");
+        var response = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(503, response.StatusCode);
+        Assert.Equal("1", controller.Response.Headers.RetryAfter.ToString());
+        Assert.DoesNotContain("private", Assert.IsType<ProblemDetails>(response.Value).Detail);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task AdminMutation_PreservesSuccessAndConflict(bool rename, bool acquired)
+    {
+        var service = new Mock<IRentalService>();
+        service.Setup(s => s.TryRetireMotorcycleAsync("OLD")).ReturnsAsync(acquired);
+        service.Setup(s => s.TryReserveLicensePlateRenameAsync("OLD", "NEW")).ReturnsAsync(acquired);
+        var controller = new RentalController(service.Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+        var result = rename
+            ? await controller.TryReserveMotorcycleRename(new MotorcycleRenameReservationDto { OldLicencePlate = "OLD", NewLicencePlate = "NEW" })
+            : await controller.TryRetireMotorcycle("OLD");
+        if (acquired) Assert.IsType<NoContentResult>(result);
+        else Assert.IsType<ConflictObjectResult>(result);
+        Assert.False(controller.Response.Headers.ContainsKey("Retry-After"));
+    }
+
+
     private static RentalCreateDto Request() => new()
     {
         MotocycleLicencePlate = "ABC1D23",

--- a/RentalOperations/RentalOperationsTests/Unit/DependencyFailureTests.cs
+++ b/RentalOperations/RentalOperationsTests/Unit/DependencyFailureTests.cs
@@ -12,6 +12,35 @@ namespace RentalOperationsTests.Unit;
 
 public sealed class DependencyFailureTests
 {
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void WrappedMongoFailure_PreservesMetricAndTraceAttribution(bool wrapped)
+    {
+        using var activity = new System.Diagnostics.Activity("dependency-attribution-test").Start();
+        string? measuredDependency = null;
+        using var listener = new System.Diagnostics.Metrics.MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == "ProjectY.Resilience" && instrument.Name == "dependency.refusals")
+                meterListener.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+        {
+            if (System.Diagnostics.Activity.Current != activity) return;
+            foreach (var tag in tags)
+                if (tag.Key == "dependency") measuredDependency = tag.Value?.ToString();
+        });
+        listener.Start();
+        Exception failure = new MongoException("database unavailable");
+        if (wrapped) failure = new PreWriteDependencyException(new Exception("wrapper", failure));
+        DependencyFailure.Record(failure);
+        Assert.Equal("mongodb", measuredDependency);
+        Assert.Equal("mongodb", activity.GetTagItem("projecty.degradation"));
+        Assert.Equal(System.Diagnostics.ActivityStatusCode.Error, activity.Status);
+    }
+
+
     [Fact]
     public async Task DatabaseFailure_RefusesWith503AndRetryAfter_WithoutLeakingException()
     {

--- a/RentalOperations/RentalOperationsTests/Unit/Services/RentalServiceTests.cs
+++ b/RentalOperations/RentalOperationsTests/Unit/Services/RentalServiceTests.cs
@@ -11,6 +11,40 @@ namespace RentalOperationsTests.Unit.Services;
 
 public sealed class RentalServiceTests
 {
+    [Theory]
+    [InlineData("database")]
+    [InlineData("rider")]
+    [InlineData("motorcycle")]
+    [InlineData("claim")]
+    [InlineData("insert")]
+    public async Task CreateRental_OnlyPreflightFailuresPermitIdempotentRetry(string stage)
+    {
+        var failure = new TimeoutException("dependency timeout");
+        var repository = new Mock<IRentalRepository>();
+        repository.Setup(r => r.HasOverlappingRentalAsync(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>())).ReturnsAsync(false);
+        repository.Setup(r => r.TryClaimRentalAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(MotorcycleClaimResult.Acquired);
+        var riders = new Mock<IRiderManagerService>();
+        riders.Setup(r => r.GetRiderByIdAsync("rider")).ReturnsAsync(new Rider { UserId = "rider", CNHType = "A" });
+        var motorcycles = new Mock<IMotorcycleService>();
+        motorcycles.Setup(m => m.GetMotorcycleByIdAsync("ABC1D23")).ReturnsAsync(new Motorcycle { licensePlate = "ABC1D23" });
+        if (stage == "database") repository.Setup(r => r.HasOverlappingRentalAsync(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>())).ThrowsAsync(failure);
+        if (stage == "rider") riders.Setup(r => r.GetRiderByIdAsync("rider")).ThrowsAsync(failure);
+        if (stage == "motorcycle") motorcycles.Setup(m => m.GetMotorcycleByIdAsync("ABC1D23")).ThrowsAsync(failure);
+        if (stage == "claim") repository.Setup(r => r.TryClaimRentalAsync(It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(failure);
+        if (stage == "insert") repository.Setup(r => r.CreateRentalAsync(It.IsAny<RentalOperations.Model.Rental>())).ThrowsAsync(failure);
+        var service = new RentalService(repository.Object, Mock.Of<IMapper>(), riders.Object, motorcycles.Object);
+        var request = new RentalCreateDto { MotocycleLicencePlate = "ABC1D23",
+            StartDate = DateTime.UtcNow.AddDays(1), PredictedEndDate = DateTime.UtcNow.AddDays(8) };
+        var error = await Record.ExceptionAsync(() => service.CreateRentalAsync(request, "rider"));
+        if (stage is "claim" or "insert") Assert.Same(failure, error);
+        else
+        {
+            Assert.Same(failure, Assert.IsType<PreWriteDependencyException>(error).InnerException);
+            repository.Verify(r => r.TryClaimRentalAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            repository.Verify(r => r.CreateRentalAsync(It.IsAny<RentalOperations.Model.Rental>()), Times.Never);
+        }
+    }
+
     [Fact]
     public async Task CreateRental_WhenRetirementClaimWins_RejectsWithoutInsertingRental()
     {

--- a/RentalOperations/RentalOperationsTests/Unit/Services/RentalServiceTests.cs
+++ b/RentalOperations/RentalOperationsTests/Unit/Services/RentalServiceTests.cs
@@ -33,8 +33,12 @@ public sealed class RentalServiceTests
         if (stage == "claim") repository.Setup(r => r.TryClaimRentalAsync(It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(failure);
         if (stage == "insert") repository.Setup(r => r.CreateRentalAsync(It.IsAny<RentalOperations.Model.Rental>())).ThrowsAsync(failure);
         var service = new RentalService(repository.Object, Mock.Of<IMapper>(), riders.Object, motorcycles.Object);
-        var request = new RentalCreateDto { MotocycleLicencePlate = "ABC1D23",
-            StartDate = DateTime.UtcNow.AddDays(1), PredictedEndDate = DateTime.UtcNow.AddDays(8) };
+        var request = new RentalCreateDto
+        {
+            MotocycleLicencePlate = "ABC1D23",
+            StartDate = DateTime.UtcNow.AddDays(1),
+            PredictedEndDate = DateTime.UtcNow.AddDays(8)
+        };
         var error = await Record.ExceptionAsync(() => service.CreateRentalAsync(request, "rider"));
         if (stage is "claim" or "insert") Assert.Same(failure, error);
         else

--- a/RiderManager/RiderManager/Services/RabbitMQService/RiderInboxRetentionService.cs
+++ b/RiderManager/RiderManager/Services/RabbitMQService/RiderInboxRetentionService.cs
@@ -45,10 +45,23 @@ public sealed class RiderInboxRetentionService : BackgroundService
             .Where(message => message.ProcessedAtUtc < cutoff)
             .ExecuteDeleteAsync(cancellationToken);
         var imageCutoff = _timeProvider.GetUtcNow().UtcDateTime - _options.ImageRetentionPeriod;
-        var deletedParts = await context.InboxImageParts
-            .Where(part => context.InboxImageParts.Any(expired => expired.UserId == part.UserId
-                && expired.FileName == part.FileName && expired.ReceivedAtUtc < imageCutoff))
-            .ExecuteDeleteAsync(cancellationToken);
+        var expiredRiders = await context.InboxImageParts
+            .Where(part => part.ReceivedAtUtc < imageCutoff)
+            .Select(part => part.UserId).Distinct().ToListAsync(cancellationToken);
+        var deletedParts = 0;
+        foreach (var userId in expiredRiders)
+        {
+            await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+            // Match the handler lock, then re-evaluate expiry after any in-flight assembly commits.
+            await context.Database.ExecuteSqlInterpolatedAsync(
+                $"SELECT pg_advisory_xact_lock(hashtextextended({userId}, 0))", cancellationToken);
+            deletedParts += await context.InboxImageParts
+                .Where(part => part.UserId == userId && context.InboxImageParts.Any(expired =>
+                    expired.UserId == part.UserId && expired.FileName == part.FileName
+                    && expired.ReceivedAtUtc < imageCutoff))
+                .ExecuteDeleteAsync(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+        }
         return deletedMessages + deletedParts;
     }
 }

--- a/RiderManager/RiderManager/appsettings.json
+++ b/RiderManager/RiderManager/appsettings.json
@@ -23,7 +23,7 @@
   "Messaging": {
     "Inbox": {
       "RetentionPeriod": "7.00:00:00",
-      "SweepInterval": "01:00:00"
+      "SweepInterval": "00:15:00"
     }
   },
   "Logging": {

--- a/RiderManager/RiderManagerTests/Integration/PostgreSql/InboxProcessorTests.cs
+++ b/RiderManager/RiderManagerTests/Integration/PostgreSql/InboxProcessorTests.cs
@@ -248,8 +248,11 @@ public sealed class InboxProcessorTests : IAsyncLifetime
         await using var handlerContext = new ApplicationDbContext(_options);
         handlerContext.InboxImageParts.Add(new InboxImagePart
         {
-            UserId = rider, FileName = "race.png", SequenceNumber = 0,
-            Content = [1, 2], ReceivedAtUtc = DateTime.UtcNow.AddHours(-2)
+            UserId = rider,
+            FileName = "race.png",
+            SequenceNumber = 0,
+            Content = [1, 2],
+            ReceivedAtUtc = DateTime.UtcNow.AddHours(-2)
         });
         await handlerContext.SaveChangesAsync();
         await using var transaction = await handlerContext.Database.BeginTransactionAsync();

--- a/RiderManager/RiderManagerTests/Integration/PostgreSql/InboxProcessorTests.cs
+++ b/RiderManager/RiderManagerTests/Integration/PostgreSql/InboxProcessorTests.cs
@@ -240,6 +240,51 @@ public sealed class InboxProcessorTests : IAsyncLifetime
         Assert.Equal("recent", (await verification.InboxImageParts.SingleAsync()).UserId);
     }
 
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task RetentionSweep_WaitsForHandlerLock_AndRechecksExpiry()
+    {
+        const string rider = "retention-race";
+        await using var handlerContext = new ApplicationDbContext(_options);
+        handlerContext.InboxImageParts.Add(new InboxImagePart
+        {
+            UserId = rider, FileName = "race.png", SequenceNumber = 0,
+            Content = [1, 2], ReceivedAtUtc = DateTime.UtcNow.AddHours(-2)
+        });
+        await handlerContext.SaveChangesAsync();
+        await using var transaction = await handlerContext.Database.BeginTransactionAsync();
+        await handlerContext.Database.ExecuteSqlInterpolatedAsync(
+            $"SELECT pg_advisory_xact_lock(hashtextextended({rider}, 0))");
+        using var services = new ServiceCollection()
+            .AddDbContext<ApplicationDbContext>(options => options.UseNpgsql(_database.GetConnectionString()))
+            .BuildServiceProvider();
+        var retention = new RiderInboxRetentionService(services.GetRequiredService<IServiceScopeFactory>(),
+            new RiderInboxRetentionOptions(), TimeProvider.System);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var sweep = retention.DeleteExpiredAsync(timeout.Token);
+        try
+        {
+            var waiting = false;
+            while (!waiting && !sweep.IsCompleted)
+            {
+                waiting = await handlerContext.Database.SqlQueryRaw<bool>(
+                    """SELECT EXISTS(SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND NOT granted) AS "Value" """)
+                    .SingleAsync(timeout.Token);
+                if (!waiting) await Task.Delay(10, timeout.Token);
+            }
+            Assert.True(waiting, "Retention must acquire the handler lock before deleting.");
+            await handlerContext.InboxImageParts.Where(p => p.UserId == rider)
+                .ExecuteUpdateAsync(setters => setters.SetProperty(p => p.ReceivedAtUtc, DateTime.UtcNow));
+        }
+        finally
+        {
+            await transaction.CommitAsync();
+        }
+        Assert.Equal(0, await sweep);
+        await using var verification = new ApplicationDbContext(_options);
+        Assert.Equal(new byte[] { 1, 2 }, (await verification.InboxImageParts.SingleAsync()).Content);
+    }
+
     private async Task<bool> ProcessRegistrationAsync(string messageId, string email)
     {
         await using var context = new ApplicationDbContext(_options);

--- a/RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs
+++ b/RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs
@@ -182,6 +182,42 @@ public sealed class IdempotencyMiddlewareTests : IAsyncLifetime
         Assert.Equal(StatusCodes.Status422UnprocessableEntity, mismatch.Response.StatusCode);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    [Trait("Category", "Integration")]
+    public async Task Dependency503_OnlyReleasesExplicitPreWriteFailures(bool beforeWrite)
+    {
+        var attempts = 0;
+        var effects = 0;
+        var middleware = CreateMiddleware(async context =>
+        {
+            attempts++;
+            if (attempts == 1)
+            {
+                if (beforeWrite) RedisIdempotencyMiddleware.AllowRetryBeforeSideEffects(context);
+                else effects++;
+                context.Response.StatusCode = 503;
+                context.Response.Headers.RetryAfter = "1";
+                await context.Response.WriteAsync("dependency unavailable");
+                return;
+            }
+            effects++;
+            context.Response.StatusCode = 201;
+            await context.Response.WriteAsync("created");
+        });
+        var key = Guid.NewGuid().ToString("N");
+        var first = await ExecuteAsync(middleware, key, "{}");
+        var retry = await ExecuteAsync(middleware, key, "{}");
+        var replay = await ExecuteAsync(middleware, key, "{}");
+        Assert.Equal(503, first.Response.StatusCode);
+        Assert.Equal("1", first.Response.Headers.RetryAfter.ToString());
+        Assert.Equal(beforeWrite ? 201 : 503, retry.Response.StatusCode);
+        Assert.Equal(beforeWrite ? 2 : 1, attempts);
+        Assert.Equal(1, effects);
+        Assert.Equal("true", replay.Response.Headers["Idempotency-Replayed"].ToString());
+    }
+
     private RedisIdempotencyMiddleware CreateMiddleware(RequestDelegate next)
         => new(
             next,

--- a/Shared/Idempotency/RedisIdempotencyMiddleware.cs
+++ b/Shared/Idempotency/RedisIdempotencyMiddleware.cs
@@ -12,6 +12,18 @@ namespace ProjectY.Shared.Idempotency;
 
 public sealed class RedisIdempotencyMiddleware
 {
+    private static readonly object RetryBeforeSideEffects = new();
+
+    // Server-side signal only: callers must establish that no write has been attempted.
+    public static void AllowRetryBeforeSideEffects(HttpContext context)
+        => context.Items[RetryBeforeSideEffects] = true;
+
+    private const string ReleaseScript = """
+        if redis.call('GET', KEYS[1]) == ARGV[1] then
+            return redis.call('DEL', KEYS[1])
+        end
+        return 0
+        """;
     private const string PendingState = "pending";
     private const string CompletedState = "completed";
     private const string UnknownState = "unknown";
@@ -169,6 +181,25 @@ public sealed class RedisIdempotencyMiddleware
             throw new IdempotencyOutcomeUnknownException(
                 "The endpoint failed after execution began, so its outcome is unknown.",
                 exception);
+        }
+
+        if (context.Response.StatusCode == StatusCodes.Status503ServiceUnavailable
+            && context.Items.TryGetValue(RetryBeforeSideEffects, out var retry) && retry is true)
+        {
+            context.Response.Body = originalBody;
+            try
+            {
+                var released = (long)await database.ScriptEvaluateAsync(ReleaseScript, [redisKey], [pendingJson]);
+                if (released != 1)
+                    throw new IdempotencyOutcomeUnknownException("The retryable idempotency claim was lost.");
+            }
+            catch (Exception exception) when (exception is RedisException or TimeoutException)
+            {
+                throw new IdempotencyOutcomeUnknownException("The retryable idempotency claim could not be released.", exception);
+            }
+            responseBuffer.Position = 0;
+            await responseBuffer.CopyToAsync(originalBody, context.RequestAborted);
+            return;
         }
 
         var completed = new IdempotencyRecord

--- a/docs/degradation-contract.md
+++ b/docs/degradation-contract.md
@@ -23,6 +23,7 @@ Prometheus name is `dependency_refusals_total`. A 503 trace carries
 to the caller. Individual driver waits are bounded; the gateway's request timeout
 is the overall public deadline, including retries. A timeout is a refusal, never
 proof that a mutation did not commit: retain the same idempotency key when retrying.
+Read-only preflight failures explicitly release the owned idempotency claim, so recovery can execute the same request. Failures during claim or mutation retain their recorded outcome; they are not automatically repeated. This contract also covers admin retirement and rename reservation refusals.
 
 Reproduce the current failure contracts:
 

--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -63,3 +63,5 @@ from the RabbitMQ scenario; its target acceptance criteria remain open.
 The `ProjectY — load and resilience` dashboard overlays the k6 percentiles,
 creation/rejection rates, error rate, service health, gateway breaker state and
 durable DLQ depth. k6 remote-writes into the same Prometheus as the application.
+
+Each VU renews its short-lived fixture token 30 seconds before expiry, including time spent in setup. Long workloads therefore keep exercising the rental path after the initial five-minute token expires.

--- a/load/fixtures/identity.mjs
+++ b/load/fixtures/identity.mjs
@@ -12,7 +12,7 @@ http.createServer((request, response) => {
     const body = encode({ alg: "EdDSA", kid: key.kid, typ: "JWT" }) + "." +
       encode({ iss: "projecty.identity", aud: "projecty.rental-operations", sub: "load-rider",
         roles: ["Rider"], iat: now, exp: now + 300, jti: randomUUID() });
-    return response.end(JSON.stringify({ token: body + "." + sign(null, Buffer.from(body), privateKey).toString("base64url") }));
+    return response.end(JSON.stringify({ expiresAt: now + 300, token: body + "." + sign(null, Buffer.from(body), privateKey).toString("base64url") }));
   }
   response.statusCode = request.url === "/health" ? 200 : 404;
   response.end("{}");

--- a/load/k6/rental-flow.js
+++ b/load/k6/rental-flow.js
@@ -33,10 +33,19 @@ function create(token, plate, key, name) {
   });
 }
 
-export function setup() {
+let vuCredentials;
+function fetchCredentials() {
   const response = http.get((__ENV.IDENTITY_URL || "http://load-identity:8080") + "/token", { tags: { name: "fixture-token" } });
   if (response.status !== 200) fail("Test identity fixture unavailable");
-  const token = response.json("token");
+  const credentials = response.json();
+  if (!credentials.token || !Number.isFinite(credentials.expiresAt) || credentials.expiresAt * 1000 <= Date.now() + 30000)
+    fail("Test identity fixture returned invalid or expiring credentials");
+  return credentials;
+}
+
+export function setup() {
+  const credentials = fetchCredentials();
+  const token = credentials.token;
   const run = Date.now().toString();
   const readyUntil = Date.now() + 40000;
   let warmup;
@@ -56,13 +65,16 @@ export function setup() {
       { headers: { "Content-Type": "application/json" }, tags: { name: "chaos-injection" } });
     if (injection.status !== 200) fail("Could not inject benchmark fault: " + injection.status);
   }
-  return { token, run };
+  return { credentials, run };
 }
 
 export default function(data) {
   const index = execution.scenario.iterationInTest;
   if (index >= 9999) fail("Fixture capacity exceeded; increase the seeded range before increasing the workload");
-  const response = create(data.token, "KAA" + String(index).padStart(4, "0"),
+  // Each VU retains renewed credentials; setup time is included in the expiry check.
+  if (!vuCredentials) vuCredentials = data.credentials;
+  if (Date.now() >= vuCredentials.expiresAt * 1000 - 30000) vuCredentials = fetchCredentials();
+  const response = create(vuCredentials.token, "KAA" + String(index).padStart(4, "0"),
     data.run + "-" + index, "rental-create");
   const created = response.status === 200 || response.status === 201;
   accepted.add(created ? 1 : 0);

--- a/load/tests/token-refresh.test.mjs
+++ b/load/tests/token-refresh.test.mjs
@@ -1,0 +1,63 @@
+﻿import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+
+// Exercise the actual k6 lifecycle with a controllable clock and HTTP boundary.
+function harness() {
+  let now = 1000000, issued = 0;
+  const requests = [];
+  let fixtureStatus = 200;
+  const sandbox = {
+    __ENV: {}, Date: { now: () => now },
+    Counter: class { add() {} }, Trend: class { add() {} },
+    execution: { scenario: { iterationInTest: 0 } },
+    check: () => true, sleep: () => {}, fail: message => { throw new Error(message); },
+    http: {
+      expectedStatuses: () => ({}),
+      get: () => ({ status: fixtureStatus, json: () => ({ token: "token-" + ++issued, expiresAt: now / 1000 + 300 }) }),
+      post: (url, body, options) => {
+        requests.push({ token: options.headers.Authorization, name: options.tags.name });
+        return { status: 201, timings: { duration: 1 } };
+      },
+    },
+  };
+  const source = readFileSync(new URL("../k6/rental-flow.js", import.meta.url), "utf8")
+    .replace(/^import .*;\r?$/gm, "")
+    .replace("export default function(data)", "function iteration(data)")
+    .replace(/export /g, "");
+  vm.createContext(sandbox);
+  vm.runInContext(source + "\nglobalThis.lifecycle = {setup, iteration};", sandbox);
+  return { lifecycle: sandbox.lifecycle, requests, issued: () => issued,
+    advance: ms => { now += ms; }, breakFixture: () => { fixtureStatus = 503; } };
+}
+
+test("renews before expiry, accounts for warmup time and retains refreshed token", () => {
+  const h = harness(), data = h.lifecycle.setup();
+  h.advance(40000);
+  h.lifecycle.iteration(data);
+  assert.equal(h.issued(), 1);
+  h.advance(229999);
+  h.lifecycle.iteration(data);
+  assert.equal(h.issued(), 1);
+  h.advance(1);
+  h.lifecycle.iteration(data);
+  assert.equal(h.requests.at(-1).token, "Bearer token-2");
+  h.advance(40000); // Workload is now beyond the original five-minute token lifetime.
+  h.lifecycle.iteration(data);
+  assert.equal(h.issued(), 2);
+  assert.equal(h.requests.at(-1).token, "Bearer token-2");
+  h.advance(230000);
+  h.lifecycle.iteration(data);
+  assert.equal(h.requests.at(-1).token, "Bearer token-3");
+});
+
+test("failed refresh stops the iteration instead of sending an expired token", () => {
+  const h = harness(), data = h.lifecycle.setup();
+  h.advance(300000);
+  h.breakFixture();
+  const count = h.requests.length;
+  assert.throws(() => h.lifecycle.iteration(data), /fixture unavailable/);
+  assert.equal(h.requests.length, count);
+});
+


### PR DESCRIPTION
Refs #68, #70, #71, #72. Parent epic #9 / #155; targets epic/9-demonstrable-fault-tolerance.

Addresses all distinct review findings on #155–#159:
- Wrapped MongoDB failures retain mongodb attribution in both metrics and traces.
- Admin retirement and rename reservation now use sanitized 503, Retry-After and refusal telemetry.
- Explicit read-only rental preflight failures release the owned Redis idempotency claim atomically, so the same key can succeed after recovery. Claim/insert failures remain protected against repeating ambiguous effects.
- Image retention acquires the same per-rider transaction lock as assembly and rechecks expiry after waiting. Deployed configuration now uses the documented 15-minute sweep.
- Chaos CI watches Invoke-ChaosDrill.ps1; load CI watches Invoke-Chaos.ps1.
- Each k6 VU renews its five-minute fixture token 30 seconds before expiry, accounting for setup time and retaining renewed credentials.

Validation: 22 focused rental service/controller tests, 15 real PostgreSQL/Redis integration tests and two clock-controlled tests of the actual k6 lifecycle passed. Tests distinguish preflight from claim/insert failures, preserve 204/409 admin responses, observe the real PostgreSQL lock wait, and prove recovery with the same idempotency key without repeating uncertain writes. CI also runs the token regressions before the real ephemeral-stack load gate.

Existing measurements remain historical; this does not close the slow-db bug #160 or prerequisite-dependent criteria.