### PR TITLE
fix(rental): reject lost concurrent settlement updates

### DIFF
--- a/RentalOperations/RentalOperations/Controllers/RentalController.cs
+++ b/RentalOperations/RentalOperations/Controllers/RentalController.cs
@@ -140,6 +140,15 @@ namespace RentalOperations.Controllers
             {
                 return Forbid();
             }
+            catch (RentalSettlementConflictException ex)
+            {
+                return Conflict(new ProblemDetails
+                {
+                    Status = StatusCodes.Status409Conflict,
+                    Title = "Rental settlement conflict",
+                    Detail = ex.Message
+                });
+            }
             catch (Exception ex) when (DependencyFailure.IsUnavailable(ex))
             {
                 return Unavailable(ex);

--- a/RentalOperations/RentalOperations/Domain/RentalSettlementConflictException.cs
+++ b/RentalOperations/RentalOperations/Domain/RentalSettlementConflictException.cs
@@ -1,0 +1,4 @@
+namespace RentalOperations.Domain;
+
+public sealed class RentalSettlementConflictException()
+    : Exception("The rental changed before settlement could be saved. Reload the rental to obtain its stored settlement.");

--- a/RentalOperations/RentalOperations/Repository/RentalRepository.cs
+++ b/RentalOperations/RentalOperations/Repository/RentalRepository.cs
@@ -119,7 +119,9 @@ namespace RentalOperations.Repository
                 filter &= Builders<Rental>.Filter.Ne(r => r.Status, RentalStatus.Completed);
                 update = update.Push(r => r.PendingEvents, RentalEventEnvelope.Create(rental, "rental.closed"));
             }
-            await _rentals.UpdateOneAsync(filter, update);
+            var result = await _rentals.UpdateOneAsync(filter, update);
+            if (result.MatchedCount == 0)
+                throw new RentalSettlementConflictException();
         }
 
         public async Task DeleteRentalAsync(string id)

--- a/RentalOperations/RentalOperationsTests/Integration/MongoDb/RentalEventTests.cs
+++ b/RentalOperations/RentalOperationsTests/Integration/MongoDb/RentalEventTests.cs
@@ -5,6 +5,17 @@ using RentalOperations.Data;
 using RentalOperations.Model;
 using RentalOperations.Repository;
 using RentalOperations.Services;
+using RentalOperations.Domain;
+using AutoMapper;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System.Security.Claims;
+using RentalOperations.Controllers;
+using RentalOperations.CrossCutting.Services;
+using RentalOperations.DTOs;
+using RentalOperations.Mapper;
 using Testcontainers.MongoDb;
 
 namespace RentalOperationsTests.Integration.MongoDb;
@@ -14,6 +25,75 @@ public sealed class RentalEventTests : IAsyncLifetime
     private readonly MongoDbContainer database = new MongoDbBuilder("mongo:8.0").Build();
     public Task InitializeAsync() => database.StartAsync();
     public Task DisposeAsync() => database.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task ConcurrentSettlements_ReturnOnlyPersistedSuccessAndConflictForLoser()
