### PR TITLE
feat(deploy): bring back the target engine and fill the table rentals will reference

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,6 +233,48 @@ services:
     networks:
       - projecty
 
+  # The engine the target schema is written for. It arrives before any row does:
+  # #135 moves rentals across with both uniqueness guarantees live at once, and
+  # neither can be live if one of the two stores is not running.
+  cockroachdb:
+    image: cockroachdb/cockroach:v26.3.1
+    container_name: cockroachdb
+    command: start-single-node --insecure --http-addr=0.0.0.0:8080
+    environment:
+      COCKROACH_HEALTH_URL: postgresql://root@localhost:26257/defaultdb?sslmode=disable
+    ports:
+      - "26257:26257"
+      - "26080:8080"
+    volumes:
+      - cockroach-data:/cockroach/cockroach-data
+    networks:
+      - projecty
+    healthcheck:
+      test: ["CMD-SHELL", "cockroach sql --url=\"$${COCKROACH_HEALTH_URL}\" --execute 'SELECT 1' >/dev/null 2>&1"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
+
+  # Two invocations: the bootstrap creates the database, the portable schema fills
+  # it. That is why the entrypoint is a shell rather than `cockroach sql` directly.
+  cockroach-init:
+    image: cockroachdb/cockroach:v26.3.1
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        cockroach sql --insecure --host=cockroachdb:26257 \
+          --file=/sql/000_bootstrap.cockroach.sql
+        cockroach sql --insecure --host=cockroachdb:26257 --database=projecty \
+          --file=/sql/001_schema.sql
+    volumes:
+      - ./deploy/db/sql:/sql:ro
+    networks:
+      - projecty
+    depends_on:
+      cockroachdb:
+        condition: service_healthy
   mongodb:
     image: mongo:8.3
     container_name: mongodb
@@ -544,6 +586,7 @@ networks:
 
 volumes:
   postgres-data:
+  cockroach-data:
   redis-data:
   mongo-data:
   rabbitmq-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ x-moto-hub-environment: &moto-hub-environment
   Swagger__Enabled: "${SWAGGER_ENABLED:-false}"
   ASPNETCORE_URLS: http://+:8100
   ConnectionStrings__Postgresql: "Host=postgres;Port=5432;Database=${MOTO_HUB_POSTGRES_DB:?Set MOTO_HUB_POSTGRES_DB in .env};Username=${POSTGRES_USER:?Set POSTGRES_USER in .env};Password=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}"
+  # Empty disables the projector, so a stack without the target engine still runs.
+  ConnectionStrings__TargetSchema: "Host=cockroachdb;Port=26257;Database=projecty;Username=root;SSL Mode=Disable"
   RabbitMQ__UserName: "${MOTO_HUB_RABBITMQ_USER:?Set MOTO_HUB_RABBITMQ_USER in .env}"
   RabbitMQ__Password: "${MOTO_HUB_RABBITMQ_PASSWORD:?Set MOTO_HUB_RABBITMQ_PASSWORD in .env}"
   Redis__ConnectionString: "redis:6379"
@@ -509,6 +511,8 @@ services:
       otel-collector:
         condition: service_healthy
       moto-hub-migrations:
+        condition: service_completed_successfully
+      cockroach-init:
         condition: service_completed_successfully
       rabbitmq:
         condition: service_healthy

--- a/services/MotoHub/MotoHub/Program.cs
+++ b/services/MotoHub/MotoHub/Program.cs
@@ -86,6 +86,7 @@ builder.Services.AddSingleton(new OutboxRelayOptions
 builder.Services.AddSingleton<IOutboxTransport, RabbitMqOutboxTransport>();
 builder.Services.AddSingleton<IRabbitMqConnectionProvider, RabbitMqConnectionProvider>();
 builder.Services.AddHostedService<OutboxRelay<ApplicationDbContext>>();
+builder.Services.AddHostedService<MotoHub.Services.MotorcycleProjector>();
 builder.Services.AddScoped<IRentalOperationService, RentalOperationService>();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>

--- a/services/MotoHub/MotoHub/Services/MotorcycleProjector.cs
+++ b/services/MotoHub/MotoHub/Services/MotorcycleProjector.cs
@@ -1,0 +1,110 @@
+using Microsoft.EntityFrameworkCore;
+using MotoHub.Data;
+using Npgsql;
+
+namespace MotoHub.Services;
+
+/// <summary>What a pass moved, and which rows the target schema would not take.</summary>
+public sealed record ProjectionResult(int Applied, IReadOnlyList<string> Rejected);
+
+/// <summary>
+/// Copies motorcycles into the target schema's <c>motorcycles</c> table.
+///
+/// rentals.motorcycle_id carries a foreign key to this table, so no rental can
+/// move to the target engine until the motorcycle it references is there. That
+/// makes this the first move of the migration rather than a part of it.
+///
+/// It reconciles rather than dual-writes on purpose. Nothing reads the target
+/// table yet, so lag costs nothing, while a synchronous second write would put
+/// a brand new datastore in the path of registering a motorcycle -- buying an
+/// availability risk to solve a problem that does not exist yet. Reconciling is
+/// also self-healing: a row missed during an outage is picked up on the next
+/// pass instead of needing a repair job.
+/// </summary>
+public sealed class MotorcycleProjector(
+    IServiceScopeFactory scopes,
+    IConfiguration config,
+    ILogger<MotorcycleProjector> log) : BackgroundService
+{
+    public static readonly TimeSpan Interval = TimeSpan.FromSeconds(30);
+
+    protected override async Task ExecuteAsync(CancellationToken token)
+    {
+        var target = config.GetConnectionString("TargetSchema");
+        if (string.IsNullOrWhiteSpace(target)) return;
+        while (!token.IsCancellationRequested)
+        {
+            try
+            {
+                using var scope = scopes.CreateScope();
+                var result = await ProjectAsync(
+                    scope.ServiceProvider.GetRequiredService<ApplicationDbContext>(), target, token);
+                log.LogDebug("Projected {Count} motorcycles into the target schema", result.Applied);
+                // Loud, and every pass. A row the target schema will not take is a row
+                // whose rentals cannot move either, so this must not decay into a line
+                // that was logged once at startup and scrolled away.
+                if (result.Rejected.Count > 0)
+                    log.LogError("Target schema rejected {Count} motorcycles: {Plates}",
+                        result.Rejected.Count, string.Join(", ", result.Rejected));
+            }
+            catch (Exception error) when (!token.IsCancellationRequested)
+            {
+                log.LogWarning(error, "Motorcycle projection delayed; retrying on the next pass");
+            }
+            await Task.Delay(Interval, token);
+        }
+    }
+
+    public static async Task<ProjectionResult> ProjectAsync(
+        ApplicationDbContext source, string target, CancellationToken token)
+    {
+        var motorcycles = await source.Motorcycles.AsNoTracking().ToListAsync(token);
+        if (motorcycles.Count == 0) return new ProjectionResult(0, []);
+
+        await using var dataSource = new NpgsqlDataSourceBuilder(target).Build();
+        await using var connection = await dataSource.OpenConnectionAsync(token);
+        var applied = 0;
+        var rejected = new List<string>();
+        foreach (var motorcycle in motorcycles)
+        {
+            // A row the target schema refuses -- a year outside its CHECK, an id that
+            // is not a UUID -- must not stop the rows behind it. It is reported and
+            // skipped, because the migration needs to know which rows disagree with
+            // the schema, and a projector that dies on the first one never finds out.
+            if (!Guid.TryParse(motorcycle.Id, out var id))
+            {
+                rejected.Add($"{motorcycle.LicensePlate} (id {motorcycle.Id} is not a UUID)");
+                continue;
+            }
+
+            await using var command = new NpgsqlCommand("""
+                INSERT INTO motorcycles (id, license_plate, model, year, registered_at, retired_at)
+                VALUES (@id, @plate, @model, @year, @registered, @retired)
+                ON CONFLICT (id) DO UPDATE SET
+                    license_plate = EXCLUDED.license_plate,
+                    model = EXCLUDED.model,
+                    year = EXCLUDED.year,
+                    registered_at = EXCLUDED.registered_at,
+                    retired_at = EXCLUDED.retired_at
+                """, connection);
+            command.Parameters.AddWithValue("id", id);
+            command.Parameters.AddWithValue("plate", motorcycle.LicensePlate);
+            command.Parameters.AddWithValue("model", (object?)motorcycle.Model ?? DBNull.Value);
+            command.Parameters.AddWithValue("year", motorcycle.Year);
+            command.Parameters.AddWithValue("registered", DateTime.SpecifyKind(motorcycle.RegistrationDate, DateTimeKind.Utc));
+            command.Parameters.AddWithValue("retired", motorcycle.RetiredAtUtc is { } retired
+                ? DateTime.SpecifyKind(retired, DateTimeKind.Utc)
+                : DBNull.Value);
+            try
+            {
+                applied += await command.ExecuteNonQueryAsync(token);
+            }
+            catch (PostgresException refused) when (refused.SqlState is
+                PostgresErrorCodes.CheckViolation or PostgresErrorCodes.UniqueViolation)
+            {
+                rejected.Add($"{motorcycle.LicensePlate} ({refused.SqlState})");
+            }
+        }
+        return new ProjectionResult(applied, rejected);
+    }
+}

--- a/services/MotoHub/MotoHubTests/Integration/PostgreSql/MotorcycleProjectorTests.cs
+++ b/services/MotoHub/MotoHubTests/Integration/PostgreSql/MotorcycleProjectorTests.cs
@@ -1,0 +1,129 @@
+using Microsoft.EntityFrameworkCore;
+using MotoHub.Data;
+using MotoHub.Models;
+using MotoHub.Services;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace MotoHubTests.Integration.PostgreSql;
+
+/// <summary>
+/// The target schema is applied here from deploy/db/sql/001_schema.sql itself, not
+/// from a copy: a projector that agrees with a transcription of the schema and
+/// disagrees with the schema is exactly the failure this has to catch. The engine
+/// is PostgreSQL rather than CockroachDB because schema-portability.yml already
+/// proves the same file produces the same schema on both.
+/// </summary>
+public sealed class MotorcycleProjectorTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _source = new PostgreSqlBuilder("postgres:17.11-alpine3.24")
+        .WithDatabase("moto_hub_source").WithUsername("projecty").Build();
+    private readonly PostgreSqlContainer _target = new PostgreSqlBuilder("postgres:17.11-alpine3.24")
+        .WithDatabase("projecty").WithUsername("projecty").Build();
+    private ApplicationDbContext _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        await Task.WhenAll(_source.StartAsync(), _target.StartAsync());
+        _context = new ApplicationDbContext(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(_source.GetConnectionString()).Options);
+        await _context.Database.MigrateAsync();
+
+        var schema = await File.ReadAllTextAsync(Path.Combine(
+            AppContext.BaseDirectory, "target-schema", "001_schema.sql"));
+        // The GRANTs name roles that 000_bootstrap creates; the projector does not
+        // exercise them and this container has no such roles.
+        schema = string.Join('\n', schema.Split('\n')
+            .Where(line => !line.TrimStart().StartsWith("GRANT", StringComparison.Ordinal)));
+        await using var connection = new NpgsqlConnection(_target.GetConnectionString());
+        await connection.OpenAsync();
+        await using var command = new NpgsqlCommand(schema, connection);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    public Task DisposeAsync() =>
+        Task.WhenAll(_source.DisposeAsync().AsTask(), _target.DisposeAsync().AsTask());
+
+    private async Task<List<(Guid Id, string Plate, DateTime? Retired)>> TargetRows()
+    {
+        await using var connection = new NpgsqlConnection(_target.GetConnectionString());
+        await connection.OpenAsync();
+        await using var command = new NpgsqlCommand(
+            "SELECT id, license_plate, retired_at FROM motorcycles ORDER BY license_plate", connection);
+        await using var reader = await command.ExecuteReaderAsync();
+        var rows = new List<(Guid, string, DateTime?)>();
+        while (await reader.ReadAsync())
+            rows.Add((reader.GetGuid(0), reader.GetString(1), reader.IsDBNull(2) ? null : reader.GetDateTime(2)));
+        return rows;
+    }
+
+    private Motorcycle Add(string plate, int year = 2026, string? id = null)
+    {
+        var motorcycle = new Motorcycle
+        {
+            Id = id ?? Guid.NewGuid().ToString(),
+            Year = year,
+            Model = "Projection proof",
+            LicensePlate = plate,
+            RegistrationDate = DateTime.UtcNow
+        };
+        _context.Motorcycles.Add(motorcycle);
+        return motorcycle;
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ProjectionFillsTheTableRentalsWillReference()
+    {
+        Add("PRJ-0001");
+        Add("PRJ-0002");
+        await _context.SaveChangesAsync();
+
+        var result = await MotorcycleProjector.ProjectAsync(_context, _target.GetConnectionString(), default);
+
+        Assert.Equal(2, result.Applied);
+        Assert.Empty(result.Rejected);
+        Assert.Equal(["PRJ-0001", "PRJ-0002"], (await TargetRows()).Select(row => row.Plate));
+    }
+
+    // The projector runs every pass, so it re-reads rows it has already written.
+    // If that were an insert rather than an upsert, the second pass would fail on
+    // the primary key and the projection would never converge.
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task RepeatedPassesConvergeInsteadOfConflicting()
+    {
+        var motorcycle = Add("PRJ-0003");
+        await _context.SaveChangesAsync();
+
+        await MotorcycleProjector.ProjectAsync(_context, _target.GetConnectionString(), default);
+        motorcycle.RetiredAtUtc = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        await _context.SaveChangesAsync();
+        var second = await MotorcycleProjector.ProjectAsync(_context, _target.GetConnectionString(), default);
+
+        Assert.Equal(1, second.Applied);
+        var row = Assert.Single(await TargetRows());
+        Assert.Equal("PRJ-0003", row.Plate);
+        Assert.NotNull(row.Retired);
+    }
+
+    // A row the target schema will not take is a row whose rentals cannot move
+    // either. It has to be named, and it must not stop the rows behind it.
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task RowsTheSchemaRefusesAreReportedWithoutStoppingTheRest()
+    {
+        Add("PRJ-0004", year: 1800);
+        Add("PRJ-0005", id: "not-a-uuid");
+        Add("PRJ-0006");
+        await _context.SaveChangesAsync();
+
+        var result = await MotorcycleProjector.ProjectAsync(_context, _target.GetConnectionString(), default);
+
+        Assert.Equal(1, result.Applied);
+        Assert.Equal("PRJ-0006", Assert.Single(await TargetRows()).Plate);
+        Assert.Equal(2, result.Rejected.Count);
+        Assert.Contains(result.Rejected, entry => entry.StartsWith("PRJ-0004", StringComparison.Ordinal));
+        Assert.Contains(result.Rejected, entry => entry.Contains("not a UUID", StringComparison.Ordinal));
+    }
+}

--- a/services/MotoHub/MotoHubTests/MotoHubTests.csproj
+++ b/services/MotoHub/MotoHubTests/MotoHubTests.csproj
@@ -30,4 +30,8 @@
     <ProjectReference Include="..\MotoHub\MotoHub.csproj" />
   </ItemGroup>
 
+<ItemGroup>
+    <!-- The projector is tested against the schema file itself, never a copy. -->
+    <Content Include="../../../deploy/db/sql/001_schema.sql" Link="target-schema/001_schema.sql" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Refs #135 — this is **PR-0 of three**, the prerequisite the issue depends on without naming. It moves no rental and carries no data risk.

## Why this exists

Two facts collided while planning #135.

**CockroachDB is not in the stack.** #131 replaced `deploy/base/compose.yaml` — the fourteen-container platform — with a five-line include of the legacy compose. That connected the two halves, and took the target engine out of the running topology with it. The target schema has had nothing to run on since.

**Nothing writes to the target `motorcycles` table.** MotoHub's motorcycles live in its own Postgres, in a different table entirely. And `rentals.motorcycle_id` carries `REFERENCES motorcycles (id)` — so the first rental insert on the new engine fails on the foreign key. Rentals cannot move before motorcycles do.

Dropping or deferring that foreign key is not an option: it is the reason #134 replaces `license_plate` with `motorcycle_id` as the reference. Weakening it now would hollow out the migration it is meant to enable.

## What is here

- **CockroachDB back in the application topology**, with `cockroach-init` applying `000_bootstrap.cockroach.sql` and `001_schema.sql`. The definition is recovered from `344a883`, folded into the single compose the stack uses today.
- **A motorcycle projector in MotoHub**, filling the target `motorcycles` table.

It **reconciles rather than dual-writes**, deliberately. Nothing reads the target table yet, so lag costs nothing — while a synchronous second write would put a brand new datastore in the path of registering a motorcycle, buying an availability risk to solve a problem that does not exist yet. Reconciling also heals itself: a row missed during an outage is picked up on the next pass rather than by a repair job. An empty connection string disables it, so a stack without the target engine still runs.

A row the target schema will not take is a row whose rentals cannot move either, so it is **named by plate and reported every pass**, and it does not stop the rows behind it.

## Verification

The engine was brought up and exercised, not inspected:

| Check | Result |
|---|---|
| Target schema applied | `inbox`, `motorcycles`, `outbox`, `rentals` created |
| `deploy/db/tests/double_booking_setup.sql` | accepted |
| `deploy/db/tests/double_booking_conflict.sql` | **refused** by `one_active_rental_per_motorcycle` |
| `deploy/db/tests/double_booking_release.sql` | accepted — the partial predicate holds |
| MotoHub suite | 69/69 (was 66; +3) |

The projector tests apply `deploy/db/sql/001_schema.sql` **itself**, not a transcription — a projector that agrees with a copy of the schema and disagrees with the schema is the failure worth catching. They prove a repeated pass converges instead of conflicting on the primary key, and that a refused row is reported by plate while the rest still land. The engine there is PostgreSQL because `schema-portability.yml` already proves the same file yields the same schema on both.

## What comes next

- **PR-1** — dual write of rentals, reads still on Mongo, both uniqueness guarantees live at once.
- **PR-2** — backfill, row counts, sampled field-by-field comparison.
- **PR-3** — read cutover, drop the collection, `MongoDB.Driver` out of the project, `mongodb` out of the compose.

The quarantine migrations are a PR-2 question. Note for that review: `MongoRentalIndexInitializer` holds **seven** routines, not the three the issue names — `ClassifyLegacyRentalsAsync`, `ReconcileMotorcycleClaimsAsync`, `RemoveStaleRentalClaimsAsync` and `EnsureHistoricalMotorcycleReferencesAsync` are also there, and each needs porting or a written reason for being dropped.

## One thing to watch

This adds a container to every stack that builds from `docker-compose.yml`, including the benchmark stack the `Rental load gate` runs. That gate already fails intermittently on `mongodb` being reported unhealthy — its probe spawns `mongosh` under the same 5s budget `pg_isready` gets — and more containers on the runner makes that contention worse, not better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)