### PR TITLE
fix(polyglot): correct legacy rollout, deleted documents and tracking lifetime

### DIFF
--- a/.github/workflows/telemetry.yml
+++ b/.github/workflows/telemetry.yml
@@ -5,6 +5,11 @@ permissions: {contents: read}
 jobs:
   telemetry:
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:8-alpine
+        ports: ['6379:6379']
+        options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
     steps:
       - uses: actions/checkout@v6
       - uses: erlef/setup-beam@v1

--- a/RentalOperations/RentalOperations/Model/RentalEventEnvelope.cs
+++ b/RentalOperations/RentalOperations/Model/RentalEventEnvelope.cs
@@ -11,16 +11,19 @@ public sealed class RentalEventEnvelope
     public byte[] Payload { get; set; } = [];
     public string? TraceParent { get; set; }
 
-    public static RentalEventEnvelope Create(Rental rental, string topic)
+    public static string PartitionKey(Rental rental) => string.IsNullOrEmpty(rental.MotorcycleId)
+        ? $"legacy-rental:{rental._id}" : rental.MotorcycleId;
+
+    public static RentalEventEnvelope Create(Rental rental, string topic, DateTime? occurredAt = null)
     {
         var id = $"{rental._id}:{topic}:v1";
-        var time = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var time = new DateTimeOffset(occurredAt ?? DateTime.UtcNow).ToUnixTimeMilliseconds();
         var message = new RentalEvent
         {
             EventId = id,
             RentalId = rental._id!.Value.ToString(),
             RiderId = rental.UserId,
-            MotorcycleId = rental.MotorcycleId,
+            MotorcycleId = PartitionKey(rental),
             OccurredAtMs = time,
             PlanDays = (rental.PredictedEndDate - rental.StartDate).Days,
             StartedAtMs = new DateTimeOffset(rental.StartDate.ToUniversalTime()).ToUnixTimeMilliseconds(),

--- a/RentalOperations/RentalOperations/Repository/RentalRepository.cs
+++ b/RentalOperations/RentalOperations/Repository/RentalRepository.cs
@@ -105,10 +105,21 @@ namespace RentalOperations.Repository
 
         public async Task UpdateRentalAsync(Rental rental)
         {
-            if (rental.Status == RentalStatus.Completed &&
-                !rental.PendingEvents.Any(e => e.Topic == "rental.closed"))
-                rental.PendingEvents.Add(RentalEventEnvelope.Create(rental, "rental.closed"));
-            await _rentals.ReplaceOneAsync(r => r._id == rental._id, rental);
+            // Patch settlement fields: replacing a stale snapshot can erase a
+            // concurrent backfill or restore envelopes acknowledged by the relay.
+            var update = Builders<Rental>.Update
+                .Set(r => r.EndDate, rental.EndDate)
+                .Set(r => r.FinalCost, rental.FinalCost)
+                .Set(r => r.AdditionalCostsOrSavings, rental.AdditionalCostsOrSavings)
+                .Set(r => r.StatusMessage, rental.StatusMessage)
+                .Set(r => r.Status, rental.Status);
+            var filter = Builders<Rental>.Filter.Eq(r => r._id, rental._id);
+            if (rental.Status == RentalStatus.Completed)
+            {
+                filter &= Builders<Rental>.Filter.Ne(r => r.Status, RentalStatus.Completed);
+                update = update.Push(r => r.PendingEvents, RentalEventEnvelope.Create(rental, "rental.closed"));
+            }
+            await _rentals.UpdateOneAsync(filter, update);
         }
 
         public async Task DeleteRentalAsync(string id)

--- a/RentalOperations/RentalOperations/Services/RentalKafkaRelay.cs
+++ b/RentalOperations/RentalOperations/Services/RentalKafkaRelay.cs
@@ -29,6 +29,7 @@ public sealed class RentalKafkaRelay(MongoDbContext context, IConfiguration conf
         {
             try
             {
+                await BackfillActiveRentalsAsync(rentals, stoppingToken);
                 var batch = await rentals.Find(pending).Limit(100).ToListAsync(stoppingToken);
                 foreach (var rental in batch)
                     foreach (var item in rental.PendingEvents)
@@ -42,7 +43,7 @@ public sealed class RentalKafkaRelay(MongoDbContext context, IConfiguration conf
                             headers.Add("traceparent", Encoding.UTF8.GetBytes(trace));
                         await producer.ProduceAsync(item.Topic, new Message<string, byte[]>
                         {
-                            Key = rental.MotorcycleId,
+                            Key = RentalEventEnvelope.PartitionKey(rental),
                             Value = item.Payload,
                             Headers = headers
                         }, stoppingToken);
@@ -56,6 +57,23 @@ public sealed class RentalKafkaRelay(MongoDbContext context, IConfiguration conf
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { break; }
             catch (Exception error) { log.LogWarning(error, "Kafka relay delayed; rental events retained"); }
             await Task.Delay(TimeSpan.FromSeconds(2), stoppingToken);
+        }
+    }
+
+    public static async Task BackfillActiveRentalsAsync(IMongoCollection<Rental> rentals,
+        CancellationToken cancellationToken = default)
+    {
+        // The legacy schema has no PendingEvents field. An empty persisted array
+        // means the start was already enqueued/acknowledged and must not be replayed.
+        var legacy = Builders<Rental>.Filter.Exists(r => r.PendingEvents, false) &
+                     Builders<Rental>.Filter.Eq(r => r.Status, RentalStatus.Active);
+        var batch = await rentals.Find(legacy).Limit(100).ToListAsync(cancellationToken);
+        foreach (var rental in batch)
+        {
+            var start = RentalEventEnvelope.Create(rental, "rental.started", rental._id!.Value.CreationTime);
+            await rentals.UpdateOneAsync(legacy & Builders<Rental>.Filter.Eq(r => r._id, rental._id),
+                Builders<Rental>.Update.Set(r => r.PendingEvents, new List<RentalEventEnvelope> { start }),
+                cancellationToken: cancellationToken);
         }
     }
 }

--- a/RentalOperations/RentalOperationsTests/Integration/MongoDb/RentalEventTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/MongoDb/RentalEventTests.cs
@@ -23,8 +23,10 @@ public sealed class RentalEventTests : IAsyncLifetime
         var raw = context.Database.GetCollection<BsonDocument>("Rentals");
         var rental = new Rental
         {
-            MotorcycleLicencePlate = "OLD1234", UserId = "legacy-rider",
-            StartDate = DateTime.UtcNow.AddDays(-2), PredictedEndDate = DateTime.UtcNow.AddDays(5)
+            MotorcycleLicencePlate = "OLD1234",
+            UserId = "legacy-rider",
+            StartDate = DateTime.UtcNow.AddDays(-2),
+            PredictedEndDate = DateTime.UtcNow.AddDays(5)
         };
         var document = rental.ToBsonDocument();
         document.Remove("PendingEvents");

--- a/RentalOperations/RentalOperationsTests/Integration/MongoDb/RentalEventTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/MongoDb/RentalEventTests.cs
@@ -1,8 +1,10 @@
 using MongoDB.Driver;
+using MongoDB.Bson;
 using ProjectY.Events;
 using RentalOperations.Data;
 using RentalOperations.Model;
 using RentalOperations.Repository;
+using RentalOperations.Services;
 using Testcontainers.MongoDb;
 
 namespace RentalOperationsTests.Integration.MongoDb;
@@ -12,6 +14,55 @@ public sealed class RentalEventTests : IAsyncLifetime
     private readonly MongoDbContainer database = new MongoDbBuilder("mongo:8.0").Build();
     public Task InitializeAsync() => database.StartAsync();
     public Task DisposeAsync() => database.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task LegacyBackfillIsStableAcrossReplicasAcknowledgementAndConcurrentClose()
+    {
+        var context = new MongoDbContext(database.GetConnectionString(), "legacy_events");
+        var rentals = context.Database.GetCollection<Rental>("Rentals");
+        var raw = context.Database.GetCollection<BsonDocument>("Rentals");
+        var rental = new Rental
+        {
+            MotorcycleLicencePlate = "OLD1234", UserId = "legacy-rider",
+            StartDate = DateTime.UtcNow.AddDays(-2), PredictedEndDate = DateTime.UtcNow.AddDays(5)
+        };
+        var document = rental.ToBsonDocument();
+        document.Remove("PendingEvents");
+        document.Remove("MotorcycleId");
+        await raw.InsertOneAsync(document);
+        var repository = new RentalRepository(context);
+        var stale = await repository.GetRentalByIdAsync(rental._id!.Value.ToString());
+        await Task.WhenAll(Enumerable.Range(0, 3).Select(_ => RentalKafkaRelay.BackfillActiveRentalsAsync(rentals)));
+        var saved = await repository.GetRentalByIdAsync(rental._id.Value.ToString());
+        var start = Assert.Single(saved.PendingEvents);
+        var payload = RentalEvent.Parser.ParseFrom(start.Payload);
+        Assert.Equal($"{rental._id}:rental.started:v1", payload.EventId);
+        Assert.Equal("legacy-rider", payload.RiderId);
+        Assert.Equal($"legacy-rental:{rental._id}", payload.MotorcycleId);
+        Assert.Equal(new DateTimeOffset(rental._id.Value.CreationTime).ToUnixTimeMilliseconds(), payload.OccurredAtMs);
+        stale.Status = RentalStatus.Completed;
+        stale.EndDate = DateTime.UtcNow;
+        await repository.UpdateRentalAsync(stale);
+        saved = await repository.GetRentalByIdAsync(rental._id.Value.ToString());
+        Assert.Equal(2, saved.PendingEvents.Count);
+        await rentals.UpdateOneAsync(r => r._id == rental._id,
+            Builders<Rental>.Update.PullFilter(r => r.PendingEvents, e => e.Id == start.Id));
+        await repository.UpdateRentalAsync(stale);
+        await RentalKafkaRelay.BackfillActiveRentalsAsync(rentals);
+        saved = await repository.GetRentalByIdAsync(rental._id.Value.ToString());
+        Assert.Equal("rental.closed", Assert.Single(saved.PendingEvents).Topic);
+
+        // An acknowledged active rental is not a legacy document.
+        var active = new Rental { MotorcycleLicencePlate = "NEW1234", UserId = "new-rider" };
+        await rentals.InsertOneAsync(active);
+        await RentalKafkaRelay.BackfillActiveRentalsAsync(rentals);
+        Assert.Empty((await repository.GetRentalByIdAsync(active._id!.Value.ToString())).PendingEvents);
+        document["_id"] = ObjectId.GenerateNewId();
+        document["status"] = "Completed";
+        await raw.InsertOneAsync(document);
+        await RentalKafkaRelay.BackfillActiveRentalsAsync(rentals);
+        Assert.False((await raw.Find(new BsonDocument("_id", document["_id"])).SingleAsync()).Contains("PendingEvents"));
+    }
 
     [Fact]
     public async Task RentalAndPendingEventsAreOneDocument_AndAcknowledgingStartPreservesClose()

--- a/docs/runbooks/polyglot-services.md
+++ b/docs/runbooks/polyglot-services.md
@@ -70,6 +70,9 @@ requires; temporary compiler dependencies are removed after installation.
 * Rust: `cargo test --manifest-path services/media-guard/Cargo.toml --locked`;
   `cargo clippy --manifest-path services/media-guard/Cargo.toml --locked --all-targets -- -D warnings`.
 * Elixir: `mix format --check-formatted` and `mix test` in services/telemetry.
+  The lifetime regression uses Redis at `TEST_REDIS_URL` (default localhost:6379);
+  CI provides an isolated Redis service. It exercises a real rental process,
+  accepted/rejected positions and stale/current timeout delivery.
 * Python: build services/risk-pricing/Dockerfile from the repo root, then run
   its image with `--entrypoint pytest -q -p no:cacheprovider`. This invokes real
   Tesseract on a generated PNG as well as restart/idempotency tests.
@@ -86,6 +89,30 @@ primary key is ((rider_id, day), recorded_at), with server timestamps and 90-day
 TTL. Query the actual rider/day after the probe to verify stored rows and TTL.
 
 ## Failure expectations
+
+On rollout, the rental Kafka relay reconciles active legacy Mongo documents in
+batches of 100. A missing `PendingEvents` field identifies the old schema; an
+empty persisted array already belongs to the outbox schema and is not replayed.
+The relay atomically adds a stable `rental.started` envelope only while the
+document remains active and uninitialized. Its occurrence time is the original
+Mongo ObjectId creation time, so a delayed backfill cannot reopen a closed rental
+in consumers. Legacy records lack an immutable motorcycle ID: their start/close
+events use the stable `legacy-rental:<id>` key, independent of licence plate
+renames. New rentals continue to use their real motorcycle ID. Settlement updates
+preserve concurrent outbox writes and acknowledgements. No SQL migration or
+manual database rewrite is needed; tracking becomes available after Kafka catches up.
+
+Replacing or deleting a document may remove its object before a delayed
+`document.stored` event arrives. Only S3 `NoSuchKey` is consumed as failed
+verification; the inbox and output events commit normally and newer verification
+facts win by timestamp. Access failures, missing buckets, timeouts and server
+errors still retry. This keeps deleted private documents from blocking unrelated
+riders without treating an unavailable storage service as an OCR result.
+
+The telemetry rental process expires after 24 hours without an accepted position.
+Each accepted position renews the timer; rejected writes do not. A timeout already
+queued for a previous timer is ignored, so continuously tracked multi-day rentals
+remain connected.
 
 | Stop/unavailable dependency | Observable behavior |
 | --- | --- |

--- a/services/risk-pricing/test_policy.py
+++ b/services/risk-pricing/test_policy.py
@@ -2,6 +2,48 @@ from policy import verify_number, pricing, score
 from state import State
 from rider_pb2 import RiderEvent
 from rental_pb2 import RentalEvent
+import pytest
+
+
+def test_deleted_document_does_not_block_replacement_or_other_riders(monkeypatch, tmp_path):
+    import worker
+    from botocore.exceptions import ClientError
+
+    class Storage:
+        def get_object(self, **kwargs):
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+
+    monkeypatch.setenv("S3_ENDPOINT", "http://storage")
+    monkeypatch.setenv("S3_BUCKET", "test")
+    monkeypatch.setattr(worker.boto3, "client", lambda *args, **kwargs: Storage())
+    state = State(str(tmp_path / "deleted.db"))
+    old = RiderEvent(event_id="deleted", rider_id="r1", occurred_at_ms=100,
+                     object_key="riders/r1/old.png")
+    assert state.apply("document.stored", old, 101, worker.ocr(old))
+    replacement = RiderEvent(event_id="replacement", rider_id="r1", occurred_at_ms=200)
+    assert state.apply("document.stored", replacement, 201, True)
+    other = RiderEvent(event_id="other", rider_id="r2", occurred_at_ms=200)
+    assert state.apply("document.stored", other, 202, True)
+    assert not state.apply("document.stored", old, 203, worker.ocr(old))
+    assert state.db.execute("SELECT verified FROM riders ORDER BY id").fetchall() == [(1,), (1,)]
+    assert state.db.execute("SELECT COUNT(*) FROM inbox").fetchone()[0] == 3
+    state.db.close()
+
+
+@pytest.mark.parametrize("code", ["AccessDenied", "NoSuchBucket", "InternalError", "SlowDown"])
+def test_storage_faults_remain_retryable(monkeypatch, code):
+    import worker
+    from botocore.exceptions import ClientError
+
+    class Storage:
+        def get_object(self, **kwargs):
+            raise ClientError({"Error": {"Code": code}}, "GetObject")
+
+    monkeypatch.setenv("S3_ENDPOINT", "http://storage")
+    monkeypatch.setenv("S3_BUCKET", "test")
+    monkeypatch.setattr(worker.boto3, "client", lambda *args, **kwargs: Storage())
+    with pytest.raises(ClientError):
+        worker.ocr(RiderEvent(object_key="riders/r1/document.png"))
 
 def test_real_tesseract_on_sanitized_document(monkeypatch):
     import io

--- a/services/risk-pricing/worker.py
+++ b/services/risk-pricing/worker.py
@@ -5,6 +5,7 @@ import time
 from concurrent.futures import Future
 import boto3
 from botocore.config import Config
+from botocore.exceptions import ClientError
 from confluent_kafka import Consumer, Producer, TopicPartition
 from PIL import Image
 import pytesseract
@@ -22,7 +23,15 @@ def ocr(event):
         raise ValueError("document must reference a sanitized object")
     s3 = boto3.client("s3", endpoint_url=os.environ["S3_ENDPOINT"],
                       config=Config(connect_timeout=2, read_timeout=5, retries={"max_attempts":1}))
-    result = s3.get_object(Bucket=os.environ["S3_BUCKET"], Key=event.object_key)
+    try:
+        result = s3.get_object(Bucket=os.environ["S3_BUCKET"], Key=event.object_key)
+    except ClientError as error:
+        if error.response.get("Error", {}).get("Code") != "NoSuchKey":
+            raise
+        # Replacements/deletions remove private objects before delayed events
+        # arrive. Consume these as unverified; newer facts still win by timestamp.
+        log.info("document no longer available; verification failed closed")
+        return False
     with result["Body"] as stream:
         content = stream.read(64*1024*1024+1)
     if len(content)>64*1024*1024:

--- a/services/telemetry/lib/rental.ex
+++ b/services/telemetry/lib/rental.ex
@@ -34,11 +34,19 @@ defmodule ProjectYTelemetry.Rental do
   def position(id, payload), do: GenServer.call(via(id), {:position, payload})
 
   def init({id, rider}) do
-    Process.send_after(self(), :idle, @max_age)
-    {:ok, %{id: id, rider: rider, last: Store.last(id), accepted_at: 0}}
+    state = %{id: id, rider: rider, last: Store.last(id), accepted_at: 0, idle_timer: nil}
+    {:ok, refresh_idle(state)}
   end
 
-  def handle_info(:idle, state), do: {:stop, :normal, state}
+  defp refresh_idle(state) do
+    if state.idle_timer, do: Process.cancel_timer(state.idle_timer)
+    %{state | idle_timer: :erlang.start_timer(@max_age, self(), :idle)}
+  end
+
+  def handle_info({:timeout, ref, :idle}, %{idle_timer: ref} = state),
+    do: {:stop, :normal, state}
+
+  def handle_info({:timeout, _, :idle}, state), do: {:noreply, state}
   def handle_call(:last, _, state), do: {:reply, state.last, state}
 
   def handle_call({:position, payload}, _, state) do
@@ -50,7 +58,7 @@ defmodule ProjectYTelemetry.Rental do
          :ok <- Store.reserve_position(state.rider),
          :ok <- Store.put(state.id, state.rider, position) do
       Tracer.with_span "tracking.position", %{attributes: %{"messaging.system" => "phoenix"}} do
-        {:reply, {:ok, position}, %{state | last: position, accepted_at: now}}
+        {:reply, {:ok, position}, refresh_idle(%{state | last: position, accepted_at: now})}
       end
     else
       _ -> {:reply, {:error, "invalid position, inactive rental or rate exceeded"}, state}

--- a/services/telemetry/test/rental_lifetime_test.exs
+++ b/services/telemetry/test/rental_lifetime_test.exs
@@ -1,0 +1,40 @@
+defmodule ProjectYTelemetry.RentalLifetimeTest do
+  use ExUnit.Case, async: false
+  alias ProjectYTelemetry.{Rental, Store}
+
+  test "accepted positions renew lifetime, rejected writes do not, and stale timers are harmless" do
+    start_supervised!(
+      {Redix,
+       {System.get_env("TEST_REDIS_URL", "redis://localhost:6379"),
+        [name: ProjectYTelemetry.Redis]}}
+    )
+
+    id = "idle-test-#{System.unique_integer([:positive])}"
+    rider = id <> "-rider"
+    :ok = Store.activate(id, rider)
+    {:ok, pid} = Rental.resume(id, rider)
+
+    try do
+      original = :sys.get_state(pid).idle_timer
+      assert {:ok, position} = Rental.position(id, %{"latitude" => 0, "longitude" => -60})
+      renewed = :sys.get_state(pid).idle_timer
+      assert renewed != original
+      assert Process.read_timer(original) == false
+      assert Process.read_timer(renewed) > 86_399_000
+      send(pid, {:timeout, original, :idle})
+      assert Rental.last(id) == position
+      assert {:error, _} = Rental.position(id, %{"latitude" => 91, "longitude" => 0})
+      assert :sys.get_state(pid).idle_timer == renewed
+      monitor = Process.monitor(pid)
+      send(pid, {:timeout, renewed, :idle})
+      assert_receive {:DOWN, ^monitor, :process, ^pid, :normal}
+    after
+      Rental.close(id)
+
+      Redix.command!(
+        ProjectYTelemetry.Redis,
+        ["DEL", "tracking:last:" <> id, "tracking:rate:" <> rider]
+      )
+    end
+  end
+end


### PR DESCRIPTION
Fixes the three review findings on #163:

- Reconcile active legacy Mongo rentals into the outbox in bounded batches, with stable event IDs and original creation timestamps. Atomic guards prevent duplicate backfills; settlement patches preserve concurrent events and acknowledgements. Legacy records use a stable rental-specific partition key because the old schema has no immutable motorcycle ID.
- Consume deleted document objects (`NoSuchKey`) as failed verification so delayed replacement/deletion events cannot block Kafka partitions. Permission, bucket and transient storage failures remain retryable; newer facts retain timestamp precedence.
- Renew the telemetry idle timer on accepted positions and ignore stale timer messages. Invalid/rate-limited writes do not extend the lifetime.

Validation: 53 RentalOperations tests (real Mongo/PostgreSQL Testcontainers), 9 Python tests including real OCR and missing-object/retry regressions, 4 Elixir tests including a real Redis/rental-process lifetime regression; mix format and git diff --check pass. CI now provides Redis for that regression. Rollout/recovery behavior is documented in the runbook.

Gitflow: task/77-pr163-review-fixes -> epic/10-remaining-polyglot-services. This updates #163; it does not merge the epic into main.