### PR TITLE
feat(billing): a liquidação ganha dono, e a nota entra na transação do inbox

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,12 @@
 !services/risk-pricing/**
 !services/console/
 !services/console/**
+!services/billing/
+!services/billing/**
+!deploy/
+!deploy/db/
+!deploy/db/sql/
+!deploy/db/sql/**
 **/node_modules/
 **/.next/
 **/__pycache__/
@@ -24,3 +30,5 @@
 **/.venv/
 **/bin/
 **/obj/
+**/.gradle/
+services/billing/build/

--- a/.github/workflows/billing.yml
+++ b/.github/workflows/billing.yml
@@ -1,0 +1,32 @@
+name: Billing
+on:
+  workflow_call:
+permissions: {contents: read}
+jobs:
+  billing:
+    runs-on: ubuntu-latest
+    defaults:
+      run: {working-directory: services/billing}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with: {distribution: temurin, java-version: '21'}
+      # Sem gradle-wrapper.jar no repositório.
+      #
+      # O wrapper serve para fixar a versão do Gradle para quem clona. Aqui ela
+      # já está fixa em dois lugares -- a imagem base do Dockerfile e a linha
+      # abaixo -- e o job "changes" recusa o PR se as duas divergirem. Isso
+      # troca um binário versionado por uma verificação em texto, que é a troca
+      # que este repositório vem fazendo em todo lugar.
+      - uses: gradle/actions/setup-gradle@v4
+        with: {gradle-version: '8.14.3'}
+      # ktlint é o `dotnet format --verify-no-changes` desta linguagem, e o teste
+      # de integração sobe um CockroachDB por Testcontainers -- o runner tem
+      # Docker, então ele roda de verdade e não como mock.
+      - run: gradle --no-daemon ktlintCheck test
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-billing
+          path: services/billing/build/reports/tests/test
+          if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,17 @@ jobs:
           docker compose --file docker-compose.yml --file docker-compose.polyglot.yml config --quiet --no-interpolate
           docker compose --file deploy/overlays/selfhost/compose.yaml config --quiet --no-interpolate
 
+      # O billing não versiona um gradle-wrapper.jar: a versão do Gradle está
+      # fixada na imagem base do Dockerfile e no workflow, e este passo é o que
+      # impede as duas de divergirem em silêncio -- que é a única coisa que o
+      # wrapper garantiria e este repositório ainda não tem.
+      - name: Validate the pinned Gradle version
+        shell: bash
+        run: |
+          set -euo pipefail
+          image=$(grep -m1 '^FROM gradle:' services/billing/Dockerfile | cut -d: -f2 | cut -d- -f1)
+          workflow=$(grep -m1 'gradle-version:' .github/workflows/billing.yml | tr -dc '0-9.')
+          test -n "$image" && test "$image" = "$workflow"
       - name: Validate spanmetrics dashboard contract
         shell: bash
         run: |
@@ -176,6 +187,8 @@ jobs:
               - 'services/telemetry/**'
               - 'services/risk-pricing/**'
               - 'services/console/**'
+              - 'services/billing/**'
+              - 'deploy/db/sql/**'
               - 'contracts/**'
               - '.github/workflows/*.yml'
               - '.dockerignore'
@@ -231,9 +244,11 @@ jobs:
           fi
 
           if [[ "$POLYGLOT_CHANGED" == "true" ]]; then
-            for service in media-guard telemetry risk-pricing console; do
+            for service in media-guard telemetry risk-pricing console billing; do
               context="services/$service"
-              if [[ "$service" == "risk-pricing" ]]; then context="."; fi
+              # risk-pricing e billing compilam da raiz: um gera de contracts/,
+              # o outro de contracts/ e deploy/db/sql.
+              if [[ "$service" == "risk-pricing" || "$service" == "billing" ]]; then context="."; fi
               image_matrix=$(jq --compact-output --arg service "$service" --arg context "$context" \
                 '.include += [{service: $service, image: $service, context: $context, dockerfile: ("services/" + $service + "/Dockerfile"), repository: ("ghcr.io/ivega123/projecty/" + $service)}]' \
                 <<< "$image_matrix")
@@ -263,6 +278,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.has_polyglot_changes == 'true'
     uses: ./.github/workflows/console.yml
+  billing-tests:
+    needs: changes
+    if: needs.changes.outputs.has_polyglot_changes == 'true'
+    uses: ./.github/workflows/billing.yml
 
   observability:
     name: Observability stack
@@ -663,6 +682,7 @@ jobs:
       - telemetry-tests
       - risk-tests
       - console-tests
+      - billing-tests
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -681,6 +701,7 @@ jobs:
           TELEMETRY_RESULT: ${{ needs.telemetry-tests.result }}
           RISK_RESULT: ${{ needs.risk-tests.result }}
           CONSOLE_RESULT: ${{ needs.console-tests.result }}
+          BILLING_RESULT: ${{ needs.billing-tests.result }}
           EVENT_NAME: ${{ github.event_name }}
           REF: ${{ github.ref }}
           HAS_IMAGE_CHANGES: ${{ needs.changes.outputs.has_image_changes }}
@@ -693,7 +714,7 @@ jobs:
           [[ "$RUST_RESULT" == "success" || "$RUST_RESULT" == "skipped" ]]
           [[ "$IMAGES_RESULT" == "success" || "$IMAGES_RESULT" == "skipped" ]]
           [[ "$SECRETS_RESULT" == "success" ]]
-          for result in "$MEDIA_RESULT" "$TELEMETRY_RESULT" "$RISK_RESULT" "$CONSOLE_RESULT"; do
+          for result in "$MEDIA_RESULT" "$TELEMETRY_RESULT" "$RISK_RESULT" "$CONSOLE_RESULT" "$BILLING_RESULT"; do
             [[ "$result" == "success" || "$result" == "skipped" ]]
           done
 

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ msbuild.wrn
 # Generated benchmark summaries (published evidence lives in docs/measurements)
 load/results/
 docs/images/console-test-failure.png
+
+# JVM build output (services/billing)
+**/.gradle/
+services/billing/build/

--- a/Tiltfile
+++ b/Tiltfile
@@ -146,9 +146,16 @@ if full:
             sync('services/risk-pricing', '/workspace'), restart_container(),
         ],
     )
+    # O billing compila da raiz, como os .NET: o Gradle gera as classes de
+    # contracts/events e o teste aplica deploy/db/sql. Sem live update -- uma
+    # troca a quente de classes na JVM daria menos do que custaria explicar.
+    docker_build(
+        'projecty/billing:dev', '.',
+        dockerfile = 'services/billing/Dockerfile', target = 'development',
+    )
     infra_resources += ['kafka', 'cassandra', 'schema-registry']
     setup_resources += ['kafka-init', 'cassandra-init', 'schema-init']
-    service_resources += ['telemetry', 'risk-pricing', 'console']
+    service_resources += ['telemetry', 'risk-pricing', 'console', 'billing']
 
 for resource in infra_resources:
     dc_resource(resource, labels = ['infra'])

--- a/deploy/db/sql/000_bootstrap.cockroach.sql
+++ b/deploy/db/sql/000_bootstrap.cockroach.sql
@@ -10,3 +10,4 @@ CREATE DATABASE IF NOT EXISTS projecty;
 -- Um papel por serviço, com permissão só no que lhe cabe (A2).
 CREATE USER IF NOT EXISTS rental_core;
 CREATE USER IF NOT EXISTS media_guard;
+CREATE USER IF NOT EXISTS billing;

--- a/deploy/db/sql/000_bootstrap.postgres.sql
+++ b/deploy/db/sql/000_bootstrap.postgres.sql
@@ -16,3 +16,8 @@ DO $$ BEGIN
     CREATE ROLE media_guard LOGIN;
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
+
+DO $$ BEGIN
+    CREATE ROLE billing LOGIN;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;

--- a/deploy/db/sql/003_billing.sql
+++ b/deploy/db/sql/003_billing.sql
@@ -1,0 +1,49 @@
+-- O que o billing precisa: a nota, e nada além dela.
+--
+-- Mesmo subconjunto portátil de 001 e 002 -- o CI aplica este arquivo ao
+-- CockroachDB e ao PostgreSQL, e o glob de scripts/verify-schema-portability.sh
+-- o inclui por existir, sem que ninguém precise citá-lo.
+--
+-- O billing divide `inbox` e `outbox` com o rental-core, de propósito. A coluna
+-- `consumer` do inbox é o que separa os dois consumidores da MESMA mensagem, e
+-- `aggregate_type` no outbox é o que separa quem publica o quê. Duas tabelas
+-- paralelas dariam o mesmo resultado ao custo de duas implementações do mesmo
+-- padrao para manter em sincronia.
+
+-- A liquidação em unidades menores, e não em DECIMAL(12,2) como `rentals`.
+--
+-- O motivo é o contrato: rental.closed carrega agreed_total_minor como inteiro,
+-- e invoice.issued devolve total_minor como inteiro. Guardar DECIMAL no meio
+-- criaria duas conversões -- uma na entrada, outra na saída -- e portanto dois
+-- lugares onde arredondar. A nota é o registro de um evento que já chegou em
+-- centavos; ela fica em centavos.
+CREATE TABLE IF NOT EXISTS invoices (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    rental_id        UUID NOT NULL,
+    rider_id         TEXT NOT NULL,
+    currency         TEXT NOT NULL,
+    plan_days        INT NOT NULL CHECK (plan_days > 0),
+    days_used        INT NOT NULL CHECK (days_used >= 0),
+    agreed_minor     BIGINT NOT NULL CHECK (agreed_minor >= 0),
+    adjustment_minor BIGINT NOT NULL,
+    total_minor      BIGINT NOT NULL CHECK (total_minor >= 0),
+    reason           TEXT NOT NULL,
+    rider_name       TEXT,
+    issued_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (total_minor = agreed_minor + adjustment_minor)
+);
+
+-- A segunda garantia, independente do inbox.
+--
+-- O inbox impede que a MESMA mensagem seja tratada duas vezes. Isto impede que
+-- o mesmo aluguel seja faturado duas vezes por mensagens DIFERENTES -- uma
+-- republicação com id novo, um replay a partir do offset zero depois de o
+-- inbox ter sido varrido pela retenção. As duas falham de formas diferentes e
+-- só uma delas o inbox cobre.
+CREATE UNIQUE INDEX IF NOT EXISTS one_invoice_per_rental ON invoices (rental_id);
+
+CREATE INDEX IF NOT EXISTS invoices_by_rider ON invoices (rider_id, issued_at DESC);
+
+GRANT USAGE ON SCHEMA public TO billing;
+GRANT SELECT, INSERT ON TABLE invoices TO billing;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE inbox, outbox TO billing;

--- a/docker-compose.polyglot.yml
+++ b/docker-compose.polyglot.yml
@@ -85,6 +85,31 @@ services:
     depends_on:
       kafka-init: {condition: service_completed_successfully}
       schema-init: {condition: service_completed_successfully}
