### PR TITLE
feat(contracts): govern Kafka events with Protobuf schemas in Apicurio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  event-contracts:
+    name: Event contracts / FULL Protobuf
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: quay.io/apicurio/apicurio-registry:3.3.2
+        ports: ['18081:8080']
+        options: >-
+          --health-cmd "curl --fail --silent http://localhost:9000/health/ready"
+          --health-interval 5s --health-timeout 3s --health-retries 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Validate conventions and registry compatibility
+        env:
+          CONTRACT_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if [[ -z "$CONTRACT_BASE_REF" || "$CONTRACT_BASE_REF" =~ ^0+$ ]]; then
+            export CONTRACT_BASE_REF=HEAD^
+          fi
+          node --test contracts/check.test.mjs
+          node contracts/check.mjs
+
   changes:
     name: Detect changed services
     runs-on: ubuntu-latest
@@ -634,6 +661,7 @@ jobs:
   required:
     name: Required
     needs:
+      - event-contracts
       - changes
       - observability
       - dotnet
@@ -652,6 +680,7 @@ jobs:
       - name: Verify CI result
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
+          CONTRACTS_RESULT: ${{ needs.event-contracts.result }}
           OBSERVABILITY_RESULT: ${{ needs.observability.result }}
           DOTNET_RESULT: ${{ needs.dotnet.result }}
           NO_CHANGES_RESULT: ${{ needs.no_relevant_changes.result }}
@@ -669,6 +698,7 @@ jobs:
         shell: bash
         run: |
           [[ "$CHANGES_RESULT" == "success" ]]
+          [[ "$CONTRACTS_RESULT" == "success" ]]
           [[ "$OBSERVABILITY_RESULT" == "success" || "$OBSERVABILITY_RESULT" == "skipped" ]]
           [[ "$DOTNET_RESULT" == "success" || "$NO_CHANGES_RESULT" == "success" ]]
           [[ "$RUST_RESULT" == "success" || "$RUST_RESULT" == "skipped" ]]

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Oo]ut/
+**/TestResults/
 **/target/
 **/_build/
 **/deps/

--- a/Shared/Messaging/RegisteredEventSchema.cs
+++ b/Shared/Messaging/RegisteredEventSchema.cs
@@ -1,0 +1,42 @@
+using System.Collections.Concurrent;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace ProjectY.Shared.Messaging;
+
+/// <summary>Resolve once per topic. Kafka payloads remain locally decodable Protobuf.</summary>
+public sealed class RegisteredEventSchema(HttpClient client, string registryUrl, string contractsDirectory)
+{
+    private readonly ConcurrentDictionary<string, int> _ids = new();
+    private readonly SemaphoreSlim _resolve = new(1, 1);
+
+    public async Task<int> ResolveAsync(string topic, CancellationToken token)
+    {
+        if (_ids.TryGetValue(topic, out var cached)) return cached;
+        await _resolve.WaitAsync(token);
+        try
+        {
+            if (_ids.TryGetValue(topic, out cached)) return cached;
+            using var topics = JsonDocument.Parse(await File.ReadAllTextAsync(Path.Combine(contractsDirectory, "topics.json"), token));
+            var schemaFile = topics.RootElement.GetProperty(topic).GetProperty("schema").GetString()!;
+            var schema = await File.ReadAllTextAsync(Path.Combine(contractsDirectory, "events", schemaFile), token);
+            // Lookup only: deployment registers schemas under FULL before rollout.
+            using var response = await client.PostAsJsonAsync(
+                registryUrl.TrimEnd('/') + "/subjects/" + Uri.EscapeDataString(topic + "-value"),
+                new { schemaType = "PROTOBUF", schema }, token);
+            response.EnsureSuccessStatusCode();
+            using var result = JsonDocument.Parse(await response.Content.ReadAsStringAsync(token));
+            var id = result.RootElement.GetProperty("id").GetInt32();
+            if (id <= 0) throw new InvalidDataException("Registry returned an invalid schema ID.");
+            _ids[topic] = id;
+            return id;
+        }
+        finally { _resolve.Release(); }
+    }
+
+    public static void ValidateKey(string key, string eventKey)
+    {
+        if (string.IsNullOrWhiteSpace(eventKey) || !string.Equals(key, eventKey, StringComparison.Ordinal))
+            throw new InvalidDataException("Kafka key does not match the immutable event identifier.");
+    }
+}

--- a/Tiltfile
+++ b/Tiltfile
@@ -143,8 +143,8 @@ if full:
             sync('services/risk-pricing', '/workspace'), restart_container(),
         ],
     )
