### PR TITLE
feat(rental): backfill the rentals and compare the two stores

### DIFF
--- a/services/RentalOperations/RentalOperations/Repository/RentalMigration.cs
+++ b/services/RentalOperations/RentalOperations/Repository/RentalMigration.cs
@@ -1,0 +1,130 @@
+using System.Globalization;
+using MongoDB.Driver;
+using RentalOperations.Data;
+using RentalOperations.Model;
+using Npgsql;
+
+namespace RentalOperations.Repository;
+
+/// <summary>What the backfill moved, and what it could not.</summary>
+public sealed record BackfillReport(int Total, int Applied, IReadOnlyList<string> Refused);
+
+/// <summary>A field the two stores disagree about, for one rental.</summary>
+public sealed record FieldDivergence(string RentalId, string Field, string Mongo, string Target);
+
+/// <summary>
+/// What the comparison found. The cutover is declared on this being clean, so it
+/// reports absence and disagreement separately: a row that never arrived and a row
+/// that arrived wrong fail for different reasons and are fixed in different places.
+/// </summary>
+public sealed record ComparisonReport(
+    int MongoRows, int TargetRows, IReadOnlyList<string> Missing, IReadOnlyList<FieldDivergence> Divergent)
+{
+    public bool IsClean => Missing.Count == 0 && Divergent.Count == 0 && MongoRows == TargetRows;
+}
+
+/// <summary>
+/// Moves the rentals Mongo already holds into the target schema, and then checks
+/// that the two stores agree.
+///
+/// Three fields of the document have no column, and each is dropped for a reason
+/// that holds on its own rather than because the table happens to lack it:
+///
+/// <list type="bullet">
+/// <item><c>MotorcycleLicencePlate</c> — the target references motorcycle_id and
+/// reaches the plate by join. A mutable business key is exactly what ADR 0004 took
+/// out of the reference, so carrying it back would undo the change.</item>
+/// <item><c>AdditionalCostsOrSavings</c> — decomposition, not information. Settlement
+/// computes final_cost as init_cost plus this, so it is exactly
+/// <c>final_cost - init_cost</c> and survives as arithmetic.</item>
+/// <item><c>StatusMessage</c> — a sentence rendered from whether the return was early,
+/// late or on time, which ends_at and predicted_ends_at already say. Settlement is
+/// leaving for billing (#137) and the sentence belongs with it, not in the store.</item>
+/// </list>
+///
+/// The <c>Quarantined</c> status is the fourth, and it is refused rather than dropped:
+/// see <see cref="RentalRowMapper.TryMapStatus"/>. Quarantine is a migration-time
+/// record — "this needs review" — and rewriting it as cancelled would assert a
+/// decision nobody made. It stays a Mongo-side concept that ends with the migration,
+/// and a row still carrying it blocks the cutover by name instead of vanishing.
+/// </summary>
+public static class RentalMigration
+{
+    public static async Task<BackfillReport> BackfillAsync(
+        MongoDbContext db, RentalTargetWriter target, CancellationToken token)
+    {
+        var rentals = await db.Database.GetCollection<Rental>("Rentals")
+            .Find(FilterDefinition<Rental>.Empty).ToListAsync(token);
+        var refused = new List<string>();
+        var applied = 0;
+        foreach (var rental in rentals)
+        {
+            if (RentalRowMapper.Refusal(rental) is { } refusal)
+            {
+                refused.Add($"{refusal.RentalId}: {refusal.Reason}");
+                continue;
+            }
+            if (await target.MirrorAsync(rental, token)) applied++;
+            else refused.Add($"{rental._id}: target store rejected the row");
+        }
+        return new BackfillReport(rentals.Count, applied, refused);
+    }
+
+    public static async Task<ComparisonReport> CompareAsync(
+        MongoDbContext db, NpgsqlDataSource target, CancellationToken token)
+    {
+        var rentals = await db.Database.GetCollection<Rental>("Rentals")
+            .Find(FilterDefinition<Rental>.Empty).ToListAsync(token);
+
+        var rows = new Dictionary<Guid, (string Rider, Guid Motorcycle, DateTime? Ends, decimal Init, decimal? Final, string Status)>();
+        await using (var connection = await target.OpenConnectionAsync(token))
+        {
+            await using var command = new NpgsqlCommand(
+                "SELECT id, rider_id, motorcycle_id, ends_at, init_cost, final_cost, status FROM rentals", connection);
+            await using var reader = await command.ExecuteReaderAsync(token);
+            while (await reader.ReadAsync(token))
+            {
+                rows[reader.GetGuid(0)] = (reader.GetString(1), reader.GetGuid(2),
+                    reader.IsDBNull(3) ? null : reader.GetDateTime(3), reader.GetDecimal(4),
+                    reader.IsDBNull(5) ? null : reader.GetDecimal(5), reader.GetString(6));
+            }
+        }
+
+        var missing = new List<string>();
+        var divergent = new List<FieldDivergence>();
+        foreach (var rental in rentals)
+        {
+            if (rental._id is null) continue;
+            var id = RentalRowMapper.ToRowId(rental._id.Value);
+            if (!rows.TryGetValue(id, out var row))
+            {
+                missing.Add(rental._id.Value.ToString());
+                continue;
+            }
+            var name = rental._id.Value.ToString();
+            void Check(string field, string mongo, string stored)
+            {
+                if (!string.Equals(mongo, stored, StringComparison.Ordinal))
+                    divergent.Add(new FieldDivergence(name, field, mongo, stored));
+            }
+            Check("rider_id", rental.UserId, row.Rider);
+            Check("motorcycle_id", rental.MotorcycleId, row.Motorcycle.ToString());
+            Check("init_cost", rental.InitCost.ToString("0.00", CultureInfo.InvariantCulture), row.Init.ToString("0.00", CultureInfo.InvariantCulture));
+            Check("ends_at", Moment(rental.EndDate), Moment(row.Ends));
+            Check("final_cost", rental.FinalCost == 0m ? "-" : rental.FinalCost.ToString("0.00", CultureInfo.InvariantCulture),
+                row.Final is { } stored ? stored.ToString("0.00", CultureInfo.InvariantCulture) : "-");
+            RentalRowMapper.TryMapStatus(rental.Status, out var expected);
+            Check("status", expected.Length == 0 ? rental.Status.ToString() : expected, row.Status);
+        }
+        return new ComparisonReport(rentals.Count, rows.Count, missing, divergent);
+    }
+
+    // Every value is rendered under the invariant culture: a divergence report that
+    // reads differently on a machine with a different locale is not a report, and
+    // the same number would print two ways depending on who ran the comparison.
+    // Compared to the second: Mongo keeps milliseconds the column does not, and a
+    // difference that fine is a formatting artefact, not a divergence worth blocking on.
+    private static string Moment(DateTime? value) => value is { } moment
+        ? DateTime.SpecifyKind(moment, DateTimeKind.Utc).ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)
+        : "-";
+}