+  billing:
+    image: projecty/billing:dev
+    build: {context: ., dockerfile: services/billing/Dockerfile}
+    networks: [projecty]
+    environment:
+      # Como o rental-core, o billing conecta como root. O papel `billing` e os
+      # seus GRANTs existem em 003_billing.sql; passar a usá-lo depende do
+      # GRANT CONNECT no bootstrap, que é a mesma dívida registrada no #134.
+      BILLING_DATABASE_URL: jdbc:postgresql://cockroachdb:26257/projecty?sslmode=disable&user=root
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      SCHEMA_REGISTRY_URL: http://schema-registry:8080/apis/ccompat/v7
+      OTEL_SERVICE_NAME: billing
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+      OTEL_METRICS_EXPORTER: otlp
+      OTEL_LOGS_EXPORTER: otlp
+    healthcheck:
+      test: [CMD, curl, --fail, --silent, http://localhost:8094/health/ready]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+    depends_on:
+      kafka-init: {condition: service_completed_successfully}
+      schema-init: {condition: service_completed_successfully}
+      cockroach-init: {condition: service_completed_successfully}
   kafka:
     image: apache/kafka:4.3.1
     networks: [projecty]

--- a/docs/adr/0009-exactly-once-effect.md
+++ b/docs/adr/0009-exactly-once-effect.md
@@ -36,6 +36,7 @@ identity, durability boundary, expiry, and failure response.
 | Relay | Outbox row and claim token | CockroachDB / PostgreSQL | A committed row remains retryable; concurrent relays do not own the same row |
 | Rider consumer | `(MessageId, ConsumerName)` | PostgreSQL inbox transaction | Inbox record and relational domain effect commit once |
 | Rental consumer | `(message_id, consumer)` | Target-schema inbox row | One active handler lease; completed messages are suppressed |
+| Settlement consumer | `(message_id, consumer)` and `rental_id` | Target-schema transaction | Inbox row, invoice, and outgoing event commit once, together |
 | HTTP retry | Service, authenticated caller, and `Idempotency-Key` | Redis AOF | Same fingerprint replays; a different fingerprint is rejected for 24 hours |
 
 <a id="database-serialized-rental-claim"></a>
@@ -123,6 +124,28 @@ Until #135 this was a MongoDB inbox document, and the idempotent handler was
 the licence-plate rewrite. Both are gone: a rental references `motorcycle_id`,
 so there is no copied plate left to rewrite.
 
+<a id="settlement-inbox"></a>
+## Settlement inbox: the effect inside the transaction
+
+billing consumes `rental.closed` and writes the inbox row, the invoice, and the
+`invoice.issued` outbox row in one transaction. There is no claim lease, no
+handler running between a claim and a completion, and therefore no crash window
+of the kind the rental inbox above lives with. Crashing anywhere before the
+commit leaves the message untreated and the redelivery settles it; crashing
+after leaves both the invoice and its inbox row.
+
+This is the same promise as the PostgreSQL transactional inbox, made in a
+different runtime and against the target schema. It is worth stating separately
+because it is the version of the promise where duplication costs money rather
+than a recomputed projection, and because it crosses a process and language
+boundary: billing shares no transaction, connection pool, or runtime with the
+producer, so it can only hold if the outbox and inbox contract is real.
+
+A second, independent guard sits under it. The inbox deduplicates *messages*;
+`one_invoice_per_rental` deduplicates *rentals*. They fail differently — a
+replay from offset zero after inbox retention has swept the row carries a new
+message id and passes the first gate — and only the second one refuses it.
+
 <a id="http-idempotency"></a>
 ## HTTP idempotency
 
@@ -198,7 +221,7 @@ acknowledge conflicting writes outside its configured consistency model.
 | After commit, before publish | Domain state exists; pending outbox row publishes after recovery |
 | After broker accept, before `PublishedAtUtc` | Message may be published again; inbox suppresses the duplicate effect |
 | During PostgreSQL inbox handler | Inbox and relational effect roll back together |
-| After an inbox handler effect, before inbox completion | Redelivery occurs; only an idempotent handler is safe |
+| After an inbox handler effect, before inbox completion | Redelivery occurs; only an idempotent handler is safe. Does not arise in billing, whose effect and inbox row share the commit |
 | After HTTP effect, before response persistence | Redis retains `unknown`; the same key never executes again during retention |
 
 ## What is deliberately not promised
@@ -216,7 +239,9 @@ acknowledge conflicting writes outside its configured consistency model.
   substitute for one.
 - **Not arbitrary inbox effect safety.** The rental inbox claims a row rather
   than committing with its handler, so it requires an idempotent effect after a
-  crash window.
+  crash window. The RiderManager and billing inboxes do commit with their
+  handlers and carry no such window; the property belongs to the consumer, not
+  to the pattern's name.
 - **Not permanent deduplication.** HTTP and inbox records expire.
 - **Not protection for requests without `Idempotency-Key`.** Those requests
   intentionally bypass Redis.
@@ -227,7 +252,8 @@ acknowledge conflicting writes outside its configured consistency model.
 
 ## Executable proof matrix
 
-Every proof carries a `Guarantee` trait that points back to the paragraph above.
+Every proof carries a `Guarantee` trait — a JUnit `@Tag` in billing — that points
+back to the paragraph above.
 All database and Redis proofs use real Testcontainers; the transport is replaced
 only where the test must deterministically stop or observe a publish.
 
@@ -244,6 +270,9 @@ only where the test must deterministically stop or observe a publish.
 | [PostgreSQL inbox](#transactional-inbox) | [`ImageRedelivery_UsesInboxAndCallsIdempotentUploadOnce`](../../services/RiderManager/RiderManagerTests/Integration/PostgreSql/InboxProcessorTests.cs) | Completed image messages are handled again |
 | [Rental inbox](#inbox-convergence) | [`SameMessageDeliveredTwice_ExecutesHandlerOnce`](../../services/rental-core/RentalCoreTests/Rentals/Integration/Database/InboxProcessorTests.cs) | Completed inbox rows are claimable |
 | [Rental inbox](#inbox-convergence) | [`CrashAfterIdempotentEffect_RedeliveryConvergesAndCompletesInbox`](../../services/rental-core/RentalCoreTests/Rentals/Integration/Database/InboxProcessorTests.cs) | A crash cannot be reclaimed or the handler is not idempotent |
+| [Settlement inbox](#settlement-inbox) | [`a mesma mensagem duas vezes emite uma nota so`](../../services/billing/src/test/kotlin/projecty/billing/ExactlyOnceTest.kt) | The inbox row stops sharing the invoice transaction |
+| [Settlement inbox](#settlement-inbox) | [`nota recusada pelo banco nao deixa a mensagem marcada como tratada`](../../services/billing/src/test/kotlin/projecty/billing/ExactlyOnceTest.kt) | A refused invoice still marks the message handled |
+| [Settlement inbox](#settlement-inbox) | [`mensagem nova para aluguel ja faturado nao emite a segunda nota`](../../services/billing/src/test/kotlin/projecty/billing/ExactlyOnceTest.kt) | `one_invoice_per_rental` is removed |
 | [HTTP idempotency](#http-idempotency) | [`ReplayingCreateWithSameKey_ReturnsOriginalResponseAndOneEffect`](../../services/RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs) | Completed responses are not stored |
 | [HTTP idempotency](#http-idempotency) | [`ReusingKeyWithDifferentBody_ReturnsUnprocessableEntity`](../../services/RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs) | Body fingerprints are ignored |
 | [HTTP idempotency](#http-idempotency) | [`ConcurrentRequestWithSameKey_ReturnsConflictUntilFirstCompletes`](../../services/RiderManager/RiderManagerTests/Integration/Redis/IdempotencyMiddlewareTests.cs) | Atomic Redis claiming is removed |

--- a/docs/runbooks/polyglot-services.md
+++ b/docs/runbooks/polyglot-services.md
@@ -113,6 +113,16 @@ returns HTTP 409 and does not persist its calculation. Reloading the rental or
 retrying settlement after completion returns the stored dates and costs; only
 the winning update enqueues `rental.closed`.
 
+The billing consumer separates a broken message from a broken dependency,
+because the two need opposite answers. Undecodable Protobuf and an event
+missing what a settlement needs are logged and skipped, and the batch still
+commits -- retrying them forever would stop the partition for every other
+rider. Anything else (the database down, a pool timeout) rewinds the batch to
+the last committed offsets and tries again, because dropping a good message
+would lose an invoice. A worker thread that dies anyway halts the process on
+purpose: a billing service that has stopped billing must not keep answering
+`/health/live` with 200.
+
 billing settles from what `rental.closed` carries and never calls back: the
 agreed total, the plan days and the three dates all travel on the event, so an
 invoice is issued with rental-core down. The invoice, the inbox row and the

--- a/docs/runbooks/polyglot-services.md
+++ b/docs/runbooks/polyglot-services.md
@@ -1,7 +1,8 @@
 # Original epic 10: running and verifying the four services
 
-The original scope is #73–#77. Identity/billing/additional BFF (#136–#138) and
-the strangler migration (#130) remain separate. The running topology is the
+The original scope is #73–#77. billing (#137) landed after it and runs in the
+same stack; identity and the BFF read composition (#136, #138) remain separate.
+The strangler migration (#130) is done. The running topology is the
 root Compose stack, extended by `docker-compose.polyglot.yml`.
 
 ## Start
@@ -81,6 +82,14 @@ requires; temporary compiler dependencies are removed after installation.
 * .NET: `dotnet test services/rental-core/RentalCore.sln` and
   `dotnet test services/RiderManager/RiderManager.sln` use isolated Testcontainers.
 * Console: `npm ci`, `npm test`, `npm run build` in services/console.
+* Kotlin: `gradle ktlintCheck test` in services/billing, with a JDK 21 and
+  Gradle 8.14.3 — there is no `gradlew` here; the version is pinned in the
+  Dockerfile and in the workflow, and CI refuses a PR where the two disagree.
+  The settlement tests are pure; `ExactlyOnceTest` starts a real CockroachDB
+  through Testcontainers and applies `deploy/db/sql` to it. Where the Docker
+  socket is not reachable from inside a container — Docker Desktop on Windows —
+  start one by hand and point the test at it with
+  `BILLING_TEST_COCKROACH=host:port`.
 
 The telemetry `test/soak.mjs` sends bursts through a real socket for 30 seconds
 by default. Its observed acceptance must remain at most one/second; Redis
@@ -103,6 +112,14 @@ guard: if another request has already closed the rental, the losing request
 returns HTTP 409 and does not persist its calculation. Reloading the rental or
 retrying settlement after completion returns the stored dates and costs; only
 the winning update enqueues `rental.closed`.
+
+billing settles from what `rental.closed` carries and never calls back: the
+agreed total, the plan days and the three dates all travel on the event, so an
+invoice is issued with rental-core down. The invoice, the inbox row and the
+`invoice.issued` outbox row share one transaction, so a crash cannot leave a
+message marked handled without its invoice. A replay that arrives with a new
+message id — after inbox retention swept the old row, say — passes the inbox and
+is refused by `one_invoice_per_rental` instead.
 
 Replacing or deleting a document may remove its object before a delayed
 `document.stored` event arrives. Only S3 `NoSuchKey` is consumed as failed

--- a/services/billing/.editorconfig
+++ b/services/billing/.editorconfig
@@ -1,0 +1,3 @@
+[*.{kt,kts}]
+max_line_length = 120
+ktlint_standard_function-naming = disabled

--- a/services/billing/Dockerfile
+++ b/services/billing/Dockerfile
@@ -1,0 +1,40 @@
+# O contexto de build é a raiz do repositório: o serviço compila contra os
+# .proto de contracts/ e o teste aplica o schema de deploy/db/sql. Copiar os
+# dois para cá seria manter duas cópias do que o #132 e o ADR 0004 decidiram ter
+# uma só.
+FROM gradle:8.14.3-jdk21-alpine AS development
+WORKDIR /src/services/billing
+COPY contracts /src/contracts
+COPY deploy/db/sql /src/deploy/db/sql
+COPY services/billing/settings.gradle.kts services/billing/build.gradle.kts \
+     services/billing/gradle.properties services/billing/.editorconfig ./
+# As dependências antes do código: mexer numa linha de Kotlin não deve baixar o
+# Maven Central de novo.
+RUN gradle --no-daemon --quiet dependencies --configuration runtimeClasspath > /dev/null
+COPY services/billing/src ./src
+RUN gradle --no-daemon --quiet ktlintCheck classes
+ENTRYPOINT ["gradle", "--no-daemon", "run"]
+
+FROM development AS builder
+RUN gradle --no-daemon --quiet installDist
+
+FROM eclipse-temurin:21-jre-alpine AS final
+RUN apk upgrade --no-cache && apk add --no-cache curl
+WORKDIR /app
+# O agente do OpenTelemetry é a única parte da observabilidade que a JVM entrega
+# de graça: instrumenta JDBC, Kafka e HTTP sem uma linha de código. É o lugar
+# onde o custo do poliglota é MENOR, e não maior -- vale registrar, já que o
+# resto do repositório mede esse custo na direção oposta.
+#
+# O checksum está fixado pela mesma razão que o do librdkafka no risk-pricing:
+# um artefato baixado no build sem conferência é uma dependência que ninguém
+# revisou.
+RUN curl --fail --location --retry 3 --output /app/opentelemetry-javaagent.jar \
+      https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.31.1/opentelemetry-javaagent.jar \
+ && echo 'bbf83c151b6400709e2f225bdd07a04f839d9d13b8b93464241333fd25d3e3ba  /app/opentelemetry-javaagent.jar' | sha256sum -c -
+COPY --from=builder /src/services/billing/build/install/billing /app
+COPY contracts /event-contracts
+ENV JAVA_TOOL_OPTIONS="-javaagent:/app/opentelemetry-javaagent.jar"
+USER 65532:65532
+EXPOSE 8094
+ENTRYPOINT ["/app/bin/billing"]

--- a/services/billing/build.gradle.kts
+++ b/services/billing/build.gradle.kts
@@ -1,0 +1,60 @@
+plugins {
+    kotlin("jvm") version "2.1.20"
+    id("com.google.protobuf") version "0.9.4"
+    id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
+    application
+}
+
+repositories { mavenCentral() }
+
+kotlin { jvmToolchain(21) }
+
+application { mainClass.set("projecty.billing.MainKt") }
+
+// O contrato é o do repositório, não uma cópia.
+//
+// O #132 pôs os .proto em contracts/events e o registry os governa a partir
+// dali. Gerar as classes desta pasta -- e não de uma cópia sob services/billing
+// -- é o que faz uma mudança incompatível de contrato quebrar a compilação
+// deste serviço em vez de passar despercebida até o consumo.
+sourceSets {
+    main {
+        proto {
+            srcDir("../../contracts/events")
+            include("rental.proto", "invoice.proto")
+        }
+    }
+}
+
+// Só o gerador Java, que é o padrão do plugin -- declará-lo explicitamente
+// duplica o builtin e o build recusa.
+protobuf {
+    protoc { artifact = "com.google.protobuf:protoc:4.29.3" }
+}
+
+// As classes geradas não são escritas à mão e não têm por que passar pelo
+// mesmo pente que o código que é.
+ktlint {
+    filter { exclude { it.file.path.contains("generated") } }
+}
+
+dependencies {
+    implementation("org.apache.kafka:kafka-clients:3.9.1")
+    implementation("com.google.protobuf:protobuf-java:4.29.3")
+    implementation("org.postgresql:postgresql:42.7.5")
+    implementation("com.zaxxer:HikariCP:6.2.1")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.18.2")
+    implementation("org.slf4j:slf4j-api:2.0.16")
+    runtimeOnly("ch.qos.logback:logback-classic:1.5.16")
+
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testImplementation("org.testcontainers:cockroachdb:1.20.4")
+    testImplementation("org.testcontainers:junit-jupiter:1.20.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+    testLogging { events("passed", "skipped", "failed") }
+}

--- a/services/billing/gradle.properties
+++ b/services/billing/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.parallel=true
+org.gradle.caching=true
+kotlin.code.style=official

--- a/services/billing/settings.gradle.kts
+++ b/services/billing/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "billing"

--- a/services/billing/src/main/kotlin/projecty/billing/Events.kt
+++ b/services/billing/src/main/kotlin/projecty/billing/Events.kt
@@ -1,0 +1,88 @@
+package projecty.billing
+
+import project_y.events.Invoice.InvoiceIssued
+import project_y.events.Rental.RentalEvent
+import java.util.UUID
+
+/**
+ * O aluguel fechado, do jeito que o billing precisa dele.
+ *
+ * Tudo o que a liquidação usa chega no evento: o total combinado, os dias do
+ * plano, as três datas e o nome do piloto. Nada aqui pede uma consulta de volta
+ * ao rental-core -- que é o ponto do estado carregado do ADR 0015, e o que
+ * permite ao billing liquidar com o rental-core fora do ar.
+ */
+data class ClosedRental(
+    val eventId: String,
+    val rentalId: String,
+    val riderId: String,
+    val currency: String,
+    val agreedTotalMinor: Long,
+    val planDays: Int,
+    val startedAtMs: Long,
+    val predictedEndAtMs: Long,
+    val endedAtMs: Long,
+    val riderName: String?,
+    val traceParent: String?,
+) {
+    companion object {
+        fun from(
+            event: RentalEvent,
+            traceParent: String?,
+        ): ClosedRental {
+            require(event.eventId.isNotBlank()) { "rental.closed without an event id cannot be deduplicated." }
+            require(event.rentalId.isNotBlank()) { "rental.closed without a rental id cannot be settled." }
+            // Um fechamento sem data de fim não é um fechamento. Recusar aqui,
+            // por engano do produtor, é melhor do que faturar um aluguel contra
+            // a época Unix -- que seria uma nota com dezenas de milhares de
+            // diárias de atraso.
+            require(event.endedAtMs > 0L) { "rental.closed without ended_at_ms is not a settlement." }
+            require(event.planDays > 0) { "rental.closed without plan_days has no daily rate." }
+            return ClosedRental(
+                eventId = event.eventId,
+                rentalId = event.rentalId,
+                riderId = event.riderId,
+                currency = event.currency.ifBlank { "BRL" },
+                agreedTotalMinor = event.agreedTotalMinor,
+                planDays = event.planDays,
+                startedAtMs = event.startedAtMs,
+                predictedEndAtMs = event.predictedEndAtMs,
+                endedAtMs = event.endedAtMs,
+                riderName = event.riderName.ifBlank { null },
+                traceParent = traceParent,
+            )
+        }
+    }
+}
+
+object InvoiceEvents {
+    /**
+     * O id do evento é derivado do aluguel, não sorteado.
+     *
+     * Mesmo motivo do `RentalEventEnvelope` do rental-core: a relay republica
+     * quando cai entre o ProduceAsync e o UPDATE, e o inbox de quem consumir
+     * `invoice.issued` só reconhece a repetição se ela chegar com o mesmo id.
+     * Um UUID novo a cada publicação transformaria uma reentrega em um segundo
+     * fato.
+     */
+    fun eventId(rentalId: String): String = "$rentalId:invoice.issued:v1"
+
+    fun issued(
+        invoiceId: UUID,
+        rental: ClosedRental,
+        settled: Settlement.Settled,
+        occurredAtMs: Long = System.currentTimeMillis(),
+    ): InvoiceIssued {
+        val builder =
+            InvoiceIssued.newBuilder()
+                .setEventId(eventId(rental.rentalId))
+                .setInvoiceId(invoiceId.toString())
+                .setRentalId(rental.rentalId)
+                .setRiderId(rental.riderId)
+                .setOccurredAtMs(occurredAtMs)
+                .setTotalMinor(settled.totalMinor)
+                .setCurrency(rental.currency)
+        rental.riderName?.let { builder.riderName = it }
+        return builder.build()
+    }
+}

--- a/services/billing/src/main/kotlin/projecty/billing/InvoiceRelay.kt
+++ b/services/billing/src/main/kotlin/projecty/billing/InvoiceRelay.kt
@@ -1,0 +1,115 @@
+package projecty.billing
+
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.header.internals.RecordHeader
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.apache.kafka.common.serialization.StringSerializer
+import org.slf4j.LoggerFactory
+import java.util.Properties
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.sql.DataSource
+
+/**
+ * Publica no Kafka o que a transação da nota deixou no outbox.
+ *
+ * Mesma forma da relay do rental-core, e pelo mesmo motivo: marcar como
+ * publicado é um UPDATE separado, DEPOIS do envio. Cair entre os dois republica
+ * o mesmo evento com o mesmo `event_id`, que é o que o inbox de quem consumir
+ * reconhece. Marcar antes perderia o evento em silêncio.
+ *
+ * O filtro por `aggregate_type = 'invoice'` é o que permite dividir a tabela
+ * com o rental-core sem que uma relay publique os eventos da outra.
+ */
+class InvoiceRelay(
+    private val dataSource: DataSource,
+    bootstrapServers: String,
+    private val schemas: SchemaRegistry,
+    private val stopping: AtomicBoolean,
+) : Runnable {
+    private val log = LoggerFactory.getLogger(InvoiceRelay::class.java)
+
+    private val producer =
+        KafkaProducer<String, ByteArray>(
+            Properties().apply {
+                put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+                put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true)
+                put(ProducerConfig.ACKS_CONFIG, "all")
+                put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 5_000)
+                put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 4_000)
+                put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer::class.java.name)
+                put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer::class.java.name)
+            },
+        )
+
+    private class Pending(
+        val id: UUID,
+        val key: String,
+        val topic: String,
+        val payload: ByteArray,
+        val traceParent: String?,
+    )
+
+    override fun run() =
+        producer.use { client ->
+            while (!stopping.get()) {
+                try {
+                    for (pending in pending()) {
+                        val headers =
+                            mutableListOf(
+                                RecordHeader("schema-id", schemas.resolve(pending.topic).toString().toByteArray()),
+                            )
+                        pending.traceParent?.let { headers.add(RecordHeader("traceparent", it.toByteArray())) }
+                        client.send(ProducerRecord(pending.topic, null, pending.key, pending.payload, headers)).get()
+                        markPublished(pending.id)
+                    }
+                } catch (error: Exception) {
+                    if (stopping.get()) break
+                    log.warn("Kafka relay delayed; invoice events retained", error)
+                }
+                Thread.sleep(2_000)
+            }
+        }
+
+    private fun pending(): List<Pending> =
+        dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                """
+                SELECT id, aggregate_id, topic, payload, trace_parent
+                  FROM outbox
+                 WHERE published_at IS NULL
+                   AND aggregate_type = 'invoice'
+                 ORDER BY occurred_at
+                 LIMIT 100
+                """.trimIndent(),
+            ).use { statement ->
+                statement.executeQuery().use { rows ->
+                    buildList {
+                        while (rows.next()) {
+                            add(
+                                Pending(
+                                    rows.getObject(1, UUID::class.java),
+                                    rows.getString(2),
+                                    rows.getString(3),
+                                    rows.getBytes(4),
+                                    rows.getString(5),
+                                ),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+    private fun markPublished(id: UUID) =
+        dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                "UPDATE outbox SET published_at = now() WHERE id = ? AND published_at IS NULL",
+            ).use { statement ->
+                statement.setObject(1, id)
+                statement.executeUpdate()
+            }
+        }
+}

--- a/services/billing/src/main/kotlin/projecty/billing/Invoices.kt
+++ b/services/billing/src/main/kotlin/projecty/billing/Invoices.kt
@@ -18,6 +18,21 @@ enum class Outcome {
 }
 
 /**
+ * Quem emite a nota.
+ *
+ * A interface existe para que o laço do consumidor possa ser testado contra uma
+ * falha de banco sem que exista um banco: o que importa lá é o que o laço faz
+ * quando esta chamada estoura, não o que ela escreve quando não estoura.
+ */
+interface InvoiceIssuer {
+    fun issue(
+        messageId: String,
+        rental: ClosedRental,
+        settled: Settlement.Settled,
+    ): Invoices.Issued
+}
+
+/**
  * A nota, a linha do inbox e o evento de saída numa transação só.
  *
  * É aqui que o ADR 0009 deixa de ser prosa. O `SqlInboxProcessor` do
@@ -32,7 +47,7 @@ enum class Outcome {
  * nenhuma janela -- o preço é que só serve para efeitos que moram no banco, que
  * é exatamente o caso de uma fatura.
  */
-class Invoices(private val dataSource: DataSource) {
+class Invoices(private val dataSource: DataSource) : InvoiceIssuer {
     companion object {
         const val CONSUMER = "billing-v1"
         private const val UNIQUE_VIOLATION = "23505"
@@ -64,7 +79,7 @@ class Invoices(private val dataSource: DataSource) {
 
     data class Issued(val outcome: Outcome, val invoiceId: UUID?)
 
-    fun issue(
+    override fun issue(
         messageId: String,
         rental: ClosedRental,
         settled: Settlement.Settled,

--- a/services/billing/src/main/kotlin/projecty/billing/Invoices.kt
+++ b/services/billing/src/main/kotlin/projecty/billing/Invoices.kt
@@ -1,0 +1,177 @@
+package projecty.billing
+
+import java.sql.Connection
+import java.sql.SQLException
+import java.util.UUID
+import javax.sql.DataSource
+
+/** O que aconteceu com uma entrega de `rental.closed`. */
+enum class Outcome {
+    /** A nota foi emitida agora, e o evento de saída ficou no outbox. */
+    ISSUED,
+
+    /** Esta MENSAGEM já havia sido tratada. O inbox a reconheceu. */
+    DUPLICATE_MESSAGE,
+
+    /** Mensagem nova, aluguel já faturado. O índice único da nota a recusou. */
+    ALREADY_SETTLED,
+}
+
+/**
+ * A nota, a linha do inbox e o evento de saída numa transação só.
+ *
+ * É aqui que o ADR 0009 deixa de ser prosa. O `SqlInboxProcessor` do
+ * rental-core reserva a mensagem, roda o handler FORA da transação da reserva e
+ * a conclui depois -- o que deixa uma janela: cair entre o efeito e a conclusão
+ * republica o efeito. Ele documenta essa janela e vive com ela porque o handler
+ * dele escreve em outro lugar.
+ *
+ * O billing não tem essa desculpa: o efeito é uma linha no MESMO banco da linha
+ * do inbox. Então as duas entram no mesmo COMMIT, e não existe instante em que
+ * uma valha sem a outra. Nenhuma reserva com prazo, nenhum handler externo,
+ * nenhuma janela -- o preço é que só serve para efeitos que moram no banco, que
+ * é exatamente o caso de uma fatura.
+ */
+class Invoices(private val dataSource: DataSource) {
+    companion object {
+        const val CONSUMER = "billing-v1"
+        private const val UNIQUE_VIOLATION = "23505"
+        private const val SERIALIZATION_FAILURE = "40001"
+
+        /**
+         * O CockroachDB roda em SERIALIZABLE e devolve 40001 quando duas
+         * transações não podem ser ordenadas. Repetir é obrigação do cliente:
+         * sem isto, duas réplicas tratando mensagens vizinhas veriam uma delas
+         * falhar por um motivo que não é erro nenhum.
+         */
+        fun <T> retrying(
+            attempts: Int = 5,
+            body: () -> T,
+        ): T {
+            var last: SQLException? = null
+            repeat(attempts) {
+                try {
+                    return body()
+                } catch (error: SQLException) {
+                    if (error.sqlState != SERIALIZATION_FAILURE) throw error
+                    last = error
+                    Thread.sleep(20L * (it + 1))
+                }
+            }
+            throw last!!
+        }
+    }
+
+    data class Issued(val outcome: Outcome, val invoiceId: UUID?)
+
+    fun issue(
+        messageId: String,
+        rental: ClosedRental,
+        settled: Settlement.Settled,
+    ): Issued =
+        retrying {
+            dataSource.connection.use { connection ->
+                connection.autoCommit = false
+                try {
+                    if (!claimMessage(connection, messageId)) {
+                        connection.rollback()
+                        return@use Issued(Outcome.DUPLICATE_MESSAGE, null)
+                    }
+                    val invoiceId = UUID.randomUUID()
+                    try {
+                        insertInvoice(connection, invoiceId, rental, settled)
+                    } catch (error: SQLException) {
+                        if (error.sqlState != UNIQUE_VIOLATION) throw error
+                        // Mensagem nova para um aluguel já faturado: um replay a
+                        // partir do offset zero, ou uma republicação com id novo.
+                        // O inbox não cobre isso -- ele guarda mensagens, não
+                        // aluguéis -- e é para isso que one_invoice_per_rental
+                        // existe. A mensagem fica registrada como tratada,
+                        // porque o efeito que ela pedia já está no banco.
+                        connection.rollback()
+                        recordHandled(connection, messageId)
+                        connection.commit()
+                        return@use Issued(Outcome.ALREADY_SETTLED, null)
+                    }
+                    insertOutbox(connection, invoiceId, rental, settled)
+                    connection.commit()
+                    Issued(Outcome.ISSUED, invoiceId)
+                } catch (error: Exception) {
+                    connection.rollback()
+                    throw error
+                } finally {
+                    connection.autoCommit = true
+                }
+            }
+        }
+
+    /** true quando esta réplica passou a ser a dona do tratamento da mensagem. */
+    private fun claimMessage(
+        connection: Connection,
+        messageId: String,
+    ): Boolean =
+        connection.prepareStatement(
+            """
+            INSERT INTO inbox (message_id, consumer, status)
+            VALUES (?, ?, 'completed')
+            ON CONFLICT (message_id, consumer) DO NOTHING
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setString(1, messageId)
+            statement.setString(2, CONSUMER)
+            statement.executeUpdate() == 1
+        }
+
+    private fun recordHandled(
+        connection: Connection,
+        messageId: String,
+    ) {
+        claimMessage(connection, messageId)
+    }
+
+    private fun insertInvoice(
+        connection: Connection,
+        invoiceId: UUID,
+        rental: ClosedRental,
+        settled: Settlement.Settled,
+    ) = connection.prepareStatement(
+        """
+        INSERT INTO invoices (id, rental_id, rider_id, currency, plan_days, days_used,
+                              agreed_minor, adjustment_minor, total_minor, reason, rider_name)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """.trimIndent(),
+    ).use { statement ->
+        statement.setObject(1, invoiceId)
+        statement.setObject(2, UUID.fromString(rental.rentalId))
+        statement.setString(3, rental.riderId)
+        statement.setString(4, rental.currency)
+        statement.setInt(5, settled.planDays)
+        statement.setInt(6, settled.daysUsed)
+        statement.setLong(7, settled.agreedMinor)
+        statement.setLong(8, settled.adjustmentMinor)
+        statement.setLong(9, settled.totalMinor)
+        statement.setString(10, settled.reason)
+        statement.setString(11, rental.riderName)
+        statement.executeUpdate()
+    }
+
+    private fun insertOutbox(
+        connection: Connection,
+        invoiceId: UUID,
+        rental: ClosedRental,
+        settled: Settlement.Settled,
+    ) = connection.prepareStatement(
+        """
+        INSERT INTO outbox (aggregate_type, aggregate_id, event_type, topic, payload, trace_parent)
+        VALUES ('invoice', ?, 'invoice.issued', 'invoice.issued', ?, ?)
+        """.trimIndent(),
+    ).use { statement ->
+        // aggregate_id é a chave de partição no Kafka, e topics.json diz que
+        // invoice.issued é particionado por rental_id. A relay não escolhe:
+        // publica o que a transação deixou aqui.
+        statement.setString(1, rental.rentalId)
+        statement.setBytes(2, InvoiceEvents.issued(invoiceId, rental, settled).toByteArray())
+        statement.setString(3, rental.traceParent)
+        statement.executeUpdate()
+    }
+}

--- a/services/billing/src/main/kotlin/projecty/billing/Main.kt
+++ b/services/billing/src/main/kotlin/projecty/billing/Main.kt
@@ -1,0 +1,79 @@
+package projecty.billing
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.slf4j.LoggerFactory
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicBoolean
+
+private val log = LoggerFactory.getLogger("billing")
+
+private fun env(name: String): String = System.getenv(name) ?: error("$name is required")
+
+fun main() {
+    val stopping = AtomicBoolean(false)
+
+    val dataSource =
+        HikariDataSource(
+            HikariConfig().apply {
+                jdbcUrl = env("BILLING_DATABASE_URL")
+                // Uma conexão por papel: a relay e o consumidor rodam em threads
+                // separadas e cada um abre a sua por operação.
+                maximumPoolSize = 8
+                connectionTimeout = 5_000
+                poolName = "billing"
+            },
+        )
+
+    val bootstrap = env("KAFKA_BOOTSTRAP_SERVERS")
+    val invoices = Invoices(dataSource)
+    val consumer = RentalClosedConsumer(bootstrap, invoices, stopping)
+    val relay = InvoiceRelay(dataSource, bootstrap, SchemaRegistry(env("SCHEMA_REGISTRY_URL")), stopping)
+
+    val health =
+        HttpServer.create(InetSocketAddress(8094), 0).apply {
+            createContext("/health/live") { it.reply(200, "live") }
+            createContext("/health/ready") { exchange ->
+                // Pronto é ter voltado do poll recentemente. Um consumidor que
+                // parou de girar é indistinguível de um processo vivo sem esta
+                // pergunta -- e é o modo de falha que interessa aqui.
+                val idleMs = System.currentTimeMillis() - consumer.lastPollAtMs.get()
+                if (idleMs < 30_000) exchange.reply(200, "ready") else exchange.reply(503, "stalled for ${idleMs}ms")
+            }
+            createContext("/invoices/count") { it.reply(200, consumer.issued.get().toString()) }
+            start()
+        }
+
+    val threads =
+        listOf(
+            Thread(relay, "invoice-relay"),
+            Thread(consumer, "rental-closed"),
+        )
+
+    Runtime.getRuntime().addShutdownHook(
+        Thread {
+            log.info("Stopping billing")
+            stopping.set(true)
+            consumer.wakeup()
+            health.stop(1)
+            threads.forEach { it.join(10_000) }
+            dataSource.close()
+        },
+    )
+
+    log.info("billing listening on 8094, settling {} into invoices", RentalClosedConsumer.TOPIC)
+    threads.forEach { it.start() }
+    threads.forEach { it.join() }
+}
+
+private fun HttpExchange.reply(
+    status: Int,
+    body: String,
+) = use {
+    val bytes = body.toByteArray()
+    responseHeaders.add("Content-Type", "text/plain; charset=utf-8")
+    sendResponseHeaders(status, bytes.size.toLong())
+    responseBody.write(bytes)
+}

--- a/services/billing/src/main/kotlin/projecty/billing/Main.kt
+++ b/services/billing/src/main/kotlin/projecty/billing/Main.kt
@@ -29,7 +29,7 @@ fun main() {
 
     val bootstrap = env("KAFKA_BOOTSTRAP_SERVERS")
     val invoices = Invoices(dataSource)
-    val consumer = RentalClosedConsumer(bootstrap, invoices, stopping)
+    val consumer = RentalClosedConsumer.kafka(bootstrap, invoices, stopping)
     val relay = InvoiceRelay(dataSource, bootstrap, SchemaRegistry(env("SCHEMA_REGISTRY_URL")), stopping)
 
     val health =
@@ -43,14 +43,28 @@ fun main() {
                 if (idleMs < 30_000) exchange.reply(200, "ready") else exchange.reply(503, "stalled for ${idleMs}ms")
             }
             createContext("/invoices/count") { it.reply(200, consumer.issued.get().toString()) }
+            createContext("/invoices/skipped") { it.reply(200, consumer.skipped.get().toString()) }
             start()
+        }
+
+    // Uma thread de trabalho que morre precisa derrubar o processo.
+    //
+    // Sem isto, o consumidor morre, a relay segue viva, o join() do main nunca
+    // volta e /health/live continua respondendo 200 -- um processo que parece
+    // saudável e não fatura mais nada. halt() e não exit() porque exit()
+    // dispararia o gancho de desligamento, que faz join na thread que está
+    // morrendo. O código 70 é EX_SOFTWARE.
+    val fatal =
+        Thread.UncaughtExceptionHandler { thread, error ->
+            log.error("{} stopped; halting so the orchestrator restarts billing", thread.name, error)
+            Runtime.getRuntime().halt(70)
         }
 
     val threads =
         listOf(
             Thread(relay, "invoice-relay"),
             Thread(consumer, "rental-closed"),
-        )
+        ).onEach { it.uncaughtExceptionHandler = fatal }
 
     Runtime.getRuntime().addShutdownHook(
         Thread {

--- a/services/billing/src/main/kotlin/projecty/billing/RentalClosedConsumer.kt
+++ b/services/billing/src/main/kotlin/projecty/billing/RentalClosedConsumer.kt
@@ -1,0 +1,110 @@
+package projecty.billing
+
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.slf4j.LoggerFactory
+import project_y.events.Rental.RentalEvent
+import java.time.Duration
+import java.util.Properties
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Lê `rental.closed` e emite a nota.
+ *
+ * O commit do offset vem DEPOIS do commit da transação, e a ordem é a única que
+ * funciona: cair entre os dois faz o Kafka reentregar a mensagem, e a linha do
+ * inbox -- já gravada -- a reconhece. O inverso perderia a nota em silêncio.
+ */
+class RentalClosedConsumer(
+    bootstrapServers: String,
+    private val invoices: Invoices,
+    private val stopping: AtomicBoolean,
+) : Runnable {
+    private val log = LoggerFactory.getLogger(RentalClosedConsumer::class.java)
+    val lastPollAtMs = AtomicLong(System.currentTimeMillis())
+    val issued = AtomicLong(0)
+
+    private val consumer =
+        KafkaConsumer<String, ByteArray>(
+            Properties().apply {
+                put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+                put(ConsumerConfig.GROUP_ID_CONFIG, Invoices.CONSUMER)
+                put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false)
+                put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+                put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java.name)
+                put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer::class.java.name)
+            },
+        )
+
+    override fun run() =
+        consumer.use { client ->
+            client.subscribe(listOf(TOPIC))
+            while (!stopping.get()) {
+                val records =
+                    try {
+                        client.poll(Duration.ofSeconds(1))
+                    } catch (error: Exception) {
+                        if (stopping.get()) break
+                        throw error
+                    }
+                lastPollAtMs.set(System.currentTimeMillis())
+                if (records.isEmpty) continue
+                for (record in records) {
+                    val traceParent = record.headers().lastHeader("traceparent")?.value()?.decodeToString()
+                    handle(RentalEvent.parseFrom(record.value()), traceParent)
+                }
+                client.commitSync()
+            }
+        }
+
+    private fun handle(
+        event: RentalEvent,
+        traceParent: String?,
+    ) {
+        val rental =
+            try {
+                ClosedRental.from(event, traceParent)
+            } catch (error: IllegalArgumentException) {
+                // Um evento malformado não melhora com repetição, e travar o grupo
+                // nele pararia o faturamento de todo mundo. Registrar e seguir é a
+                // escolha; o aluguel fica sem nota e aparece como tal.
+                log.error("Refusing malformed rental.closed: {}", error.message)
+                return
+            }
+        val settled =
+            Settlement.settle(
+                agreedMinor = rental.agreedTotalMinor,
+                planDays = rental.planDays,
+                startedAtMs = rental.startedAtMs,
+                predictedEndAtMs = rental.predictedEndAtMs,
+                endedAtMs = rental.endedAtMs,
+            )
+        val result = invoices.issue(rental.eventId, rental, settled)
+        when (result.outcome) {
+            Outcome.ISSUED -> {
+                issued.incrementAndGet()
+                log.info(
+                    "Invoice {} issued for rental {}: {} {} ({})",
+                    result.invoiceId,
+                    rental.rentalId,
+                    rental.currency,
+                    settled.totalMinor,
+                    settled.reason,
+                )
+            }
+            Outcome.DUPLICATE_MESSAGE ->
+                log.debug("rental.closed {} already handled; no second invoice", rental.eventId)
+            Outcome.ALREADY_SETTLED ->
+                log.warn("Rental {} was already invoiced; refused by one_invoice_per_rental", rental.rentalId)
+        }
+    }
+
+    fun wakeup() = consumer.wakeup()
+
+    companion object {
+        const val TOPIC = "rental.closed"
+    }
+}

--- a/services/billing/src/main/kotlin/projecty/billing/RentalClosedConsumer.kt
+++ b/services/billing/src/main/kotlin/projecty/billing/RentalClosedConsumer.kt
@@ -1,7 +1,12 @@
 package projecty.billing
 
+import com.google.protobuf.InvalidProtocolBufferException
+import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.WakeupException
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.slf4j.LoggerFactory
@@ -17,61 +22,71 @@ import java.util.concurrent.atomic.AtomicLong
  * O commit do offset vem DEPOIS do commit da transação, e a ordem é a única que
  * funciona: cair entre os dois faz o Kafka reentregar a mensagem, e a linha do
  * inbox -- já gravada -- a reconhece. O inverso perderia a nota em silêncio.
+ *
+ * Duas falhas chegam por este laço e não podem ser tratadas igual:
+ *
+ * - **A mensagem está estragada.** Nenhuma repetição a conserta, e insistir
+ *   nela trava a partição para todo mundo. Registra e segue; o aluguel fica sem
+ *   nota e aparece como tal.
+ * - **A dependência caiu.** A mensagem está boa e a repetição a resolve.
+ *   Desistir dela perderia uma fatura, então o lote volta ao último offset
+ *   confirmado e é tentado de novo.
+ *
+ * Confundir as duas dá o pior dos dois lados: ou uma nota some porque o banco
+ * piscou, ou o faturamento inteiro para por causa de um byte torto.
  */
 class RentalClosedConsumer(
-    bootstrapServers: String,
-    private val invoices: Invoices,
+    private val invoices: InvoiceIssuer,
     private val stopping: AtomicBoolean,
+    private val consumer: Consumer<String, ByteArray>,
+    private val backoff: Duration = Duration.ofSeconds(5),
 ) : Runnable {
     private val log = LoggerFactory.getLogger(RentalClosedConsumer::class.java)
     val lastPollAtMs = AtomicLong(System.currentTimeMillis())
     val issued = AtomicLong(0)
-
-    private val consumer =
-        KafkaConsumer<String, ByteArray>(
-            Properties().apply {
-                put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
-                put(ConsumerConfig.GROUP_ID_CONFIG, Invoices.CONSUMER)
-                put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false)
-                put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-                put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java.name)
-                put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer::class.java.name)
-            },
-        )
+    val skipped = AtomicLong(0)
+    val retriedBatches = AtomicLong(0)
 
     override fun run() =
         consumer.use { client ->
             client.subscribe(listOf(TOPIC))
             while (!stopping.get()) {
-                val records =
-                    try {
-                        client.poll(Duration.ofSeconds(1))
-                    } catch (error: Exception) {
-                        if (stopping.get()) break
-                        throw error
-                    }
-                lastPollAtMs.set(System.currentTimeMillis())
-                if (records.isEmpty) continue
-                for (record in records) {
-                    val traceParent = record.headers().lastHeader("traceparent")?.value()?.decodeToString()
-                    handle(RentalEvent.parseFrom(record.value()), traceParent)
+                try {
+                    val records = client.poll(Duration.ofSeconds(1))
+                    lastPollAtMs.set(System.currentTimeMillis())
+                    if (records.isEmpty) continue
+                    for (record in records) handle(record)
+                    client.commitSync()
+                } catch (error: WakeupException) {
+                    if (!stopping.get()) throw error
+                    break
+                } catch (error: Exception) {
+                    if (stopping.get()) break
+                    // O lote não foi confirmado, mas a posição do consumidor já
+                    // andou -- o Kafka não rebobina sozinho. Sem este seek a
+                    // mensagem só voltaria num rebalanceamento ou num restart, e
+                    // até lá a fatura simplesmente não existiria.
+                    retriedBatches.incrementAndGet()
+                    log.warn("Settlement batch failed; rewinding to the committed offsets", error)
+                    rewind(client)
+                    sleep()
                 }
-                client.commitSync()
             }
         }
 
-    private fun handle(
-        event: RentalEvent,
-        traceParent: String?,
-    ) {
+    private fun handle(record: ConsumerRecord<String, ByteArray>) {
+        val traceParent = record.headers().lastHeader("traceparent")?.value()?.decodeToString()
         val rental =
             try {
-                ClosedRental.from(event, traceParent)
+                ClosedRental.from(RentalEvent.parseFrom(record.value()), traceParent)
+            } catch (error: InvalidProtocolBufferException) {
+                // O parse acontece aqui dentro, e não na chamada: lá fora ele
+                // derrubaria a thread antes de qualquer tratamento, e o mesmo
+                // registro envenenado voltaria a cada restart.
+                skip(record, "undecodable protobuf", error.message)
+                return
             } catch (error: IllegalArgumentException) {
-                // Um evento malformado não melhora com repetição, e travar o grupo
-                // nele pararia o faturamento de todo mundo. Registrar e seguir é a
-                // escolha; o aluguel fica sem nota e aparece como tal.
-                log.error("Refusing malformed rental.closed: {}", error.message)
+                skip(record, "incomplete settlement", error.message)
                 return
             }
         val settled =
@@ -102,9 +117,69 @@ class RentalClosedConsumer(
         }
     }
 
+    private fun skip(
+        record: ConsumerRecord<String, ByteArray>,
+        reason: String,
+        detail: String?,
+    ) {
+        skipped.incrementAndGet()
+        log.error(
+            "Skipping {}-{} offset {}: {} ({})",
+            record.topic(),
+            record.partition(),
+            record.offset(),
+            reason,
+            detail,
+        )
+    }
+
+    private fun rewind(client: Consumer<String, ByteArray>) {
+        runCatching {
+            val assignment = client.assignment()
+            if (assignment.isEmpty()) return
+            val committed = client.committed(assignment)
+            for (partition in assignment) {
+                val offset = committed[partition]
+                if (offset == null) {
+                    client.seekToBeginning(
+                        listOf<TopicPartition>(partition),
+                    )
+                } else {
+                    client.seek(partition, offset.offset())
+                }
+            }
+        }.onFailure { log.warn("Could not rewind after a failed batch; the next rebalance will", it) }
+    }
+
+    private fun sleep() {
+        val until = System.nanoTime() + backoff.toNanos()
+        while (!stopping.get() && System.nanoTime() < until) {
+            Thread.sleep(minOf(200L, backoff.toMillis()))
+        }
+    }
+
     fun wakeup() = consumer.wakeup()
 
     companion object {
         const val TOPIC = "rental.closed"
+
+        fun kafka(
+            bootstrapServers: String,
+            invoices: InvoiceIssuer,
+            stopping: AtomicBoolean,
+        ) = RentalClosedConsumer(
+            invoices,
+            stopping,
+            KafkaConsumer<String, ByteArray>(
+                Properties().apply {
+                    put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+                    put(ConsumerConfig.GROUP_ID_CONFIG, Invoices.CONSUMER)
+                    put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false)
+                    put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+                    put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java.name)
+                    put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer::class.java.name)
+                },
+            ),
+        )
     }
 }

--- a/services/billing/src/main/kotlin/projecty/billing/SchemaRegistry.kt
+++ b/services/billing/src/main/kotlin/projecty/billing/SchemaRegistry.kt
@@ -1,0 +1,64 @@
+package projecty.billing
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * O id de schema que acompanha cada mensagem no header `schema-id`.
+ *
+ * O #132 decidiu Protobuf cru com o id num header, e não o envelope binário do
+ * Confluent: quem consome decodifica localmente e a mensagem continua legível
+ * sem o registry no caminho. O registry serve para uma coisa só -- recusar um
+ * contrato incompatível no momento do registro.
+ *
+ * A resolução é uma vez por tópico e fica em memória. Um registry fora do ar
+ * depois disso não segura nenhuma linha do outbox.
+ */
+class SchemaRegistry(
+    private val baseUrl: String,
+    private val contracts: Path = Path.of("/event-contracts"),
+) {
+    private val json = ObjectMapper()
+    private val ids = ConcurrentHashMap<String, Int>()
+    private val http: HttpClient =
+        HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build()
+
+    fun resolve(topic: String): Int =
+        ids.computeIfAbsent(topic) { name ->
+            val topics = json.readTree(Files.readAllBytes(contracts.resolve("topics.json")))
+            val file =
+                topics.path(name).path("schema").asText(null)
+                    ?: error("Topic $name is not declared in topics.json")
+            val schema = Files.readString(contracts.resolve("events").resolve(file))
+            val body =
+                json.createObjectNode()
+                    .put("schemaType", "PROTOBUF")
+                    .put("schema", schema)
+                    .toString()
+
+            val response =
+                http.send(
+                    HttpRequest.newBuilder(URI.create("${baseUrl.trimEnd('/')}/subjects/$name-value"))
+                        .timeout(Duration.ofSeconds(5))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(body))
+                        .build(),
+                    HttpResponse.BodyHandlers.ofString(),
+                )
+            check(response.statusCode() in 200..299) {
+                "Schema registry refused $name: ${response.statusCode()} ${response.body()}"
+            }
+            val id = json.readTree(response.body()).path("id").asInt(0)
+            check(id > 0) { "Schema registry returned no usable id for $name" }
+            id
+        }
+}

--- a/services/billing/src/main/kotlin/projecty/billing/Settlement.kt
+++ b/services/billing/src/main/kotlin/projecty/billing/Settlement.kt
@@ -1,0 +1,144 @@
+package projecty.billing
+
+import java.math.BigDecimal
+import java.math.MathContext
+import java.math.RoundingMode
+
+/**
+ * As regras de liquidação, e o único lugar onde elas moram.
+ *
+ * Antes do #137 elas viviam em `RentalService.CalculateFinalCostAsync`, que
+ * calculava o dinheiro e mutava o aluguel -- `EndDate`, `FinalCost`, `Status` --
+ * dentro de um método chamado `Calculate`. Dois contextos numa classe só, e
+ * nenhum teste sobre os números: a busca por `AdditionalCostsOrSavings` nos
+ * testes do rental-core não encontrava uma única asserção de valor.
+ */
+object Settlement {
+    /**
+     * Meio centavo arredonda para cima.
+     *
+     * HALF_UP e não HALF_EVEN porque isto é uma cobrança ao cliente, não uma
+     * série estatística: o desempate de HALF_EVEN depende do dígito anterior,
+     * e explicar isso a quem recebe a fatura custa mais do que o viés que ele
+     * corrige. E o arredondamento acontece UMA vez, sobre o total -- arredondar
+     * cada parcela e somar deixaria o erro se acumular parcela a parcela.
+     */
+    val ROUNDING: RoundingMode = RoundingMode.HALF_UP
+
+    /** Diária extra do atraso: R$ 50,00, em centavos. */
+    const val LATE_DAY_MINOR: Long = 5_000L
+
+    /**
+     * A diária não é recalculada pela tabela de hoje.
+     *
+     * O evento carrega `agreed_total_minor` e `plan_days`, e a diária sai da
+     * divisão dos dois. É deliberado: quem liquida cobra a tarifa que valia
+     * quando o aluguel começou, não a que o risk-pricing publicou desde então.
+     * Consultar a tabela atual aqui faria o preço de um contrato mudar depois
+     * de assinado.
+     */
+    private val RATE_CONTEXT = MathContext(20, RoundingMode.HALF_UP)
+
+    /**
+     * 20% para o plano de 7 dias, 40% para os demais.
+     *
+     * O enunciado original só nomeia os planos de 7 e 15 dias. Os planos de 30,
+     * 45 e 50 dias existem na tabela de preços e não têm multa declarada; esta
+     * função os trata como o plano de 15, que é a extensão conservadora -- a
+     * mais cara para quem devolve antes. Se alguém decidir outra coisa, é aqui
+     * que a decisão muda, e este comentário é o que diz que ela foi tomada.
+     */
+    fun penaltyRate(planDays: Int): BigDecimal = if (planDays <= 7) BigDecimal("0.20") else BigDecimal("0.40")
+
+    /**
+     * O resultado da liquidação.
+     *
+     * `adjustment` é derivado, e não somado: `total - agreed`. O schema repete
+     * a relação como CHECK, então uma das duas contas teria de estar errada
+     * para a linha entrar.
+     */
+    data class Settled(
+        val agreedMinor: Long,
+        val adjustmentMinor: Long,
+        val totalMinor: Long,
+        val planDays: Int,
+        val daysUsed: Int,
+        val reason: String,
+    )
+
+    /**
+     * Dias inteiros, truncando.
+     *
+     * Uma fração de dia não é cobrada -- nem a favor do cliente na devolução
+     * antecipada, nem contra ele no atraso. É o comportamento que o `.Days` de
+     * TimeSpan já tinha no C#, e mudá-lo junto com a mudança de dono
+     * transformaria uma mudança de estrutura numa mudança de preço.
+     */
+    fun wholeDays(
+        fromMs: Long,
+        toMs: Long,
+    ): Int {
+        val days = (toMs - fromMs) / 86_400_000L
+        return if (days <= 0L) 0 else days.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+    }
+
+    fun settle(
+        agreedMinor: Long,
+        planDays: Int,
+        startedAtMs: Long,
+        predictedEndAtMs: Long,
+        endedAtMs: Long,
+    ): Settled {
+        require(planDays > 0) { "A rental with no planned days has no daily rate to settle against." }
+        require(agreedMinor >= 0) { "The agreed total cannot be negative." }
+
+        val daysUsed = wholeDays(startedAtMs, endedAtMs)
+        val daysLate = wholeDays(predictedEndAtMs, endedAtMs)
+
+        if (daysLate > 0) {
+            // O atraso soma diárias à ponta do contrato; o combinado continua
+            // devido por inteiro, porque os dias planejados foram todos usados.
+            val extra = LATE_DAY_MINOR * daysLate
+            return Settled(
+                agreedMinor = agreedMinor,
+                adjustmentMinor = extra,
+                totalMinor = agreedMinor + extra,
+                planDays = planDays,
+                daysUsed = daysUsed,
+                reason = "Returned $daysLate day(s) late. Extra days charged at the late daily rate.",
+            )
+        }
+
+        val daysEarly = planDays - daysUsed
+        if (daysEarly <= 0) {
+            return Settled(
+                agreedMinor,
+                0L,
+                agreedMinor,
+                planDays,
+                daysUsed,
+                "Returned on the predicted end date. No adjustment.",
+            )
+        }
+
+        // Devolução antecipada: paga-se o que se usou, mais a multa sobre o que
+        // se deixou de usar. A versão anterior cobrava o combinado INTEIRO e
+        // depois subtraía a multa como desconto, o que fazia devolver antes
+        // sair mais barato do que o contrato -- o oposto de uma multa.
+        val dailyRate = BigDecimal.valueOf(agreedMinor).divide(BigDecimal(planDays), RATE_CONTEXT)
+        val used = dailyRate.multiply(BigDecimal(daysUsed))
+        val penalty = dailyRate.multiply(BigDecimal(daysEarly)).multiply(penaltyRate(planDays))
+        val total = used.add(penalty).setScale(0, ROUNDING).longValueExact()
+
+        return Settled(
+            agreedMinor = agreedMinor,
+            adjustmentMinor = total - agreedMinor,
+            totalMinor = total,
+            planDays = planDays,
+            daysUsed = daysUsed,
+            reason =
+                "Returned $daysEarly day(s) early. Unused days charged at " +
+                    "${penaltyRate(planDays).movePointRight(2).toPlainString()}% penalty.",
+        )
+    }
+}

--- a/services/billing/src/test/kotlin/projecty/billing/ExactlyOnceTest.kt
+++ b/services/billing/src/test/kotlin/projecty/billing/ExactlyOnceTest.kt
@@ -1,0 +1,247 @@
+package projecty.billing
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.TestInstance
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+import project_y.events.Invoice.InvoiceIssued
+import java.nio.file.Files
+import java.nio.file.Path
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.SQLException
+import java.util.UUID
+import javax.sql.DataSource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * O efeito "exatamente uma vez" do ADR 0009, contra o banco de verdade.
+ *
+ * Contra o CockroachDB e não contra o Postgres porque a garantia depende do
+ * nível de isolamento: SERIALIZABLE é o padrão lá, e é o que faz duas réplicas
+ * competindo pela mesma mensagem terminarem com uma nota, não duas. Em READ
+ * COMMITTED este teste passaria por sorte.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExactlyOnceTest {
+    private var container: GenericContainer<*>? = null
+    private lateinit var endpoint: String
+    private lateinit var dataSource: HikariDataSource
+    private lateinit var invoices: Invoices
+
+    @BeforeAll
+    fun start() {
+        // Um CockroachDB já de pé, quando houver, e um container quando não.
+        //
+        // O Testcontainers precisa falar com o daemon, e nem toda máquina de
+        // desenvolvimento expõe o socket de dentro de um container -- o Docker
+        // Desktop no Windows não expõe. O CI roda pelo caminho de cima; a
+        // variável existe para rodar o teste à mão sem ele.
+        endpoint = System.getenv("BILLING_TEST_COCKROACH") ?: startCockroach()
+
+        val root = url("defaultdb")
+        awaitReady(root)
+        applyFile(root, "000_bootstrap.cockroach.sql")
+        val app = url("projecty")
+        for (file in listOf("001_schema.sql", "002_rental_core.sql", "003_billing.sql")) applyFile(app, file)
+
+        dataSource =
+            HikariDataSource(
+                HikariConfig().apply {
+                    jdbcUrl = app
+                    maximumPoolSize = 4
+                },
+            )
+        invoices = Invoices(dataSource)
+    }
+
+    private fun startCockroach(): String {
+        val started =
+            GenericContainer(DockerImageName.parse("cockroachdb/cockroach:v26.3.1"))
+                .withCommand("start-single-node", "--insecure")
+                .withExposedPorts(26257)
+        started.start()
+        container = started
+        return "${started.host}:${started.getMappedPort(26257)}"
+    }
+
+    @AfterAll
+    fun stop() {
+        if (this::dataSource.isInitialized) dataSource.close()
+        container?.stop()
+    }
+
+    @Test
+    @Tag("ADR-0009#settlement-inbox")
+    fun `a mesma mensagem duas vezes emite uma nota so`() {
+        val rental = closed()
+
+        val first = invoices.issue(rental.eventId, rental, settle(rental))
+        val second = invoices.issue(rental.eventId, rental, settle(rental))
+
+        assertEquals(Outcome.ISSUED, first.outcome)
+        assertEquals(Outcome.DUPLICATE_MESSAGE, second.outcome)
+        assertEquals(1, invoiceCount(rental.rentalId))
+        // E um evento de saída só: publicar duas vezes o mesmo fato seria a
+        // mesma duplicata, um passo adiante.
+        assertEquals(1, outboxCount(rental.rentalId))
+    }
+
+    @Test
+    @Tag("ADR-0009#settlement-inbox")
+    fun `mensagem nova para aluguel ja faturado nao emite a segunda nota`() {
+        val rental = closed()
+        invoices.issue(rental.eventId, rental, settle(rental))
+
+        // O inbox guarda mensagens, não aluguéis: com um id novo ele deixa
+        // passar. Quem recusa aqui é one_invoice_per_rental -- a razão de a
+        // garantia não depender de uma tabela só.
+        val replay = invoices.issue("replay:" + UUID.randomUUID(), rental, settle(rental))
+
+        assertEquals(Outcome.ALREADY_SETTLED, replay.outcome)
+        assertNull(replay.invoiceId)
+        assertEquals(1, invoiceCount(rental.rentalId))
+    }
+
+    /**
+     * A propriedade que o rental-core não consegue prometer.
+     *
+     * O SqlInboxProcessor dele reserva a mensagem, roda o handler fora da
+     * transação e conclui depois. Aqui a nota e a linha do inbox estão no mesmo
+     * COMMIT: se a nota não entra, a mensagem continua por tratar e a próxima
+     * entrega tenta de novo. Não existe estado em que o inbox diga "já tratei"
+     * e a nota não exista.
+     */
+    @Test
+    @Tag("ADR-0009#settlement-inbox")
+    fun `nota recusada pelo banco nao deixa a mensagem marcada como tratada`() {
+        val rental = closed()
+        val messageId = rental.eventId
+        val impossible = settle(rental).copy(planDays = 0) // viola CHECK (plan_days > 0)
+
+        val error = runCatching { invoices.issue(messageId, rental, impossible) }.exceptionOrNull()
+
+        assertTrue(error is SQLException, "a violação do CHECK precisa chegar a quem chamou")
+        assertEquals(0, inboxCount(messageId))
+        assertEquals(0, invoiceCount(rental.rentalId))
+    }
+
+    @Test
+    @Tag("ADR-0009#settlement-inbox")
+    fun `o evento de saida carrega a nota e e particionado pelo aluguel`() {
+        val rental = closed()
+        val settled = settle(rental)
+
+        val issued = invoices.issue(rental.eventId, rental, settled)
+
+        val row = outboxRow(rental.rentalId)
+        assertNotNull(row)
+        assertEquals("invoice.issued", row.topic)
+        assertEquals(rental.rentalId, row.key)
+        val event = InvoiceIssued.parseFrom(row.payload)
+        assertEquals(settled.totalMinor, event.totalMinor)
+        assertEquals(issued.invoiceId.toString(), event.invoiceId)
+        assertEquals(InvoiceEvents.eventId(rental.rentalId), event.eventId)
+    }
+
+    // ------------------------------------------------------------------ apoio
+
+    private fun closed(): ClosedRental {
+        val rentalId = UUID.randomUUID().toString()
+        val start = 1_767_225_600_000L
+        return ClosedRental(
+            eventId = "$rentalId:rental.closed:v1",
+            rentalId = rentalId,
+            riderId = "rider-" + rentalId.take(8),
+            currency = "BRL",
+            agreedTotalMinor = 21_000L,
+            planDays = 7,
+            startedAtMs = start,
+            predictedEndAtMs = start + 7 * 86_400_000L,
+            endedAtMs = start + 4 * 86_400_000L,
+            riderName = "Ada Lovelace",
+            traceParent = null,
+        )
+    }
+
+    private fun settle(rental: ClosedRental) =
+        Settlement.settle(
+            rental.agreedTotalMinor,
+            rental.planDays,
+            rental.startedAtMs,
+            rental.predictedEndAtMs,
+            rental.endedAtMs,
+        )
+
+    private class OutboxRow(val key: String, val topic: String, val payload: ByteArray)
+
+    private fun outboxRow(rentalId: String): OutboxRow? =
+        query { connection ->
+            connection.prepareStatement(
+                "SELECT aggregate_id, topic, payload FROM outbox WHERE aggregate_type = 'invoice' AND aggregate_id = ?",
+            ).use { statement ->
+                statement.setString(1, rentalId)
+                statement.executeQuery().use { rows ->
+                    if (rows.next()) OutboxRow(rows.getString(1), rows.getString(2), rows.getBytes(3)) else null
+                }
+            }
+        }
+
+    private fun invoiceCount(rentalId: String) =
+        count("SELECT count(*) FROM invoices WHERE rental_id = ?::UUID", rentalId)
+
+    private fun outboxCount(rentalId: String) =
+        count("SELECT count(*) FROM outbox WHERE aggregate_type = 'invoice' AND aggregate_id = ?", rentalId)
+
+    private fun inboxCount(messageId: String) =
+        count("SELECT count(*) FROM inbox WHERE message_id = ? AND consumer = ?", messageId, Invoices.CONSUMER)
+
+    private fun count(
+        sql: String,
+        vararg arguments: String,
+    ): Int =
+        query { connection ->
+            connection.prepareStatement(sql).use { statement ->
+                arguments.forEachIndexed { index, value -> statement.setString(index + 1, value) }
+                statement.executeQuery().use { rows -> if (rows.next()) rows.getInt(1) else 0 }
+            }
+        }
+
+    private fun <T> query(body: (Connection) -> T): T = (dataSource as DataSource).connection.use(body)
+
+    private fun url(database: String) = "jdbc:postgresql://$endpoint/$database?sslmode=disable&user=root"
+
+    private fun awaitReady(url: String) {
+        var last: Exception? = null
+        repeat(60) {
+            try {
+                DriverManager.getConnection(url).use { connection ->
+                    connection.createStatement().use { it.execute("SELECT 1") }
+                }
+                return
+            } catch (error: SQLException) {
+                last = error
+                Thread.sleep(1_000)
+            }
+        }
+        throw IllegalStateException("CockroachDB did not become ready", last)
+    }
+
+    private fun applyFile(
+        url: String,
+        file: String,
+    ) {
+        val sql = Files.readString(Path.of("../../deploy/db/sql", file))
+        DriverManager.getConnection(url).use { connection ->
+            connection.createStatement().use { it.execute(sql) }
+        }
+    }
+}

--- a/services/billing/src/test/kotlin/projecty/billing/RentalClosedConsumerTest.kt
+++ b/services/billing/src/test/kotlin/projecty/billing/RentalClosedConsumerTest.kt
@@ -1,0 +1,162 @@
+package projecty.billing
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.MockConsumer
+import org.apache.kafka.clients.consumer.OffsetResetStrategy
+import org.apache.kafka.common.TopicPartition
+import org.junit.jupiter.api.Tag
+import java.sql.SQLException
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * O laço do consumidor, e as duas falhas que ele não pode confundir.
+ *
+ * Uma mensagem estragada e um banco fora do ar chegam ao mesmo `catch` se
+ * ninguém os separar, e aí só sobram escolhas ruins: ou se descarta a mensagem
+ * boa quando o banco pisca -- e a fatura some --, ou se insiste na estragada
+ * para sempre -- e a partição inteira para de andar.
+ */
+class RentalClosedConsumerTest {
+    private val partition = TopicPartition(RentalClosedConsumer.TOPIC, 0)
+
+    private class Observed(val position: Long, val committed: Long?)
+
+    @Test
+    @Tag("ADR-0009#settlement-inbox")
+    fun `um registro indecifravel e pulado, e o lote segue e confirma`() {
+        val issuer = RecordingIssuer()
+        val result =
+            run(
+                issuer,
+                // Campo 31 com wire type 7, que não existe: o parser do Protobuf
+                // recusa estes bytes em vez de os aceitar como campo desconhecido.
+                record(0, byteArrayOf(0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte())),
+                record(1, payload()),
+            )
+
+        assertNull(result.escaped, "um registro envenenado não pode derrubar a thread")
+        assertEquals(1, issuer.calls.get(), "a mensagem boa do mesmo lote precisa ser faturada")
+        assertEquals(2L, result.observed?.committed, "a partição precisa andar por cima do registro pulado")
+    }
+
+    @Test
+    @Tag("ADR-0009#settlement-inbox")
+    fun `uma falha de banco nao confirma o offset nem mata a thread`() {
+        val issuer = FailingIssuer(SQLException("connection refused"))
+
+        val result = run(issuer, record(0, payload()))
+
+        // A thread sai pelo `stopping`, não por exceção: uma queda aqui deixaria
+        // de faturar até alguém reiniciar o processo, e /health/live continuaria
+        // respondendo 200 enquanto isso.
+        assertNull(result.escaped, "uma falha transitória não pode escapar do laço")
+        // Nada confirmado: a mensagem continua devida, e é isso que faz a fatura
+        // existir quando o banco voltar.
+        assertNull(result.observed?.committed)
+        assertTrue(issuer.calls.get() >= 1)
+    }
+
+    @Test
+    @Tag("ADR-0009#settlement-inbox")
+    fun `o lote que falhou volta ao ultimo offset confirmado`() {
+        val result = run(FailingIssuer(SQLException("connection refused")), record(0, payload()))
+
+        // Sem o seek, a posição ficaria em 1: o Kafka não rebobina sozinho, e a
+        // mensagem só voltaria num rebalanceamento -- que numa réplica só pode
+        // nunca acontecer.
+        assertEquals(0L, result.observed?.position)
+    }
+
+    // ------------------------------------------------------------------ apoio
+
+    private class LoopResult(val escaped: Throwable?, val observed: Observed?)
+
+    /**
+     * Roda o laço contra um lote e observa o consumidor antes de ele fechar.
+     *
+     * A observação acontece dentro de uma tarefa de poll porque o laço fecha o
+     * consumidor ao sair, e um MockConsumer fechado recusa `position` e
+     * `committed`.
+     */
+    private fun run(
+        issuer: InvoiceIssuer,
+        vararg records: ConsumerRecord<String, ByteArray>,
+    ): LoopResult {
+        val stopping = AtomicBoolean(false)
+        var observed: Observed? = null
+        val consumer =
+            MockConsumer<String, ByteArray>(OffsetResetStrategy.EARLIEST).apply {
+                updateBeginningOffsets(mapOf(partition to 0L))
+                schedulePollTask {
+                    rebalance(listOf(partition))
+                    records.forEach { addRecord(it) }
+                }
+                schedulePollTask {
+                    observed = Observed(position(partition), committed(setOf(partition))[partition]?.offset())
+                    stopping.set(true)
+                }
+            }
+
+        var escaped: Throwable? = null
+        val thread = Thread(RentalClosedConsumer(issuer, stopping, consumer, Duration.ofMillis(10)), "test-consumer")
+        thread.setUncaughtExceptionHandler { _, error -> escaped = error }
+        thread.start()
+        thread.join(20_000)
+        assertTrue(!thread.isAlive, "o laço precisa terminar quando observa stopping")
+        return LoopResult(escaped, observed)
+    }
+
+    private fun record(
+        offset: Long,
+        value: ByteArray,
+    ) = ConsumerRecord(RentalClosedConsumer.TOPIC, 0, offset, "key-$offset", value)
+
+    private fun payload(): ByteArray {
+        val rentalId = UUID.randomUUID().toString()
+        val start = 1_767_225_600_000L
+        return project_y.events.Rental.RentalEvent
+            .newBuilder()
+            .setEventId("$rentalId:rental.closed:v1")
+            .setRentalId(rentalId)
+            .setRiderId("rider-1")
+            .setCurrency("BRL")
+            .setAgreedTotalMinor(21_000L)
+            .setPlanDays(7)
+            .setStartedAtMs(start)
+            .setPredictedEndAtMs(start + 7 * 86_400_000L)
+            .setEndedAtMs(start + 4 * 86_400_000L)
+            .build()
+            .toByteArray()
+    }
+
+    private open class RecordingIssuer : InvoiceIssuer {
+        val calls = AtomicInteger(0)
+
+        override fun issue(
+            messageId: String,
+            rental: ClosedRental,
+            settled: Settlement.Settled,
+        ): Invoices.Issued {
+            calls.incrementAndGet()
+            return Invoices.Issued(Outcome.ISSUED, UUID.randomUUID())
+        }
+    }
+
+    private class FailingIssuer(private val error: SQLException) : RecordingIssuer() {
+        override fun issue(
+            messageId: String,
+            rental: ClosedRental,
+            settled: Settlement.Settled,
+        ): Invoices.Issued {
+            calls.incrementAndGet()
+            throw error
+        }
+    }
+}

--- a/services/billing/src/test/kotlin/projecty/billing/SettlementTest.kt
+++ b/services/billing/src/test/kotlin/projecty/billing/SettlementTest.kt
@@ -1,0 +1,110 @@
+package projecty.billing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * As regras de liquidação, agora com testes.
+ *
+ * Elas não tinham nenhum: em todo o RentalCoreTests não havia uma asserção
+ * sobre `AdditionalCostsOrSavings` ou sobre `FinalTotalCost` -- só sobre quem
+ * pode chamar o endpoint. Um cálculo de dinheiro sem teste é um cálculo de
+ * dinheiro que ninguém conferiu, e foi assim que a inversão da multa abaixo
+ * sobreviveu.
+ */
+class SettlementTest {
+    private val day = 86_400_000L
+    private val start = 1_767_225_600_000L // 2026-01-01T00:00:00Z
+
+    private fun settle(
+        planDays: Int,
+        usedDays: Int,
+        dailyMinor: Long = 3_000L,
+    ) = Settlement.settle(
+        agreedMinor = dailyMinor * planDays,
+        planDays = planDays,
+        startedAtMs = start,
+        predictedEndAtMs = start + planDays * day,
+        endedAtMs = start + usedDays * day,
+    )
+
+    @Test
+    fun `devolucao na data prevista nao ajusta nada`() {
+        val settled = settle(planDays = 7, usedDays = 7)
+
+        assertEquals(21_000L, settled.agreedMinor)
+        assertEquals(0L, settled.adjustmentMinor)
+        assertEquals(21_000L, settled.totalMinor)
+    }
+
+    /**
+     * A regressão que motiva metade deste serviço.
+     *
+     * A versão anterior cobrava o combinado INTEIRO e subtraía a multa:
+     * 21000 - (3 x 3000 x 0,20) = 19200. Devolver antes saía mais barato que o
+     * contrato, o que faz da "multa" um desconto. O correto é pagar os dias
+     * usados mais a multa sobre os que sobraram: 4x3000 + 3x3000x0,20 = 13800.
+     */
+    @Test
+    fun `devolucao antecipada cobra os dias usados mais multa sobre os que sobraram`() {
+        val settled = settle(planDays = 7, usedDays = 4)
+
+        assertEquals(13_800L, settled.totalMinor)
+        assertEquals(-7_200L, settled.adjustmentMinor)
+        assertEquals(4, settled.daysUsed)
+        assertTrue(settled.totalMinor < settled.agreedMinor, "devolver antes deve custar menos que o contrato")
+        assertTrue(settled.totalMinor > 4 * 3_000L, "a multa precisa aparecer acima dos dias usados")
+    }
+
+    @Test
+    fun `o plano de 15 dias multa em 40 por cento`() {
+        val settled = settle(planDays = 15, usedDays = 10, dailyMinor = 2_800L)
+
+        // 10 x 2800 + 5 x 2800 x 0,40 = 28000 + 5600
+        assertEquals(33_600L, settled.totalMinor)
+    }
+
+    @Test
+    fun `atraso soma a diaria extra a cada dia inteiro`() {
+        val settled = settle(planDays = 7, usedDays = 9)
+
+        assertEquals(21_000L + 2 * Settlement.LATE_DAY_MINOR, settled.totalMinor)
+        assertEquals(2 * Settlement.LATE_DAY_MINOR, settled.adjustmentMinor)
+    }
+
+    @Test
+    fun `a fracao de dia nao e cobrada de nenhum dos lados`() {
+        val agreed = 21_000L
+        val halfLate = Settlement.settle(agreed, 7, start, start + 7 * day, start + 7 * day + day / 2)
+        val halfEarly = Settlement.settle(agreed, 7, start, start + 7 * day, start + 6 * day + day / 2)
+
+        assertEquals(0L, halfLate.adjustmentMinor)
+        assertEquals(6, halfEarly.daysUsed)
+    }
+
+    /**
+     * A diária sai do combinado, e o arredondamento acontece uma vez só.
+     *
+     * 1000 em 3 dias dá 333,333... de diária. Um dia usado e dois de multa a
+     * 20%: 333,333... + 133,333... = 466,666..., que arredonda para 467.
+     *
+     * Arredondar cada parcela ANTES daria 333 + 133 = 466. A diferença de um
+     * centavo é o ponto: ela existe em toda divisão inexata, e cresce com o
+     * número de parcelas. Por isso a regra é arredondar uma vez, no fim.
+     */
+    @Test
+    fun `a divisao inexata arredonda uma vez, no total`() {
+        val settled = Settlement.settle(1_000L, 3, start, start + 3 * day, start + day)
+
+        assertEquals(467L, settled.totalMinor)
+        assertEquals(-533L, settled.adjustmentMinor)
+    }
+
+    @Test
+    fun `um plano sem dias nao tem diaria para liquidar`() {
+        val error = runCatching { Settlement.settle(1_000L, 0, start, start, start) }.exceptionOrNull()
+
+        assertTrue(error is IllegalArgumentException)
+    }
+}


### PR DESCRIPTION
Fecha metade do #137: o billing existe, consome `rental.closed` e emite a nota. O rental-core continua calculando o número dele — isso sai na próxima PR, junto com o console lendo a fatura.

## O bug que estava lá

`RentalService.CalculateFinalCostAsync` cobrava o combinado **inteiro** e depois **subtraía** a multa:

```
plano de 7 dias a R$ 30, devolvido no 4º dia
   antes:  210 − (3 × 30 × 0,20) = 192
  agora:   4 × 30 + 3 × 30 × 0,20 = 138
```

Devolver antes saía mais barato que o contrato pelo valor da multa — ou seja, a multa era um desconto, e o cliente ainda pagava os três dias que não usou. Nenhum teste em `RentalCoreTests` afirmava um único desses números; a busca por `AdditionalCostsOrSavings` só encontra asserções sobre **quem pode chamar** o endpoint.

O `SettlementTest` fixa os dois lados agora: devolver antes custa menos que o contrato **e** mais que os dias usados.

## A propriedade que o repositório ainda não tinha

O `SqlInboxProcessor` do rental-core reserva a mensagem, roda o handler **fora** da transação da reserva e conclui depois. O ADR 0009 documenta essa janela e vive com ela, porque o handler dele escreve em outro lugar.

Uma fatura não tem essa desculpa: o efeito é uma linha no **mesmo banco** da linha do inbox. Então a nota, o inbox e o `invoice.issued` entram no mesmo `COMMIT`.

`ExactlyOnceTest` prova isso contra um CockroachDB de verdade — inclusive o caso que interessa: uma nota recusada pelo banco **não** deixa a mensagem marcada como tratada.

### Correção ao enunciado da issue

A issue dizia que "hoje o outbox existe e ninguém lê". Estava desatualizado — o `risk-pricing` e o `telemetry` já consomem `rental.closed`, [e comentei isso na issue antes de começar](https://github.com/iVega123/ProjectY/issues/137#issuecomment-5590375439). O que continuava sem dono é a versão da promessa em que a duplicata custa **dinheiro**, e não um score recalculado.

## Duas garantias, porque falham diferente

| Guarda | Deduplica | Falha que ela cobre |
|---|---|---|
| `inbox (message_id, consumer)` | mensagens | reentrega do Kafka, republicação da relay |
| `one_invoice_per_rental` | aluguéis | replay do offset zero depois da retenção varrer o inbox |

Um replay com id novo passa pela primeira e é recusado pela segunda.

## Decisões que valem a pena discordar

- **A diária sai do evento, não da tabela de preços.** `agreed_total_minor / plan_days`. Uma liquidação cobra a tarifa que valia quando o aluguel começou; consultar a tabela de hoje faria o preço de um contrato mudar depois de assinado.
- **Arredondamento HALF_UP, uma vez, sobre o total.** Não HALF_EVEN, porque o desempate depender do dígito anterior é caro de explicar a quem recebe a fatura. E não por parcela, porque o erro se acumularia.
- **Multa de 40% para os planos de 30/45/50 dias.** O enunciado original só nomeia 7 e 15. Tratei os demais como o de 15 — a extensão conservadora. Está comentado em `Settlement.penaltyRate` para que a decisão seja visível em vez de inferida.
- **Centavos (`BIGINT`) em `invoices`, e não `DECIMAL(12,2)` como em `rentals`.** O contrato entra e sai em unidades menores; guardar decimal no meio criaria dois lugares para arredondar.
- **Sem `gradle-wrapper.jar`.** A versão está fixa na imagem base e no workflow, e o job `changes` recusa o PR se as duas divergirem. Troca um binário versionado por uma verificação em texto.

## Verificação

- **11 testes**, todos passando: 7 de liquidação (puros) e 4 de exatamente-uma-vez contra `cockroachdb/cockroach:v26.3.1`.
- `ktlintCheck` limpo — é o `dotnet format --verify-no-changes` desta linguagem.
- `003_billing.sql` aplicado **duas vezes** ao CockroachDB e ao PostgreSQL, sem erro: portátil e idempotente, como o resto de `deploy/db/sql`.
- Os três modelos do Compose validam.
- A imagem final builda; o agente do OpenTelemetry vem com checksum fixado, como o librdkafka do risk-pricing.

## Dívida registrada

- O billing conecta como `root`. O papel `billing` e os GRANTs existem em `003_billing.sql`; usá-lo depende do `GRANT CONNECT` no bootstrap — a mesma dívida já registrada no #134, e merece a própria PR.
- Sem live update no Tilt para o billing: troca a quente de classes na JVM daria menos do que custaria explicar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