+    {
+        var context = new MongoDbContext(database.GetConnectionString(), "concurrent_settlements");
+        var repository = new RentalRepository(context);
+        var rental = new Rental
+        {
+            MotorcycleId = "moto-1",
+            MotorcycleLicencePlate = "RACE1234",
+            UserId = "rider-1",
+            StartDate = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            PredictedEndDate = new DateTime(2026, 9, 8, 0, 0, 0, DateTimeKind.Utc),
+            InitCost = 210
+        };
+        await repository.CreateRentalAsync(rental);
+        var id = rental._id!.Value.ToString();
+        await repository.TryClaimRentalAsync(rental.MotorcycleLicencePlate, id);
+
+        // Both requests must read separate active snapshots before either writes.
+        var reads = 0;
+        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var synchronized = new Mock<IRentalRepository>(MockBehavior.Strict);
+        synchronized.Setup(r => r.GetRentalByIdAsync(id)).Returns(async () =>
+        {
+            var snapshot = await repository.GetRentalByIdAsync(id);
+            if (Interlocked.Increment(ref reads) == 2) ready.SetResult();
+            await ready.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            return snapshot;
+        });
+        synchronized.Setup(r => r.UpdateRentalAsync(It.IsAny<Rental>()))
+            .Returns((Rental value) => repository.UpdateRentalAsync(value));
+        synchronized.Setup(r => r.ReleaseRentalClaimAsync(rental.MotorcycleLicencePlate, id))
+            .Returns(() => repository.ReleaseRentalClaimAsync(rental.MotorcycleLicencePlate, id));
+        var mapper = new MapperConfiguration(c => c.AddProfile<RentalProfile>(), NullLoggerFactory.Instance).CreateMapper();
+        var service = new RentalService(synchronized.Object, mapper,
+            Mock.Of<IRiderManagerService>(), Mock.Of<IMotorcycleService>());
+        RentalController Controller() => new(service)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(
+                        [new Claim(ClaimTypes.NameIdentifier, rental.UserId)], "test"))
+                }
+            }
+        };
+
+        var results = await Task.WhenAll(
+            Controller().CalculateFinalCost(id, rental.PredictedEndDate.AddDays(-2)),
+            Controller().CalculateFinalCost(id, rental.PredictedEndDate.AddDays(3)));
+        var success = Assert.IsType<ResponseRentalDTO>(Assert.Single(results.OfType<OkObjectResult>()).Value);
+        var conflict = Assert.Single(results.OfType<ConflictObjectResult>());
+        Assert.Equal(409, Assert.IsType<ProblemDetails>(conflict.Value).Status);
+        synchronized.Verify(r => r.ReleaseRentalClaimAsync(rental.MotorcycleLicencePlate, id), Times.Once);
+        var stored = await repository.GetRentalByIdAsync(id);
+        Assert.Equal(stored.EndDate, success.ActualEndDate);
+        Assert.Equal(stored.FinalCost, success.FinalTotalCost);
+        Assert.Equal(stored.AdditionalCostsOrSavings, success.AdditionalCostsOrSavings);
+        Assert.Equal(stored.StatusMessage, success.StatusMessage);
+        Assert.Single(stored.PendingEvents.Where(e => e.Topic == "rental.closed"));
+
+        // A later retry reads the committed settlement, regardless of its supplied date.
+        var retry = Assert.IsType<OkObjectResult>(await Controller().CalculateFinalCost(id, rental.PredictedEndDate.AddDays(9)));
+        var replay = Assert.IsType<ResponseRentalDTO>(retry.Value);
+        Assert.Equal(success.ActualEndDate, replay.ActualEndDate);
+        Assert.Equal(success.FinalTotalCost, replay.FinalTotalCost);
+    }
 
     [Fact]
     public async Task LegacyBackfillIsStableAcrossReplicasAcknowledgementAndConcurrentClose()
@@ -49,7 +129,7 @@ public sealed class RentalEventTests : IAsyncLifetime
         Assert.Equal(2, saved.PendingEvents.Count);
         await rentals.UpdateOneAsync(r => r._id == rental._id,
             Builders<Rental>.Update.PullFilter(r => r.PendingEvents, e => e.Id == start.Id));
-        await repository.UpdateRentalAsync(stale);
+        await Assert.ThrowsAsync<RentalSettlementConflictException>(() => repository.UpdateRentalAsync(stale));
         await RentalKafkaRelay.BackfillActiveRentalsAsync(rentals);
         saved = await repository.GetRentalByIdAsync(rental._id.Value.ToString());
         Assert.Equal("rental.closed", Assert.Single(saved.PendingEvents).Topic);

--- a/docs/runbooks/polyglot-services.md
+++ b/docs/runbooks/polyglot-services.md
@@ -102,6 +102,12 @@ renames. New rentals continue to use their real motorcycle ID. Settlement update
 preserve concurrent outbox writes and acknowledgements. No SQL migration or
 manual database rewrite is needed; tracking becomes available after Kafka catches up.
 
+Concurrent settlements use the Mongo update's matched count: if another request
+has already completed the rental, the losing request returns HTTP 409 and does
+not release the motorcycle claim or return its unpersisted calculation. Reloading
+the rental or retrying settlement after completion returns the stored dates and
+costs; only the winning update enqueues `rental.closed`.
+
 Replacing or deleting a document may remove its object before a delayed
 `document.stored` event arrives. Only S3 `NoSuchKey` is consumed as failed
 verification; the inbox and output events commit normally and newer verification


### PR DESCRIPTION
Concurrent settlement requests could both return success even though MongoDB only persisted the first. Check MatchedCount and raise a settlement conflict when the conditional update loses. The controller returns HTTP 409 before the losing service call releases the motorcycle claim or returns unpersisted costs. A later retry continues to return the stored settlement.

Regression validation uses real MongoDB and synchronizes two service/controller requests so both read active snapshots with different return dates. It verifies one persisted success, one 409, one claim release, one rental.closed event, and consistent stored results on retry. All 54 RentalOperations tests, dotnet format --verify-no-changes, and git diff --check pass.

Addresses https://github.com/iVega123/ProjectY/pull/168#discussion_r3945285116 and updates epic PR #163 through task -> epic Gitflow. Main is not merged.