--- a/services/RentalOperations/RentalOperationsTests/Integration/MongoDb/RentalMigrationTests.cs
+++ b/services/RentalOperations/RentalOperationsTests/Integration/MongoDb/RentalMigrationTests.cs
@@ -1,0 +1,195 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Driver;
+using Npgsql;
+using RentalOperations.Data;
+using RentalOperations.Model;
+using RentalOperations.Repository;
+using Testcontainers.MongoDb;
+using Testcontainers.PostgreSql;
+
+namespace RentalOperationsTests.Integration.MongoDb;
+
+/// <summary>
+/// The backfill and the comparison that gates the cutover, against both stores.
+/// The target schema is applied from deploy/db/sql/001_schema.sql itself.
+/// </summary>
+public sealed class RentalMigrationTests : IAsyncLifetime
+{
+    private const string DatabaseName = "rental_migration_tests";
+    private readonly MongoDbContainer _mongo = new MongoDbBuilder("mongo:8.0").Build();
+    private readonly PostgreSqlContainer _target = new PostgreSqlBuilder("postgres:17.11-alpine3.24")
+        .WithDatabase("projecty").WithUsername("projecty").Build();
+    private MongoDbContext _context = null!;
+    private NpgsqlDataSource _dataSource = null!;
+    private RentalTargetWriter _writer = null!;
+    private IMongoCollection<Rental> _rentals = null!;
+    private Guid _motorcycle;
+
+    public async Task InitializeAsync()
+    {
+        await Task.WhenAll(_mongo.StartAsync(), _target.StartAsync());
+        _context = new MongoDbContext(_mongo.GetConnectionString(), DatabaseName);
+        _rentals = _context.Database.GetCollection<Rental>("Rentals");
+
+        var schema = await File.ReadAllTextAsync(Path.Combine(
+            AppContext.BaseDirectory, "target-schema", "001_schema.sql"));
+        schema = string.Join('\n', schema.Split('\n')
+            .Where(line => !line.TrimStart().StartsWith("GRANT", StringComparison.Ordinal)));
+        await Execute(schema);
+
+        _motorcycle = Guid.NewGuid();
+        await Execute("INSERT INTO motorcycles (id, license_plate, model, year) VALUES ('"
+            + _motorcycle + "', 'MIG-0001', 'Migration', 2026);");
+
+        _dataSource = NpgsqlDataSource.Create(_target.GetConnectionString());
+        _writer = new RentalTargetWriter(_dataSource, NullLogger<RentalTargetWriter>.Instance);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _dataSource.DisposeAsync();
+        await Task.WhenAll(_mongo.DisposeAsync().AsTask(), _target.DisposeAsync().AsTask());
+    }
+
+    private async Task Execute(string sql)
+    {
+        await using var connection = new NpgsqlConnection(_target.GetConnectionString());
+        await connection.OpenAsync();
+        await using var command = new NpgsqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private async Task<Rental> Seed(RentalStatus status = RentalStatus.Active, decimal final = 0m)
+    {
+        var rental = new Rental
+        {
+            MotorcycleLicencePlate = "MIG-0001",
+            MotorcycleId = _motorcycle.ToString(),
+            UserId = "rider-1",
+            StartDate = DateTime.UtcNow.Date.AddDays(1),
+            PredictedEndDate = DateTime.UtcNow.Date.AddDays(8),
+            InitCost = 210.25m,
+            FinalCost = final,
+            Status = status
+        };
+        await _rentals.InsertOneAsync(rental);
+        return rental;
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task BackfillMovesWhatMongoAlreadyHolds()
+    {
+        await Seed();
+        await Seed(RentalStatus.Completed, final: 180m);
+
+        var report = await RentalMigration.BackfillAsync(_context, _writer, CancellationToken.None);
+
+        Assert.Equal(2, report.Total);
+        Assert.Equal(2, report.Applied);
+        Assert.Empty(report.Refused);
+    }
+
+    // Running it twice must not double anything: the identity is derived from the
+    // document, so the second pass updates the same rows it wrote the first time.
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task BackfillIsSafeToRunAgain()
+    {
+        await Seed();
+
+        await RentalMigration.BackfillAsync(_context, _writer, CancellationToken.None);
+        var second = await RentalMigration.BackfillAsync(_context, _writer, CancellationToken.None);
+        var comparison = await RentalMigration.CompareAsync(_context, _dataSource, CancellationToken.None);
+
+        Assert.Equal(1, second.Applied);
+        Assert.Equal(1, comparison.TargetRows);
+        Assert.True(comparison.IsClean);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ComparisonIsCleanOnceBothStoresAgree()
+    {
+        await Seed();
+        await Seed(RentalStatus.Completed, final: 180m);
+        await RentalMigration.BackfillAsync(_context, _writer, CancellationToken.None);
+
+        var comparison = await RentalMigration.CompareAsync(_context, _dataSource, CancellationToken.None);
+
+        Assert.True(comparison.IsClean);
+        Assert.Equal(2, comparison.MongoRows);
+        Assert.Equal(2, comparison.TargetRows);
+    }
+
+    // A comparison that cannot fail is not a gate. This changes one store behind the
+    // other's back, exactly as a missed dual write would, and the report has to say so.
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ComparisonNamesAFieldTheStoresDisagreeAbout()
+    {
+        var rental = await Seed(RentalStatus.Completed, final: 180m);
+        await RentalMigration.BackfillAsync(_context, _writer, CancellationToken.None);
+        await Execute("UPDATE rentals SET final_cost = 999.00;");
+
+        var comparison = await RentalMigration.CompareAsync(_context, _dataSource, CancellationToken.None);
+
+        Assert.False(comparison.IsClean);
+        var divergence = Assert.Single(comparison.Divergent);
+        Assert.Equal("final_cost", divergence.Field);
+        Assert.Equal(rental._id!.Value.ToString(), divergence.RentalId);
+        Assert.Equal("180.00", divergence.Mongo);
+        Assert.Equal("999.00", divergence.Target);
+    }
+
+    // Absence and disagreement fail for different reasons and are fixed in different
+    // places, so the report keeps them apart rather than counting one number.
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ComparisonSeparatesARowThatNeverArrivedFromOneThatArrivedWrong()
+    {
+        var rental = await Seed();
+
+        var comparison = await RentalMigration.CompareAsync(_context, _dataSource, CancellationToken.None);
+
+        Assert.False(comparison.IsClean);
+        Assert.Empty(comparison.Divergent);
+        Assert.Equal(rental._id!.Value.ToString(), Assert.Single(comparison.Missing));
+    }
+
+    // Quarantine does not cross into the target schema. The backfill refuses the row
+    // by name so the cutover cannot be declared while one still exists, rather than
+    // rewriting it as cancelled and asserting a decision nobody made.
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task BackfillRefusesAQuarantinedRentalByName()
+    {
+        var rental = await Seed(RentalStatus.Quarantined);
+
+        var report = await RentalMigration.BackfillAsync(_context, _writer, CancellationToken.None);
+
+        Assert.Equal(0, report.Applied);
+        var refusal = Assert.Single(report.Refused);
+        Assert.Contains(rental._id!.Value.ToString(), refusal, StringComparison.Ordinal);
+        Assert.Contains("Quarantined", refusal, StringComparison.Ordinal);
+    }
+
+    // The dropped column has to be recoverable for dropping it to be honest:
+    // AdditionalCostsOrSavings is exactly final_cost - init_cost.
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task TheDroppedSettlementColumnIsArithmeticOnTwoThatRemain()
+    {
+        var rental = await Seed(RentalStatus.Completed, final: 180m);
+        rental.AdditionalCostsOrSavings = rental.FinalCost - rental.InitCost;
+        await _rentals.ReplaceOneAsync(candidate => candidate._id == rental._id, rental);
+        await RentalMigration.BackfillAsync(_context, _writer, CancellationToken.None);
+
+        await using var connection = await _dataSource.OpenConnectionAsync();
+        await using var command = new NpgsqlCommand(
+            "SELECT final_cost - init_cost FROM rentals", connection);
+        var derived = (decimal)(await command.ExecuteScalarAsync())!;
+
+        Assert.Equal(rental.AdditionalCostsOrSavings, derived);
+    }
+}


### PR DESCRIPTION
Refs #135 — **PR-2 of three**, after [#174](https://github.com/iVega123/ProjectY/pull/174) and [#175](https://github.com/iVega123/ProjectY/pull/175). This is the step the cutover is declared on.

## What is here

**A backfill** that moves what Mongo already holds, and is safe to run again: the row identity is derived from the document, so a second pass updates the rows the first one wrote instead of doubling them.

**A comparison** that reports **absence and disagreement separately**. A row that never arrived and a row that arrived wrong fail for different reasons and are fixed in different places, so collapsing them into one number would hide which of the two you have.

## The four orphan fields, decided

Each is dropped for a reason that stands on its own — not because the table happens to lack a column:

| Field | Why it does not cross |
|---|---|
| `MotorcycleLicencePlate` | Reached by join. Carrying it back would undo exactly what ADR 0004 took out of the reference. |
| `AdditionalCostsOrSavings` | Decomposition, not information. Settlement computes `final_cost = init_cost + this`, so it **is** `final_cost - init_cost`. |
| `StatusMessage` | A sentence rendered from early / late / on time, which `ends_at` and `predicted_ends_at` already say. Settlement leaves for `billing` (#137) and the sentence goes with it. |
| `Quarantined` status | **Refused, not dropped.** It records "this needs review"; rewriting it as `cancelled` would assert a decision nobody made. |

The `AdditionalCostsOrSavings` claim is asserted as arithmetic, not as prose: a test backfills a settled rental and checks `final_cost - init_cost` against the dropped value.

Quarantine stays a Mongo-side concept that ends when the migration ends. A row still carrying it blocks the cutover **by name** rather than vanishing into a status that means something else. The target schema keeps the three statuses it was designed with.

## Verification

RentalOperations: **81/81** (was 74; +7).

The comparison is proven to be able to fail, which is the only thing that makes a gate worth having: one test changes `final_cost` in the target behind Mongo's back — exactly as a missed dual write would — and asserts the report names the rental, the field, and both values. Another seeds Mongo without backfilling and asserts the row is reported as *missing*, with zero divergences.

A bug the tests caught: the first version formatted decimals under the machine's culture, so the same number printed `180.00` or `180,00` depending on who ran the comparison. Everything is rendered under the invariant culture now.

## An honest note on what this proves

There is no production data behind this migration. The backfill, the comparison and the cutover gate are a rehearsal of the technique, exercised against seeded stores in tests rather than against rows that exist. That is worth saying plainly in the PR rather than letting the choreography imply otherwise — the engineering is real, the data risk it is guarding against is not.

It also means the quarantine question resolved itself: there are no quarantined rentals to adjudicate, so the strict reading costs nothing and the target schema stays as designed.

## Next

**PR-3** — read cutover, drop the collection, `MongoDB.Driver` out of the project, `mongodb` out of the compose.

Given there is no data to verify a soak against, PR-3 could reasonably be folded into this one. I kept it separate because the reason for slicing was reviewability, and that reason still holds — but say the word and the next one carries both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)