-    infra_resources += ['kafka', 'cassandra']
-    setup_resources += ['kafka-init', 'cassandra-init']
+    infra_resources += ['kafka', 'cassandra', 'schema-registry']
+    setup_resources += ['kafka-init', 'cassandra-init', 'schema-init']
     service_resources += ['telemetry', 'risk-pricing', 'console']
 
 for resource in infra_resources:

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,55 @@
+# Governed Kafka event contracts
+
+The topic manifest fixes the schema and immutable partition key for each event.
+Rental events use `motorcycle_id`, rider/document/risk events use `rider_id`, and
+invoices use `rental_id`. Money uses signed 64-bit minor units plus `currency`;
+singular scalar fields have explicit presence. Removed numbers remain reserved.
+The carried rider name and agreed price describe the rental at creation time.
+Historical events without those fields remain distinguishable from zero/empty.
+
+The pre-existing `pricing.updated` catalog is keyed by its fixed ISO currency
+identifier (`BRL`), not by a rider. Its retained `pricing_json` contains integer
+minor units and the currency, and is preserved for the existing price-table
+consumer. New settlement/invoice money is typed directly as Protobuf `int64`.
+
+The first governed versions are installed by `schema-init`. Producers look up
+the exact schema through `/apis/ccompat/v7/subjects/{topic}-value`, cache its ID
+in memory, and send raw Protobuf directly to Kafka with a `schema-id` header.
+This deliberately preserves the retained raw payloads and existing decoders;
+it is **not** Confluent's binary wire envelope. Consumers decode locally and do
+not call the registry. A warm producer continues during registry failure. A cold
+producer retains its outbox until lookup succeeds. Schema registration is a
+deployment task, never a per-message operation.
+
+## Verified registry behavior
+
+Apicurio **3.3.2** is pinned. Its [Apache 2.0 license](https://github.com/Apicurio/apicurio-registry/blob/3.3.2/LICENSE)
+and [Confluent-compatible API](https://www.apicur.io/registry/docs/apicurio-registry/3.3.x/getting-started/assembly-confluent-schema-registry-compatibility.html)
+were checked during #132. Registry data uses the existing Kafka broker's
+KafkaSQL journal, with no registry request in the message delivery path.
+
+The real checker accepts unchanged schemas and rejects the string-to-int64
+canary. It also rejects optional field additions under FULL: its forward pass
+reverses the schemas and treats the added fields as unreserved removals. This
+is a conservative false rejection, not absent enforcement. See the pinned
+[checker implementation](https://github.com/Apicurio/apicurio-registry/blob/3.3.2/schema-util/protobuf/src/main/java/io/apicurio/registry/protobuf/rules/compatibility/ProtobufCompatibilityChecker.java).
+Do not downgrade FULL or silently ignore its rejection. Further evolution of
+governed messages requires resolving that upstream limitation or introducing an
+explicitly versioned contract with a consumer rollout.
+
+Before #132, these topics had raw Protobuf but no registry version. Initial
+adoption validates all old field names, numbers, types and presence against Git
+and establishes the expanded schema as registry version 1. Tests prove that old
+payloads decode with absent money and new payloads preserve explicit zero.
+Once `topics.json` exists in the base revision, CI registers that revision first
+and checks the proposed schema against it under FULL. The negative control is
+sent to the compatibility endpoint only, never registered.
+
+## Validation
+
+`node --test contracts/check.test.mjs` checks conventions.
+`CONTRACT_BASE_REF=<base-sha> node contracts/check.mjs` checks a disposable
+registry at `http://localhost:18081/apis/ccompat/v7` (override with
+`SCHEMA_REGISTRY_URL`). Never run the CI checker against a deployed registry;
+use `node contracts/register.mjs` for deployment. The root Required job depends
+on the registry test, including its incompatible canary.

--- a/contracts/check.mjs
+++ b/contracts/check.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import {readFile} from 'node:fs/promises';
+import {execFileSync} from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+
+export function fields(schema) {
+  return [...schema.replace(/\/\/[^\n]*/g, '').matchAll(/^\s*(?:(optional|repeated)\s+)?(\w+)\s+(\w+)\s*=\s*(\d+)\s*;/gm)]
+    .map(([, presence, type, name, number]) => ({presence, type, name, number: Number(number)}));
+}
+
+export function validate(schema, previous = schema) {
+  const current = fields(schema);
+  assert(current.length, 'Schema has no fields');
+  assert.equal(new Set(current.map(f => f.number)).size, current.length, 'Duplicate field number');
+  for (const field of current) {
+    assert(['optional', 'repeated'].includes(field.presence), `${field.name}: explicit presence required`);
+    if (/(minor|cost|amount|price|total)/.test(field.name)) assert.equal(field.type, 'int64', `${field.name}: money must use int64 minor units`);
+  }
+  for (const match of schema.matchAll(/enum\s+\w+\s*\{([^}]+)\}/g)) {
+    assert(/\w+_UNSPECIFIED\s*=\s*0\s*;/.test(match[1]), 'Enum requires _UNSPECIFIED = 0');
+  }
+  for (const old of fields(previous)) {
+    const next = current.find(f => f.number === old.number);
+    if (next) {
+      assert.equal(next.name, old.name, `Field ${old.number} reused or renamed`);
+      assert.equal(next.type, old.type, `Field ${old.number} changed type`);
+      assert.equal(next.presence, old.presence, `Field ${old.number} changed presence`);
+    } else {
+      assert(new RegExp(`reserved\\s+[^;]*\\b${old.number}\\b[^;]*;`).test(schema), `Removed field ${old.number} must be reserved`);
+    }
+  }
+}
+
+export async function registryRequest(base, path, method = 'GET', body) {
+  const response = await fetch(base + path, {method,
+    headers: {'Content-Type': 'application/vnd.schemaregistry.v1+json'},
+    body: body === undefined ? undefined : JSON.stringify(body), signal: AbortSignal.timeout(10000)});
+  if (!response.ok) throw new Error(`${method} ${path}: ${response.status} ${await response.text()}`);
+  return response.json();
+}
+
+export async function checkRegistry(base, baselineRef) {
+  const topics = JSON.parse(await readFile(new URL('./topics.json', import.meta.url)));
+  let governedTopics = {};
+  if (baselineRef) {
+    execFileSync('git', ['rev-parse', '--verify', baselineRef], {stdio: 'pipe'});
+    if (execFileSync('git', ['ls-tree', '--name-only', baselineRef, 'contracts/topics.json'], {encoding: 'utf8'}).trim()) {
+      governedTopics = JSON.parse(execFileSync('git', ['show', `${baselineRef}:contracts/topics.json`], {encoding: 'utf8'}));
+    }
+    for (const topic of Object.keys(governedTopics)) assert(topics[topic], `Retained topic contract removed: ${topic}`);
+  }
+  for (const [topic, contract] of Object.entries(topics)) {
+    const expected = topic.startsWith('rental.') || topic.startsWith('motorcycle.') ? 'motorcycle_id'
+      : topic.startsWith('invoice.') ? 'rental_id' : topic === 'pricing.updated' ? 'currency' : 'rider_id';
+    assert.equal(contract.key, expected, `${topic}: immutable partition key required`);
+    const schema = await readFile(new URL('./events/' + contract.schema, import.meta.url), 'utf8');
+    let previous = schema;
+    if (baselineRef) {
+      const path = `contracts/events/${governedTopics[topic]?.schema || contract.schema}`;
+      if (execFileSync('git', ['ls-tree', '--name-only', baselineRef, path], {encoding: 'utf8'}).trim()) {
+        previous = execFileSync('git', ['show', `${baselineRef}:${path}`], {encoding: 'utf8'});
+      }
+    }
+    validate(schema, previous);
+    const subject = encodeURIComponent(topic + '-value');
+    await registryRequest(base, '/config/' + subject, 'PUT', {compatibility: 'FULL'});
+    // Registry adoption establishes the first governed version. The old raw
+    // Protobuf still passes the field-preservation check above. Once governed,
+    // every change must also pass the registry against the actual base version.
+    await registryRequest(base, `/subjects/${subject}/versions`, 'POST', {schemaType: 'PROTOBUF', schema: governedTopics[topic] ? previous : schema});
+    const compatible = await registryRequest(base, `/compatibility/subjects/${subject}/versions/latest`, 'POST', {schemaType: 'PROTOBUF', schema});
+    assert.equal(compatible.is_compatible, true, `${topic}: registry rejected proposed schema`);
+    await registryRequest(base, `/subjects/${subject}/versions`, 'POST', {schemaType: 'PROTOBUF', schema});
+    // A real negative control: proves Protobuf checking is active, not a no-op.
+    const broken = schema.replace('optional string event_id = 1;', 'optional int64 event_id = 1;');
+    assert.notEqual(broken, schema);
+    const rejected = await registryRequest(base, `/compatibility/subjects/${subject}/versions/latest`, 'POST', {schemaType: 'PROTOBUF', schema: broken});
+    assert.equal(rejected.is_compatible, false, `${topic}: registry accepted the incompatible canary`);
+  }
+  console.log('PASS: FULL Protobuf compatibility, negative controls, presence, money and immutable keys');
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await checkRegistry(process.env.SCHEMA_REGISTRY_URL || 'http://localhost:18081/apis/ccompat/v7', process.env.CONTRACT_BASE_REF);
+}

--- a/contracts/check.test.mjs
+++ b/contracts/check.test.mjs
@@ -1,0 +1,15 @@
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {validate} from './check.mjs';
+const original = 'message Fact {\n optional string event_id = 1;\n optional int64 total_minor = 2;\n}';
+test('additive optional evolution is safe', () => validate(original.replace('\n}', '\n optional string currency = 3;\n}'), original));
+test('money, presence and field reuse fail closed', () => {
+  for (const broken of [original.replace('int64', 'double'), original.replace('optional string', 'string'), original.replace('event_id', 'rental_id')]) {
+    assert.throws(() => validate(broken, original));
+  }
+});
+test('removed field requires reservation', () => {
+  const removed = original.replace(' optional int64 total_minor = 2;', '');
+  assert.throws(() => validate(removed, original));
+  validate(removed.replace('\n}', '\n reserved 2;\n}'), original);
+});

--- a/contracts/events/invoice.proto
+++ b/contracts/events/invoice.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package project_y.events;
+
+message InvoiceIssued {
+  optional string event_id = 1;
+  optional string invoice_id = 2;
+  optional string rental_id = 3;
+  optional string rider_id = 4;
+  optional int64 occurred_at_ms = 5;
+  optional int64 total_minor = 6;
+  optional string currency = 7;
+  optional string rider_name = 8;
+}

--- a/contracts/events/rental.proto
+++ b/contracts/events/rental.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 package project_y.events;
 
-// Kafka raw Protobuf payload, immutable motorcycle_id partition key.
-// Registry framing is owned by #132; field numbers must never be reused.
+// Raw Protobuf with the registry schema ID in a Kafka header. Consumers decode
+// locally, including retained messages written before registry introduction.
 message RentalEvent {
   optional string event_id = 1;
   optional string rental_id = 2;
@@ -13,4 +13,7 @@ message RentalEvent {
   optional int64 started_at_ms = 7;
   optional int64 predicted_end_at_ms = 8;
   optional int64 ended_at_ms = 9;
+  optional int64 agreed_total_minor = 10;
+  optional string currency = 11;
+  optional string rider_name = 12;
 }

--- a/contracts/register.mjs
+++ b/contracts/register.mjs
@@ -1,0 +1,12 @@
+import {readFile} from 'node:fs/promises';
+import {registryRequest, validate} from './check.mjs';
+const base = process.env.SCHEMA_REGISTRY_URL || 'http://schema-registry:8080/apis/ccompat/v7';
+const topics = JSON.parse(await readFile(new URL('./topics.json', import.meta.url)));
+for (const [topic, {schema: file}] of Object.entries(topics)) {
+  const schema = await readFile(new URL('./events/' + file, import.meta.url), 'utf8');
+  validate(schema);
+  const subject = encodeURIComponent(topic + '-value');
+  await registryRequest(base, '/config/' + subject, 'PUT', {compatibility: 'FULL'});
+  const result = await registryRequest(base, `/subjects/${subject}/versions`, 'POST', {schemaType: 'PROTOBUF', schema});
+  console.log(`${topic}: registered schema ${result.id} under FULL compatibility`);
+}

--- a/contracts/topics.json
+++ b/contracts/topics.json
@@ -1,0 +1,11 @@
+{
+  "rental.started": {"schema": "rental.proto", "key": "motorcycle_id"},
+  "rental.closed": {"schema": "rental.proto", "key": "motorcycle_id"},
+  "rider.registered": {"schema": "rider.proto", "key": "rider_id"},
+  "rider.verified": {"schema": "rider.proto", "key": "rider_id"},
+  "document.stored": {"schema": "rider.proto", "key": "rider_id"},
+  "document.verified": {"schema": "rider.proto", "key": "rider_id"},
+  "risk.scored": {"schema": "rider.proto", "key": "rider_id"},
+  "pricing.updated": {"schema": "rider.proto", "key": "currency"},
+  "invoice.issued": {"schema": "invoice.proto", "key": "rental_id"}
+}

--- a/deploy/kafka/topics.txt
+++ b/deploy/kafka/topics.txt
@@ -1,7 +1,8 @@
 # One durable event stream per contract. Commands use --if-not-exists.
 rental.started
 rental.closed
-motorcycle.registered
+rider.registered
+invoice.issued
 document.stored
 document.verified
 rider.verified

--- a/docker-compose.polyglot.yml
+++ b/docker-compose.polyglot.yml
@@ -1,4 +1,24 @@
 services:
+  schema-registry:
+    image: quay.io/apicurio/apicurio-registry:3.3.2
+    networks: [projecty]
+    environment:
+      APICURIO_STORAGE_KIND: kafkasql
+      APICURIO_KAFKASQL_BOOTSTRAP_SERVERS: kafka:9092
+    healthcheck:
+      test: [CMD, curl, --fail, --silent, http://localhost:9000/health/ready]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+    depends_on:
+      kafka: {condition: service_healthy}
+  schema-init:
+    image: node:24-alpine
+    networks: [projecty]
+    volumes: [./contracts:/contracts:ro]
+    command: [node, /contracts/register.mjs]
+    depends_on:
+      schema-registry: {condition: service_healthy}
   console:
     image: projecty/console:dev
     build: {context: services/console}
@@ -19,9 +39,15 @@ services:
   rental-operations:
     environment:
       Kafka__BootstrapServers: kafka:9092
+      Kafka__SchemaRegistryUrl: http://schema-registry:8080/apis/ccompat/v7
+    depends_on:
+      schema-init: {condition: service_completed_successfully}
   rider-manager:
     environment:
       Kafka__BootstrapServers: kafka:9092
+      Kafka__SchemaRegistryUrl: http://schema-registry:8080/apis/ccompat/v7
+    depends_on:
+      schema-init: {condition: service_completed_successfully}
   kafka-init:
     image: apache/kafka:4.3.1
     networks: [projecty]
@@ -43,6 +69,7 @@ services:
     volumes: [risk-state:/data]
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      SCHEMA_REGISTRY_URL: http://schema-registry:8080/apis/ccompat/v7
       S3_ENDPOINT: http://minio:9000
       S3_BUCKET: my-bucket
       AWS_ACCESS_KEY_ID: '${MINIO_USER:?Set MINIO_USER}'
@@ -57,6 +84,7 @@ services:
       retries: 12
     depends_on:
       kafka-init: {condition: service_completed_successfully}
+      schema-init: {condition: service_completed_successfully}
   kafka:
     image: apache/kafka:4.3.1
     networks: [projecty]

--- a/services/RentalOperations/RentalOperations/Model/Rental.cs
+++ b/services/RentalOperations/RentalOperations/Model/Rental.cs
@@ -7,6 +7,7 @@ namespace RentalOperations.Model
     public class Rental
     {
         public string MotorcycleId { get; set; } = string.Empty;
+        public string? RiderName { get; set; }
         public List<RentalEventEnvelope> PendingEvents { get; set; } = [];
         [BsonId]
         [BsonRepresentation(BsonType.ObjectId)]

--- a/services/RentalOperations/RentalOperations/Model/RentalEventEnvelope.cs
+++ b/services/RentalOperations/RentalOperations/Model/RentalEventEnvelope.cs
@@ -26,9 +26,12 @@ public sealed class RentalEventEnvelope
             MotorcycleId = PartitionKey(rental),
             OccurredAtMs = time,
             PlanDays = (rental.PredictedEndDate - rental.StartDate).Days,
+            AgreedTotalMinor = checked((long)decimal.Round(rental.InitCost * 100m, 0, MidpointRounding.ToEven)),
+            Currency = "BRL",
             StartedAtMs = new DateTimeOffset(rental.StartDate.ToUniversalTime()).ToUnixTimeMilliseconds(),
             PredictedEndAtMs = new DateTimeOffset(rental.PredictedEndDate.ToUniversalTime()).ToUnixTimeMilliseconds()
         };
+        if (rental.RiderName is { } riderName) message.RiderName = riderName;
         if (rental.EndDate is { } ended) message.EndedAtMs = new DateTimeOffset(ended.ToUniversalTime()).ToUnixTimeMilliseconds();
         return new() { Id = id, Topic = topic, Payload = message.ToByteArray(), TraceParent = Activity.Current?.Id };
     }

--- a/services/RentalOperations/RentalOperations/RentalOperations.csproj
+++ b/services/RentalOperations/RentalOperations/RentalOperations.csproj
@@ -45,6 +45,9 @@
   <ItemGroup><Compile Include="..\..\..\Shared\Messaging\BoundedRabbitMqRetryRouter.cs" Link="Shared\Messaging\BoundedRabbitMqRetryRouter.cs" /></ItemGroup>
   <ItemGroup>
     <Protobuf Include="../../../contracts/events/rental.proto" GrpcServices="None" />
+    <Compile Include="../../../Shared/Messaging/RegisteredEventSchema.cs" Link="Shared/Messaging/RegisteredEventSchema.cs" />
+    <Content Include="../../../contracts/topics.json" Link="event-contracts/topics.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="../../../contracts/events/*.proto" Link="event-contracts/events/%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
     <Protobuf Include="../../../contracts/events/rider.proto" GrpcServices="None" />
     <Content Include="../../risk-pricing/pricing-policy.json" Link="pricing-policy.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/services/RentalOperations/RentalOperations/Services/RentalKafkaRelay.cs
+++ b/services/RentalOperations/RentalOperations/Services/RentalKafkaRelay.cs
@@ -4,6 +4,8 @@ using Confluent.Kafka;
 using MongoDB.Driver;
 using RentalOperations.Data;
 using RentalOperations.Model;
+using ProjectY.Shared.Messaging;
+using ProjectY.Events;
 
 namespace RentalOperations.Services;
 
@@ -15,6 +17,10 @@ public sealed class RentalKafkaRelay(MongoDbContext context, IConfiguration conf
     {
         var bootstrap = config["Kafka:BootstrapServers"];
         if (string.IsNullOrWhiteSpace(bootstrap)) return;
+        using var registryClient = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        var schemas = new RegisteredEventSchema(registryClient,
+            config["Kafka:SchemaRegistryUrl"] ?? throw new InvalidOperationException("Kafka schema registry URL is required."),
+            Path.Combine(AppContext.BaseDirectory, "event-contracts"));
         using var producer = new ProducerBuilder<string, byte[]>(new ProducerConfig
         {
             BootstrapServers = bootstrap,
@@ -39,6 +45,9 @@ public sealed class RentalKafkaRelay(MongoDbContext context, IConfiguration conf
                         span?.SetTag("messaging.system", "kafka");
                         span?.SetTag("messaging.destination.name", item.Topic);
                         var headers = new Headers();
+                        RegisteredEventSchema.ValidateKey(RentalEventEnvelope.PartitionKey(rental), RentalEvent.Parser.ParseFrom(item.Payload).MotorcycleId);
+                        var schemaId = await schemas.ResolveAsync(item.Topic, stoppingToken);
+                        headers.Add("schema-id", Encoding.UTF8.GetBytes(schemaId.ToString(System.Globalization.CultureInfo.InvariantCulture)));
                         if ((span?.Id ?? item.TraceParent) is { } trace)
                             headers.Add("traceparent", Encoding.UTF8.GetBytes(trace));
                         await producer.ProduceAsync(item.Topic, new Message<string, byte[]>

--- a/services/RentalOperations/RentalOperations/Services/RentalService.cs
+++ b/services/RentalOperations/RentalOperations/Services/RentalService.cs
@@ -72,6 +72,7 @@ namespace RentalOperations.Services
                 MotorcycleId = motorcycle.id,
                 MotorcycleLicencePlate = rentalDomain.MotocycleLicencePlate,
                 UserId = rentalDomain.UserId,
+                RiderName = rider.Name,
                 StartDate = rentalDomain.StartDate,
                 EndDate = rentalDomain.EndDate,
                 PredictedEndDate = rentalDomain.PredictedEndDate,

--- a/services/RentalOperations/RentalOperationsTests/Unit/Messaging/RegisteredEventSchemaTests.cs
+++ b/services/RentalOperations/RentalOperationsTests/Unit/Messaging/RegisteredEventSchemaTests.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using Google.Protobuf;
+using ProjectY.Events;
+using ProjectY.Shared.Messaging;
+using RentalOperations.Model;
+using Xunit;
+
+namespace RentalOperationsTests.Unit.Messaging;
+
+public sealed class RegisteredEventSchemaTests
+{
+    [Fact]
+    public async Task CachedSchemaSurvivesRegistryFailure()
+    {
+        var handler = new RegistryHandler();
+        using var client = new HttpClient(handler);
+        var schemas = new RegisteredEventSchema(client, "http://registry/apis/ccompat/v7",
+            Path.Combine(AppContext.BaseDirectory, "event-contracts"));
+        Assert.Equal(42, await schemas.ResolveAsync("rental.closed", default));
+        handler.Available = false;
+        Assert.Equal(42, await schemas.ResolveAsync("rental.closed", default));
+        Assert.Equal(1, handler.Requests);
+        await Assert.ThrowsAsync<HttpRequestException>(() => schemas.ResolveAsync("rental.started", default));
+    }
+
+    [Fact]
+    public void PlateCannotReplaceImmutablePartitionKey()
+    {
+        RegisteredEventSchema.ValidateKey("motorcycle-id", "motorcycle-id");
+        Assert.Throws<InvalidDataException>(() => RegisteredEventSchema.ValidateKey("ABC1D23", "motorcycle-id"));
+    }
+
+    [Fact]
+    public void HistoricPayloadDistinguishesMissingMoneyFromZero()
+    {
+        // Retained v0 message: event_id=e, rental_id=r, motorcycle_id=m.
+        var historic = RentalEvent.Parser.ParseFrom(Convert.FromHexString("0A016512017222016D"));
+        Assert.Equal("m", historic.MotorcycleId);
+        Assert.False(historic.HasAgreedTotalMinor);
+        var current = new RentalEvent { EventId = "e", AgreedTotalMinor = 0, Currency = "BRL" };
+        Assert.True(RentalEvent.Parser.ParseFrom(current.ToByteArray()).HasAgreedTotalMinor);
+        var golden = new RentalEvent
+        {
+            EventId = "e",
+            RentalId = "r",
+            MotorcycleId = "m",
+            AgreedTotalMinor = 0,
+            Currency = "BRL",
+            RiderName = "Ada"
+        };
+        // The unchanged Elixir v0 decoder consumes this same golden in tracking_test.exs.
+        Assert.Equal("0A016512017222016D50005A0342524C6203416461", Convert.ToHexString(golden.ToByteArray()));
+    }
+
+    [Fact]
+    public void ClosedEventCarriesAgreedMoneyAndDatedRiderName()
+    {
+        var rental = new Rental
+        {
+            MotorcycleLicencePlate = "ABC1D23",
+            MotorcycleId = "immutable-id",
+            UserId = "rider",
+            RiderName = "Original name",
+            InitCost = 210.25m,
+            StartDate = new DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+            PredictedEndDate = new DateTime(2026, 10, 8, 0, 0, 0, DateTimeKind.Utc)
+        };
+        var envelope = RentalEventEnvelope.Create(rental, "rental.closed");
+        rental.RiderName = "Renamed later";
+        var message = RentalEvent.Parser.ParseFrom(envelope.Payload);
+        Assert.Equal(21025, message.AgreedTotalMinor);
+        Assert.Equal("BRL", message.Currency);
+        Assert.Equal("Original name", message.RiderName);
+    }
+
+    private sealed class RegistryHandler : HttpMessageHandler
+    {
+        public bool Available { get; set; } = true;
+        public int Requests { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken token)
+        {
+            Requests++;
+            if (!Available) throw new HttpRequestException("Registry unavailable");
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            { Content = new StringContent("{\"id\":42}") });
+        }
+    }
+}

--- a/services/RiderManager/RiderManager/RiderManager.csproj
+++ b/services/RiderManager/RiderManager/RiderManager.csproj
@@ -53,5 +53,8 @@
   <ItemGroup><Compile Include="..\..\..\Shared\Messaging\BoundedRabbitMqRetryRouter.cs" Link="Shared\Messaging\BoundedRabbitMqRetryRouter.cs" /></ItemGroup>
   <ItemGroup>
     <Protobuf Include="../../../contracts/events/rider.proto" GrpcServices="None" />
+    <Compile Include="../../../Shared/Messaging/RegisteredEventSchema.cs" Link="Shared/Messaging/RegisteredEventSchema.cs" />
+    <Content Include="../../../contracts/topics.json" Link="event-contracts/topics.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="../../../contracts/events/*.proto" Link="event-contracts/events/%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/services/RiderManager/RiderManager/Services/RiderKafkaRelay.cs
+++ b/services/RiderManager/RiderManager/Services/RiderKafkaRelay.cs
@@ -4,6 +4,8 @@ using RiderManager.Data;
 using System.Diagnostics;
 using System.Text;
 using ProjectY.Shared.Observability;
+using ProjectY.Shared.Messaging;
+using ProjectY.Events;
 
 namespace RiderManager.Services;
 
@@ -13,6 +15,10 @@ public sealed class RiderKafkaRelay(IServiceScopeFactory scopes, IConfiguration 
     protected override async Task ExecuteAsync(CancellationToken token)
     {
         if (string.IsNullOrWhiteSpace(config["Kafka:BootstrapServers"])) return;
+        using var registryClient = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        var schemas = new RegisteredEventSchema(registryClient,
+            config["Kafka:SchemaRegistryUrl"] ?? throw new InvalidOperationException("Kafka schema registry URL is required."),
+            Path.Combine(AppContext.BaseDirectory, "event-contracts"));
         using var producer = new ProducerBuilder<string, byte[]>(new ProducerConfig
         { BootstrapServers = config["Kafka:BootstrapServers"], EnableIdempotence = true, Acks = Acks.All, MessageTimeoutMs = 5000 }).Build();
         while (!token.IsCancellationRequested)
@@ -27,6 +33,9 @@ public sealed class RiderKafkaRelay(IServiceScopeFactory scopes, IConfiguration 
                     using var span = Traces.StartActivity("publish document.stored", ActivityKind.Producer, parent);
                     span?.SetTag("messaging.system", "kafka");
                     var headers = new Headers();
+                    RegisteredEventSchema.ValidateKey(item.RiderId, RiderEvent.Parser.ParseFrom(item.Payload).RiderId);
+                    var schemaId = await schemas.ResolveAsync(item.Topic, token);
+                    headers.Add("schema-id", Encoding.UTF8.GetBytes(schemaId.ToString(System.Globalization.CultureInfo.InvariantCulture)));
                     if ((span?.Id ?? item.TraceParent) is { } trace) headers.Add("traceparent", Encoding.UTF8.GetBytes(trace));
                     await producer.ProduceAsync(item.Topic, new Message<string, byte[]> { Key = item.RiderId, Value = item.Payload, Headers = headers }, token);
                     db.EventOutbox.Remove(item);

--- a/services/risk-pricing/Dockerfile
+++ b/services/risk-pricing/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache --virtual .build-deps build-base bash curl openssl-dev zl
     && rm -rf /tmp/librdkafka-2.15.0 /tmp/librdkafka.tar.gz \
     && apk del .build-deps
 COPY contracts/events /contracts
+COPY contracts /event-contracts
 RUN python -m grpc_tools.protoc -I/contracts --python_out=/workspace /contracts/rental.proto /contracts/rider.proto
 COPY services/risk-pricing/ ./
 RUN mkdir -p /data && chown 65532:65532 /data

--- a/services/risk-pricing/schema_registry.py
+++ b/services/risk-pricing/schema_registry.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+
+class RegisteredSchemas:
+    """Lookup once per topic; an unavailable registry never loses an outbox row."""
+
+    def __init__(self, url, contracts=Path('/event-contracts')):
+        self.url = url.rstrip('/')
+        self.contracts = contracts
+        self.ids = {}
+
+    def resolve(self, topic):
+        if topic not in self.ids:
+            topics = json.loads((self.contracts / 'topics.json').read_text())
+            schema = (self.contracts / 'events' / topics[topic]['schema']).read_text()
+            request = Request(self.url + '/subjects/' + topic + '-value',
+                              json.dumps({'schemaType': 'PROTOBUF', 'schema': schema}).encode(),
+                              {'Content-Type': 'application/json'}, method='POST')
+            with urlopen(request, timeout=5) as response:
+                schema_id = json.load(response)['id']
+            if not isinstance(schema_id, int) or schema_id <= 0:
+                raise ValueError('Invalid registry schema ID')
+            self.ids[topic] = schema_id
+        return self.ids[topic]

--- a/services/risk-pricing/test_schema_registry.py
+++ b/services/risk-pricing/test_schema_registry.py
@@ -1,0 +1,22 @@
+import io
+import json
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+from schema_registry import RegisteredSchemas
+
+
+def test_cache_keeps_warm_producer_independent_of_registry(tmp_path):
+    (tmp_path / 'events').mkdir()
+    (tmp_path / 'topics.json').write_text(json.dumps({'risk.scored': {'schema': 'rider.proto'}}))
+    (tmp_path / 'events' / 'rider.proto').write_text('syntax = "proto3";')
+    cache = RegisteredSchemas('http://registry/apis/ccompat/v7', tmp_path)
+    with patch('schema_registry.urlopen', return_value=io.BytesIO(b'{"id":42}')) as request:
+        assert cache.resolve('risk.scored') == 42
+        request.side_effect = OSError('registry down')
+        assert cache.resolve('risk.scored') == 42
+        assert request.call_count == 1
+    cold = RegisteredSchemas('http://registry/apis/ccompat/v7', tmp_path)
+    with patch('schema_registry.urlopen', side_effect=OSError('registry down')):
+        with pytest.raises(OSError):
+            cold.resolve('risk.scored')

--- a/services/risk-pricing/worker.py
+++ b/services/risk-pricing/worker.py
@@ -1,4 +1,5 @@
 import io
+import json
 import logging
 import os
 import time
@@ -14,6 +15,7 @@ from rental_pb2 import RentalEvent
 from rider_pb2 import RiderEvent
 from state import State
 from policy import verify_number
+from schema_registry import RegisteredSchemas
 
 log = logging.getLogger("risk-pricing")
 tracer = trace.get_tracer("risk-pricing")
@@ -48,6 +50,7 @@ def run(stop, health):
     consumer = Consumer({"bootstrap.servers":bootstrap, "group.id":"risk-pricing-v1",
                          "enable.auto.commit":False, "auto.offset.reset":"earliest"})
     producer = Producer({"bootstrap.servers":bootstrap, "enable.idempotence":True, "message.timeout.ms":5000})
+    schemas = RegisteredSchemas(os.environ['SCHEMA_REGISTRY_URL'])
     consumer.subscribe(["document.stored", "rider.verified", "rental.started", "rental.closed"])
     last_periodic = 0
     try:
@@ -66,6 +69,11 @@ def run(stop, health):
                             attributes={"messaging.system":"kafka", "messaging.destination.name":topic}):
                         carrier = {}
                         propagate.inject(carrier)
+                        outbox_event = RiderEvent.FromString(payload)
+                        event_key = json.loads(outbox_event.pricing_json)['currency'] if topic == 'pricing.updated' else outbox_event.rider_id
+                        if not event_key or key != event_key:
+                            raise ValueError('Kafka key must match the immutable event identifier')
+                        carrier['schema-id'] = str(schemas.resolve(topic))
                         producer.produce(topic, key=key, value=payload, headers=list(carrier.items()),
                                          on_delivery=lambda error, _msg, result=delivered: result.set_result(error))
                         if producer.flush(6) or not delivered.done() or delivered.result():

--- a/services/telemetry/test/tracking_test.exs
+++ b/services/telemetry/test/tracking_test.exs
@@ -23,6 +23,11 @@ defmodule ProjectYTelemetry.TrackingTest do
     assert RentalEvent.decode(<<>>).occurred_at_ms == nil
     event = %RentalEvent{rental_id: "r1", rider_id: "u1", occurred_at_ms: 0}
     assert RentalEvent.decode(RentalEvent.encode(event)).occurred_at_ms == 0
+    # Golden emitted by the .NET v1 producer; fields 10-12 are unknown to this v0 decoder.
+    golden = Base.decode16!("0A016512017222016D50005A0342524C6203416461")
+
+    assert %RentalEvent{event_id: "e", rental_id: "r", motorcycle_id: "m"} =
+             RentalEvent.decode(golden)
   end
 
   test "socket rejects unsigned tickets" do


### PR DESCRIPTION
Closes #132. Targets `epic/130-strangler-migration`.

## What this does

Apicurio Schema Registry joins the stack **beside the message path, never inside it**. A producer resolves a topic's schema id once, caches it in memory, serialises locally and publishes raw Protobuf straight to Kafka with a `schema-id` header. Consumers decode locally and never call the registry — so retained messages written before the registry still decode, and a registry outage never stalls a warm producer. Registration is a deployment task (`schema-init`), never a per-message operation.

Apicurio over Confluent SR for the reason that runs through the repo: it speaks the Confluent REST API, so the client library stays the portable interface. Apache 2.0, pinned at 3.3.2.

`rental.closed` carries the facts that describe it: `agreed_total_minor` as `int64` minor units with `currency`, and `rider_name` dated at creation — a dated fact, not a cache. All four conventions hold: explicit presence on every field, numbers never reused, money as int64 minor units, enums with `_UNSPECIFIED = 0`.

## The gate actually checks

The CI job runs the registry's own compatibility check under FULL, and each subject must **reject** an incompatible canary (`event_id` `string` → `int64`). A gate that passes everything is worse than no gate, so the negative control is part of the assertion, not a comment. Partition keys are asserted against `contracts/topics.json` rather than reviewed by eye — no topic can be keyed by a mutable business identifier such as a licence plate.

## Verification

| Suite | Result |
|---|---|
| `node --test contracts/check.test.mjs` | 3/3 |
| `contracts/check.mjs` vs live Apicurio 3.3.2 | PASS, 9 subjects, canary rejected on each |
| RentalOperations | 58/58 |
| RiderManager | 40/40 |
| risk-pricing (real image) | 10/10 |
| telemetry (real image + Redis) | 4/4 |

Cross-language forward compatibility is proven, not asserted: the C# test pins the exact bytes the .NET producer emits for a v1 `rental.closed`, and the **unchanged** Elixir v0 decoder consumes those same bytes in `tracking_test.exs`, ignoring fields 10–12.

## Known constraint, documented

Apicurio 3.3.2 under FULL **rejects additive optional fields** — its forward pass reverses the schemas and treats added fields as unreserved removals. Conservative false rejection, not absent enforcement. It does not affect this PR (initial adoption has no prior governed version), but the next schema evolution will hit it. `contracts/README.md` records the limitation and what not to do about it: do not downgrade FULL, do not silently ignore a rejection.

## Also here

`chore(git)`: `TestResults/` was covered by no ignore rule, so `.trx` artefacts kept surfacing as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)