### PR TITLE
refactor(rental-core): a liquidação sai, e fechar volta a ser só fechar

### DIFF
--- a/deploy/db/sql/004_settlement_moves_to_billing.sql
+++ b/deploy/db/sql/004_settlement_moves_to_billing.sql
@@ -1,0 +1,21 @@
+-- O #137 tirou a liquidação do rental-core, e estas colunas vão junto.
+--
+-- Elas nasceram em 002 porque a mesma classe que fechava o aluguel calculava o
+-- dinheiro: `RentalService.CalculateFinalCostAsync` gravava o total final, o
+-- ajuste e a frase que o explicava. Quem produz esses três agora é o billing, e
+-- eles moram em `invoices` (003) -- em centavos, junto do id da nota e do
+-- motivo, que é onde uma liquidação pertence.
+--
+-- Este arquivo não as recria condicionalmente nem as preserva: um aluguel
+-- fechado antes daqui perde o número que o rental-core guardava, e o
+-- `rental.closed` correspondente é o que o billing precisa para refazê-lo. Vale
+-- o mesmo que valeu no #135 -- não existe instalação a preservar, e a virada é
+-- `docker compose down -v`.
+--
+-- 001 e 002 ficam como estão. Eles descrevem o que era verdade quando foram
+-- escritos; apagar as colunas de lá faria a história dizer que a liquidação
+-- nunca esteve aqui, e ela esteve.
+
+ALTER TABLE rentals DROP COLUMN IF EXISTS final_cost;
+ALTER TABLE rentals DROP COLUMN IF EXISTS additional_costs;
+ALTER TABLE rentals DROP COLUMN IF EXISTS status_message;

--- a/deploy/db/tests/double_booking_release.sql
+++ b/deploy/db/tests/double_booking_release.sql
@@ -5,7 +5,7 @@
 -- devolvida não poder ser alugada nunca mais. É este arquivo que prova que a
 -- restrição é parcial, e não só única.
 UPDATE rentals
-   SET status = 'closed', ends_at = now(), final_cost = 210.00
+   SET status = 'closed', ends_at = now()
  WHERE status = 'active'
    AND motorcycle_id IN (SELECT id FROM motorcycles WHERE license_plate = 'CI0T35T');
 

--- a/docs/AUDITORIA-ARQUITETURA-SEGURANCA.md
+++ b/docs/AUDITORIA-ARQUITETURA-SEGURANCA.md
@@ -90,6 +90,12 @@ autenticado; na linha 111 faz `response.UserId = userId` antes de gravar.
 `UserId`. O controller converte a violação em `403`. Testes pelo pipeline HTTP comprovam que um
 rider não consegue finalizar nem ler o resultado já finalizado de outro, que o documento permanece
 inalterado na tentativa e que o proprietário legítimo continua conseguindo finalizar o aluguel.
+
+**Nota de #137.** O método passou a chamar-se `CloseRentalAsync` e a rota, `POST /api/Rental/close`.
+A comparação de proprietário é a mesma e os testes acima continuam existindo com os nomes
+`Close_*`; o que saiu do método foi o cálculo do valor, que hoje mora no billing. Este relatório
+é um registro datado e não foi reescrito -- esta nota existe só para que um achado fechado
+continue verificável.
 Fechado pelo commit
 [`e0873be`](https://github.com/iVega123/ProjectY/commit/e0873be) (C4, task #21).
 

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -23,7 +23,11 @@ installation holding real rentals would need at least:
 - every rental copied, closed history included, carrying `rider_name`,
   `additional_costs` and `status_message`. The pre-cutover mirror wrote nine
   columns and none of those three, so migrated rows would read back as `0` and
-  empty text rather than as what was settled.
+  empty text rather than as what was settled. (#137 has since dropped the last
+  two from `rentals` altogether — settlement moved to `invoices`, and
+  `004_settlement_moves_to_billing.sql` is where they leave. The paragraph
+  stands as written because it describes what the #135 cutover would have had to
+  carry at the time it happened.)
 - a stable external identifier. The mirror derived a row id by zero-padding a
   12-byte ObjectId into a UUID, while issued URLs and already-published
   `rental.started` events carry the ObjectId itself — so a migrated rental's

--- a/docs/runbooks/polyglot-services.md
+++ b/docs/runbooks/polyglot-services.md
@@ -107,11 +107,18 @@ two republishes the same event, and its id -- derived from the rental and the
 subject -- is what lets the consumer recognise it. The partition key is the
 motorcycle id, which does not change when a licence plate is corrected.
 
-Concurrent settlements are decided by the update's row count under a status
-guard: if another request has already closed the rental, the losing request
-returns HTTP 409 and does not persist its calculation. Reloading the rental or
-retrying settlement after completion returns the stored dates and costs; only
-the winning update enqueues `rental.closed`.
+Concurrent closings are decided by the update's row count under a status guard:
+if another request has already closed the rental, the losing request returns
+HTTP 409. Closing again returns the stored rental unchanged; only the winning
+update enqueues `rental.closed`.
+
+Since #137 that endpoint is `POST /api/Rental/close`, and it computes no money.
+It records the end date and the status; what is owed is decided by billing from
+the event, which makes the amount eventually consistent by design. Closing
+returns the closed rental, not the invoice — the invoice exists moments later,
+once the relay publishes and the consumer settles. A rental closed with no
+invoice after the relay has drained means billing is behind or refused the
+event, and its log says which.
 
 The billing consumer separates a broken message from a broken dependency,
 because the two need opposite answers. Undecodable Protobuf and an event

--- a/services/api-gateway/src/lib.rs
+++ b/services/api-gateway/src/lib.rs
@@ -1723,7 +1723,7 @@ mod tests {
         let token = issuer.token("projecty.rental-operations", &["Rider"]);
         let response = app
             .oneshot(
-                HttpRequest::post("/api/rental/calculate-final-cost?plan=weekly")
+                HttpRequest::post("/api/rental/close?plan=weekly")
                     .header(AUTHORIZATION, format!("Bearer {token}"))
                     .header(http::header::COOKIE, "session=must-not-cross")
                     .body(Body::empty())
@@ -1746,7 +1746,7 @@ mod tests {
             .strip_prefix("v1=")
             .unwrap();
         let canonical = format!(
-            "v1\nlocal-v1\nrider-123\nRider\n{issued_at}\nPOST\n/api/rental/calculate-final-cost?plan=weekly\nprojecty.rental-operations"
+            "v1\nlocal-v1\nrider-123\nRider\n{issued_at}\nPOST\n/api/rental/close?plan=weekly\nprojecty.rental-operations"
         );
         let mut mac = Hmac::<Sha256>::new_from_slice(&[b'x'; 32]).unwrap();
         mac.update(canonical.as_bytes());
@@ -1857,7 +1857,7 @@ mod tests {
         let token = issuer.token("projecty.rider-manager", &["Rider"]);
         let response = app
             .oneshot(
-                HttpRequest::post("/api/rental/calculate-final-cost")
+                HttpRequest::post("/api/rental/close")
                     .header(AUTHORIZATION, format!("Bearer {token}"))
                     .body(Body::empty())
                     .unwrap(),
@@ -1883,7 +1883,7 @@ mod tests {
         let token = issuer.token_with_lifetime("projecty.rental-operations", &["Rider"], 301);
         let response = app
             .oneshot(
-                HttpRequest::post("/api/rental/calculate-final-cost")
+                HttpRequest::post("/api/rental/close")
                     .header(AUTHORIZATION, format!("Bearer {token}"))
                     .body(Body::empty())
                     .unwrap(),
@@ -1908,7 +1908,7 @@ mod tests {
         let first_response = app
             .clone()
             .oneshot(
-                HttpRequest::post("/api/rental/calculate-final-cost")
+                HttpRequest::post("/api/rental/close")
                     .header(AUTHORIZATION, format!("Bearer {first_token}"))
                     .body(Body::empty())
                     .unwrap(),
@@ -1922,7 +1922,7 @@ mod tests {
         let second_response = app
             .clone()
             .oneshot(
-                HttpRequest::post("/api/rental/calculate-final-cost")
+                HttpRequest::post("/api/rental/close")
                     .header(AUTHORIZATION, format!("Bearer {second_token}"))
                     .body(Body::empty())
                     .unwrap(),
@@ -1934,7 +1934,7 @@ mod tests {
 
         let retired_response = app
             .oneshot(
-                HttpRequest::post("/api/rental/calculate-final-cost")
+                HttpRequest::post("/api/rental/close")
                     .header(AUTHORIZATION, format!("Bearer {first_token}"))
                     .body(Body::empty())
                     .unwrap(),
@@ -1955,7 +1955,7 @@ mod tests {
         let token = issuer.token("projecty.rental-operations", &["Rider"]);
         let response = app
             .oneshot(
-                HttpRequest::post("/api/rental/calculate-final-cost")
+                HttpRequest::post("/api/rental/close")
                     .header(AUTHORIZATION, format!("Bearer {token}"))
                     .body(Body::empty())
                     .unwrap(),
@@ -1977,7 +1977,7 @@ mod tests {
         let app = build_app(config).unwrap();
         let token = issuer.token("projecty.rental-operations", &["Rider"]);
         let request = || {
-            HttpRequest::post("/api/rental/calculate-final-cost")
+            HttpRequest::post("/api/rental/close")
                 .header(AUTHORIZATION, format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap()

--- a/services/rental-core/RentalCore/Rentals/Controllers/RentalController.cs
+++ b/services/rental-core/RentalCore/Rentals/Controllers/RentalController.cs
@@ -130,8 +130,15 @@ namespace RentalOperations.Controllers
             }
         }
 
-        [HttpPost("calculate-final-cost")]
-        public async Task<IActionResult> CalculateFinalCost([FromQuery] string rentalId, [FromQuery] DateTime actualEndDate)
+        /// <summary>
+        /// Fecha o aluguel.
+        ///
+        /// Chamava-se calculate-final-cost, e o nome era o problema: um POST que
+        /// diz "calcular" e na verdade encerra o contrato. Encerrar é o que ele
+        /// sempre fez; o cálculo saiu daqui no #137 e a rota passa a dizer isso.
+        /// </summary>
+        [HttpPost("close")]
+        public async Task<IActionResult> Close([FromQuery] string rentalId, [FromQuery] DateTime actualEndDate)
         {
             try
             {
@@ -140,7 +147,7 @@ namespace RentalOperations.Controllers
                 {
                     return Forbid();
                 }
-                var response = await _rentalService.CalculateFinalCostAsync(rentalId, userIdClaim.Value, actualEndDate);
+                var response = await _rentalService.CloseRentalAsync(rentalId, userIdClaim.Value, actualEndDate);
                 return Ok(response);
             }
             catch (UnauthorizedAccessException)

--- a/services/rental-core/RentalCore/Rentals/DTOs/ResponseRentalDTO.cs
+++ b/services/rental-core/RentalCore/Rentals/DTOs/ResponseRentalDTO.cs
@@ -20,10 +20,15 @@
         public DateTime StartDate { get; set; }
         public DateTime PredictedEndDate { get; set; }
         public DateTime? ActualEndDate { get; set; }
+
+        /// <summary>
+        /// O combinado, e só ele.
+        ///
+        /// O total final, o ajuste e a frase que os explicava saíram daqui no
+        /// #137: quem os produz é o billing, e lê-los desta resposta faria a
+        /// tela acreditar que o rental-core ainda os conhece.
+        /// </summary>
         public decimal OriginalTotalCost { get; set; }
-        public decimal FinalTotalCost { get; set; }
-        public decimal AdditionalCostsOrSavings { get; set; }
-        public string StatusMessage { get; set; } = string.Empty;
     }
 
 }

--- a/services/rental-core/RentalCore/Rentals/Mapper/RentalProfile.cs
+++ b/services/rental-core/RentalCore/Rentals/Mapper/RentalProfile.cs
@@ -16,9 +16,6 @@ namespace RentalOperations.Mapper
             .ForMember(dest => dest.PredictedEndDate, opt => opt.MapFrom(src => src.PredictedEndDate))
             .ForMember(dest => dest.OriginalTotalCost, opt => opt.MapFrom(src => src.InitCost))
             .ForMember(dest => dest.ActualEndDate, opt => opt.MapFrom(src => src.EndDate))
-            .ForMember(dest => dest.FinalTotalCost, opt => opt.MapFrom(src => src.FinalCost))
-            .ForMember(dest => dest.AdditionalCostsOrSavings, opt => opt.MapFrom(src => src.AdditionalCostsOrSavings))
-            .ForMember(dest => dest.StatusMessage, opt => opt.MapFrom(src => src.StatusMessage))
             .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.UserId));
 
         }

--- a/services/rental-core/RentalCore/Rentals/Model/Rental.cs
+++ b/services/rental-core/RentalCore/Rentals/Model/Rental.cs
@@ -22,9 +22,15 @@ public sealed class Rental
     public DateTime StartDate { get; set; }
     public DateTime? EndDate { get; set; }
     public DateTime PredictedEndDate { get; set; }
+    /// <summary>
+    /// O combinado, decidido quando o aluguel começa. Não é a liquidação.
+    ///
+    /// Continua aqui porque é o preço do contrato, e o billing precisa dele no
+    /// evento para saber a diária que valia. O que saiu no #137 foi o outro
+    /// número -- quanto se deve no fim --, que era calculado nesta classe e
+    /// agora tem dono.
+    /// </summary>
     public decimal InitCost { get; set; }
-    public decimal FinalCost { get; set; }
-    public decimal AdditionalCostsOrSavings { get; set; }
-    public string StatusMessage { get; set; } = string.Empty;
+
     public RentalStatus Status { get; set; } = RentalStatus.Active;
 }

--- a/services/rental-core/RentalCore/Rentals/Repository/SqlRentalRepository.cs
+++ b/services/rental-core/RentalCore/Rentals/Repository/SqlRentalRepository.cs
@@ -35,8 +35,7 @@ public sealed class SqlRentalRepository(NpgsqlDataSource database) : IRentalRepo
 
     private const string SelectRental = """
         SELECT r.id, r.rider_id, r.motorcycle_id, r.rider_name, m.license_plate,
-               r.starts_at, r.predicted_ends_at, r.ends_at, r.init_cost, r.final_cost,
-               r.additional_costs, r.status_message, r.status, r.created_at
+               r.starts_at, r.predicted_ends_at, r.ends_at, r.init_cost, r.status, r.created_at
           FROM rentals AS r
           JOIN motorcycles AS m ON m.id = r.motorcycle_id
         """;
@@ -60,11 +59,9 @@ public sealed class SqlRentalRepository(NpgsqlDataSource database) : IRentalRepo
                      FOR UPDATE
                 )
                 INSERT INTO rentals (id, rider_id, motorcycle_id, rider_name, starts_at,
-                                     predicted_ends_at, ends_at, init_cost, final_cost,
-                                     additional_costs, status_message, status)
+                                     predicted_ends_at, ends_at, init_cost, status)
                 SELECT @id, @rider, available.id, @rider_name, @starts::timestamptz,
-                       @predicted::timestamptz, @ends::timestamptz, @init::decimal,
-                       @final::decimal, @additional::decimal, @message, @status
+                       @predicted::timestamptz, @ends::timestamptz, @init::decimal, @status
                   FROM available
                 """, connection, transaction))
             {
@@ -76,9 +73,6 @@ public sealed class SqlRentalRepository(NpgsqlDataSource database) : IRentalRepo
                 insert.Parameters.AddWithValue("predicted", Utc(rental.PredictedEndDate));
                 insert.Parameters.AddWithValue("ends", rental.EndDate is { } ends ? Utc(ends) : DBNull.Value);
                 insert.Parameters.AddWithValue("init", rental.InitCost);
-                insert.Parameters.AddWithValue("final", rental.FinalCost == 0m ? DBNull.Value : rental.FinalCost);
-                insert.Parameters.AddWithValue("additional", rental.AdditionalCostsOrSavings);
-                insert.Parameters.AddWithValue("message", rental.StatusMessage);
                 insert.Parameters.AddWithValue("status", ToColumn(rental.Status));
                 inserted = await insert.ExecuteNonQueryAsync(token);
             }
@@ -121,18 +115,12 @@ public sealed class SqlRentalRepository(NpgsqlDataSource database) : IRentalRepo
         await using (var update = new NpgsqlCommand($"""
             UPDATE rentals
                SET ends_at = @ends,
-                   final_cost = @final,
-                   additional_costs = @additional,
-                   status_message = @message,
                    status = @status
              WHERE id = @id{guard}
             """, connection, transaction))
         {
             update.Parameters.AddWithValue("id", rental.Id);
             update.Parameters.AddWithValue("ends", rental.EndDate is { } ends ? Utc(ends) : DBNull.Value);
-            update.Parameters.AddWithValue("final", rental.FinalCost == 0m ? DBNull.Value : rental.FinalCost);
-            update.Parameters.AddWithValue("additional", rental.AdditionalCostsOrSavings);
-            update.Parameters.AddWithValue("message", rental.StatusMessage);
             update.Parameters.AddWithValue("status", ToColumn(rental.Status));
             updated = await update.ExecuteNonQueryAsync(token);
         }
@@ -360,11 +348,6 @@ public sealed class SqlRentalRepository(NpgsqlDataSource database) : IRentalRepo
             ? null
             : reader.GetDateTime(reader.GetOrdinal("ends_at")),
         InitCost = reader.GetDecimal(reader.GetOrdinal("init_cost")),
-        FinalCost = reader.IsDBNull(reader.GetOrdinal("final_cost"))
-            ? 0m
-            : reader.GetDecimal(reader.GetOrdinal("final_cost")),
-        AdditionalCostsOrSavings = reader.GetDecimal(reader.GetOrdinal("additional_costs")),
-        StatusMessage = reader.GetString(reader.GetOrdinal("status_message")),
         Status = FromColumn(reader.GetString(reader.GetOrdinal("status")))
     };
 

--- a/services/rental-core/RentalCore/Rentals/Services/IRentalService.cs
+++ b/services/rental-core/RentalCore/Rentals/Services/IRentalService.cs
@@ -8,7 +8,7 @@ namespace RentalOperations.Services
     public interface IRentalService
     {
         Task CreateRentalAsync(RentalCreateDto createDto, string userId);
-        Task<ResponseRentalDTO> CalculateFinalCostAsync(string rentalId, string userId, DateTime actualEndDate);
+        Task<ResponseRentalDTO> CloseRentalAsync(string rentalId, string userId, DateTime actualEndDate);
         Task<CursorPage<ResponseRentalDTO>> GetRentalsByUserIdAsync(
             string userId,
             string? cursor,

--- a/services/rental-core/RentalCore/Rentals/Services/RentalService.cs
+++ b/services/rental-core/RentalCore/Rentals/Services/RentalService.cs
@@ -97,7 +97,19 @@ namespace RentalOperations.Services
             await _repository.CreateRentalAsync(rental);
         }
 
-        public async Task<ResponseRentalDTO> CalculateFinalCostAsync(string rentalId, string userId, DateTime actualEndDate)
+        /// <summary>
+        /// Fecha o aluguel. Não calcula dinheiro.
+        ///
+        /// O que acontece aqui é uma transição de estado e uma data. Quanto se
+        /// deve é decidido pelo billing, a partir do rental.closed que esta
+        /// mesma transação enfileira -- porque liquidação e ciclo de vida do
+        /// aluguel são contextos diferentes, e até o #137 dividiam esta classe.
+        ///
+        /// A consequência está à vista e vale ser dita: o valor devido passa a
+        /// ser eventualmente consistente. Fechar devolve o aluguel fechado, não
+        /// a fatura; ela existe alguns instantes depois, quando o evento chega.
+        /// </summary>
+        public async Task<ResponseRentalDTO> CloseRentalAsync(string rentalId, string userId, DateTime actualEndDate)
         {
             var rental = await BeforeWriteAsync(() => _repository.GetRentalByIdAsync(rentalId));
 
@@ -107,44 +119,27 @@ namespace RentalOperations.Services
             if (!string.Equals(rental.UserId, userId, StringComparison.Ordinal))
                 throw new UnauthorizedAccessException("The rental belongs to another rider.");
 
+            // Fechar de novo devolve o mesmo aluguel em vez de enfileirar um
+            // segundo rental.closed: o inbox do billing reconheceria a
+            // repetição, mas não há razão para produzi-la.
             if (rental.Status == RentalStatus.Completed)
             {
                 return _mapper.Map<ResponseRentalDTO>(rental);
             }
 
-            var response = _mapper.Map<ResponseRentalDTO>(rental);
-            response.ActualEndDate = actualEndDate;
-
-            int daysPlanned = (rental.PredictedEndDate - rental.StartDate).Days;
-            decimal dailyRate = daysPlanned > 0 ? rental.InitCost / daysPlanned : 0;
-
-            if (actualEndDate < rental.PredictedEndDate)
+            // Uma devolução antes do início não existe, e o billing não tem como
+            // recusá-la: para ele seriam zero dias usados e o plano inteiro em
+            // multa. A data é entrada de usuário, e a validação pertence a quem
+            // a recebe.
+            if (actualEndDate < rental.StartDate)
             {
-                decimal penaltyRate = GetPenaltyRate(daysPlanned);
-                int daysEarly = (rental.PredictedEndDate - actualEndDate).Days;
-                response.AdditionalCostsOrSavings = -(daysEarly * dailyRate * penaltyRate);
-                response.StatusMessage = "Return was early. A penalty was applied.";
+                throw new ArgumentException("A rental cannot end before it starts.");
             }
-            else if (actualEndDate > rental.PredictedEndDate)
-            {
-                int daysLate = (actualEndDate - rental.PredictedEndDate).Days;
-                response.AdditionalCostsOrSavings = daysLate * 50.00m;
-                response.StatusMessage = "Return was late. Additional cost for extra days.";
-            }
-            else
-            {
-                response.StatusMessage = "Returned on the predicted end date. No additional costs.";
-            }
-
-            response.FinalTotalCost = response.OriginalTotalCost + response.AdditionalCostsOrSavings;
 
             rental.EndDate = actualEndDate;
-            rental.FinalCost = response.FinalTotalCost;
-            rental.AdditionalCostsOrSavings = response.AdditionalCostsOrSavings;
-            rental.StatusMessage = response.StatusMessage;
             rental.Status = RentalStatus.Completed;
             await _repository.UpdateRentalAsync(rental);
-            return response;
+            return _mapper.Map<ResponseRentalDTO>(rental);
         }
 
         public async Task<CursorPage<ResponseRentalDTO>> GetRentalsByUserIdAsync(
@@ -193,10 +188,5 @@ namespace RentalOperations.Services
             }
         }
 
-        private decimal GetPenaltyRate(int days)
-        {
-            if (days <= 7) return 0.20m;
-            return 0.40m;
-        }
     }
 }

--- a/services/rental-core/RentalCoreTests/Rentals/Integration/AdminAuthorizationPipelineTests.cs
+++ b/services/rental-core/RentalCoreTests/Rentals/Integration/AdminAuthorizationPipelineTests.cs
@@ -71,7 +71,7 @@ public class AdminAuthorizationPipelineTests : IClassFixture<CustomWebApplicatio
     }
 
     [Fact]
-    public async Task CalculateFinalCost_ForAnotherRidersRental_ReturnsForbiddenAndLeavesRentalUnchanged()
+    public async Task Close_ForAnotherRidersRental_ReturnsForbiddenAndLeavesRentalUnchanged()
     {
         var original = _factory.Repository.SeedRental(new Rental
         {
@@ -87,7 +87,7 @@ public class AdminAuthorizationPipelineTests : IClassFixture<CustomWebApplicatio
         var actualEndDate = Uri.EscapeDataString(original.PredictedEndDate.ToString("O"));
 
         var response = await client.PostAsync(
-            $"/api/Rental/calculate-final-cost?rentalId={rentalId}&actualEndDate={actualEndDate}",
+            $"/api/Rental/close?rentalId={rentalId}&actualEndDate={actualEndDate}",
             content: null);
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -95,13 +95,11 @@ public class AdminAuthorizationPipelineTests : IClassFixture<CustomWebApplicatio
         Assert.NotNull(persisted);
         Assert.Equal(original.UserId, persisted.UserId);
         Assert.Equal(original.EndDate, persisted.EndDate);
-        Assert.Equal(original.FinalCost, persisted.FinalCost);
-        Assert.Equal(original.AdditionalCostsOrSavings, persisted.AdditionalCostsOrSavings);
-        Assert.Equal(original.StatusMessage, persisted.StatusMessage);
+        Assert.Equal(RentalStatus.Active, persisted.Status);
     }
 
     [Fact]
-    public async Task CalculateFinalCost_ForFinalizedRentalOwnedByAnotherRider_ReturnsForbidden()
+    public async Task Close_ForFinalizedRentalOwnedByAnotherRider_ReturnsForbidden()
     {
         var original = _factory.Repository.SeedRental(new Rental
         {
@@ -112,22 +110,21 @@ public class AdminAuthorizationPipelineTests : IClassFixture<CustomWebApplicatio
             EndDate = DateTime.UtcNow.Date,
             PredictedEndDate = DateTime.UtcNow.Date,
             InitCost = 210m,
-            FinalCost = 210m,
-            StatusMessage = "Already finalized."
+            Status = RentalStatus.Completed
         });
         var rentalId = original.Id.ToString();
         using var client = CreateClient("Rider", "rider-b");
         var actualEndDate = Uri.EscapeDataString(original.EndDate!.Value.ToString("O"));
 
         var response = await client.PostAsync(
-            $"/api/Rental/calculate-final-cost?rentalId={rentalId}&actualEndDate={actualEndDate}",
+            $"/api/Rental/close?rentalId={rentalId}&actualEndDate={actualEndDate}",
             content: null);
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
     [Fact]
-    public async Task CalculateFinalCost_ForOwnedRental_PreservesOwner()
+    public async Task Close_ForOwnedRental_PreservesOwnerAndRecordsOnlyTheEndDate()
     {
         var original = _factory.Repository.SeedRental(new Rental
         {
@@ -143,7 +140,7 @@ public class AdminAuthorizationPipelineTests : IClassFixture<CustomWebApplicatio
         var actualEndDate = Uri.EscapeDataString(original.PredictedEndDate.ToString("O"));
 
         var response = await client.PostAsync(
-            $"/api/Rental/calculate-final-cost?rentalId={rentalId}&actualEndDate={actualEndDate}",
+            $"/api/Rental/close?rentalId={rentalId}&actualEndDate={actualEndDate}",
             content: null);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -151,7 +148,11 @@ public class AdminAuthorizationPipelineTests : IClassFixture<CustomWebApplicatio
         Assert.NotNull(persisted);
         Assert.Equal(original.UserId, persisted.UserId);
         Assert.Equal(original.PredictedEndDate, persisted.EndDate);
-        Assert.Equal(original.InitCost, persisted.FinalCost);
+        Assert.Equal(RentalStatus.Completed, persisted.Status);
+        // O combinado nao muda ao fechar: ele e o preco do contrato. O quanto se
+        // deve depois da devolucao nao esta mais nesta resposta nem nesta tabela
+        // -- e a nota que o billing emite a partir do rental.closed.
+        Assert.Equal(original.InitCost, persisted.InitCost);
     }
 
     private HttpClient CreateClient(string role, string userId = "requesting-user")

--- a/services/rental-core/RentalCoreTests/Rentals/Integration/Database/RentalStoreTests.cs
+++ b/services/rental-core/RentalCoreTests/Rentals/Integration/Database/RentalStoreTests.cs
@@ -58,7 +58,6 @@ public sealed class RentalStoreTests(RentalCoreDatabase database)
         var first = await repository.CreateRentalAsync(NewRental(motorcycleId, "rider-first"));
         first.Status = RentalStatus.Completed;
         first.EndDate = first.PredictedEndDate;
-        first.FinalCost = 210m;
         await repository.UpdateRentalAsync(first);
 
         // O predicado é o que torna a restrição correta. Um índice único comum
@@ -130,7 +129,6 @@ public sealed class RentalStoreTests(RentalCoreDatabase database)
             var snapshot = await repository.GetRentalByIdAsync(rental.Id.ToString());
             snapshot!.Status = RentalStatus.Completed;
             snapshot.EndDate = snapshot.PredictedEndDate;
-            snapshot.FinalCost = 210m;
             try
             {
                 await repository.UpdateRentalAsync(snapshot);
@@ -166,7 +164,6 @@ public sealed class RentalStoreTests(RentalCoreDatabase database)
         var created = await repository.CreateRentalAsync(rental);
         created.Status = RentalStatus.Completed;
         created.EndDate = start.AddDays(7);
-        created.FinalCost = 210m;
         await repository.UpdateRentalAsync(created);
 
         // Um aluguel devolvido continua ocupando a agenda até onde ocupou. Sem

--- a/services/rental-core/RentalCoreTests/Rentals/Unit/Messaging/RegisteredEventSchemaTests.cs
+++ b/services/rental-core/RentalCoreTests/Rentals/Unit/Messaging/RegisteredEventSchemaTests.cs
@@ -73,6 +73,46 @@ public sealed class RegisteredEventSchemaTests
         Assert.Equal("Original name", message.RiderName);
     }
 
+    /// <summary>
+    /// O contrato com o billing, agora que a liquidação mora lá.
+    ///
+    /// O billing recusa um rental.closed sem ended_at_ms ou sem plan_days -- não
+    /// há como liquidar sem eles -- e calcula errado sem as outras duas datas.
+    /// Nada disso é opcional do lado de cá, e este teste é o que faz uma coluna
+    /// removida do evento aparecer aqui em vez de virar uma fatura errada.
+    /// </summary>
+    [Fact]
+    public void ClosedEventCarriesEverythingTheSettlementNeeds()
+    {
+        var start = new DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc);
+        var rental = new Rental
+        {
+            MotorcycleId = new Guid("22222222-2222-2222-2222-222222222222"),
+            UserId = "rider",
+            InitCost = 210m,
+            StartDate = start,
+            PredictedEndDate = start.AddDays(7),
+            EndDate = start.AddDays(4),
+            Status = RentalStatus.Completed
+        };
+
+        var message = RentalEvent.Parser.ParseFrom(
+            RentalEventEnvelope.Create(rental, "rental.closed").Payload);
+
+        Assert.True(message.HasEndedAtMs, "sem a data de fim o billing recusa o evento");
+        Assert.Equal(7, message.PlanDays);
+        Assert.Equal(21000, message.AgreedTotalMinor);
+        Assert.Equal(
+            new DateTimeOffset(start).ToUnixTimeMilliseconds(),
+            message.StartedAtMs);
+        Assert.Equal(
+            new DateTimeOffset(start.AddDays(7)).ToUnixTimeMilliseconds(),
+            message.PredictedEndAtMs);
+        Assert.Equal(
+            new DateTimeOffset(start.AddDays(4)).ToUnixTimeMilliseconds(),
+            message.EndedAtMs);
+    }
+
     private sealed class RegistryHandler : HttpMessageHandler
     {
         public bool Available { get; set; } = true;

--- a/services/rental-core/RentalCoreTests/Rentals/Unit/Services/RentalServiceTests.cs
+++ b/services/rental-core/RentalCoreTests/Rentals/Unit/Services/RentalServiceTests.cs
@@ -146,6 +146,76 @@ public sealed class RentalServiceTests
     }
 
     /// <summary>
+    /// Fechar grava a data e o estado, e mais nada.
+    ///
+    /// A devolução é dois dias atrasada de propósito: era o caso em que a versão
+    /// anterior somava R$ 50 por dia e escrevia a frase que explicava a soma,
+    /// tudo dentro de um método chamado Calculate. O aluguel que chega ao
+    /// repositório agora não carrega número nenhum além do combinado.
+    /// </summary>
+    [Fact]
+    public async Task CloseRental_RecordsTheDateAndStatusWithoutSettling()
+    {
+        var start = DateTime.UtcNow.Date;
+        var rental = new RentalOperations.Model.Rental
+        {
+            Id = Guid.NewGuid(),
+            MotorcycleId = Motorcycle,
+            UserId = "rider-1",
+            StartDate = start,
+            PredictedEndDate = start.AddDays(7),
+            InitCost = 210m
+        };
+        var repository = new Mock<IRentalRepository>();
+        repository.Setup(r => r.GetRentalByIdAsync(rental.Id.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rental);
+        RentalOperations.Model.Rental? persisted = null;
+        repository.Setup(r => r.UpdateRentalAsync(
+                It.IsAny<RentalOperations.Model.Rental>(), It.IsAny<CancellationToken>()))
+            .Callback((RentalOperations.Model.Rental updated, CancellationToken _) => persisted = updated)
+            .Returns(Task.CompletedTask);
+        var service = new RentalService(
+            repository.Object, Mock.Of<IMapper>(), Mock.Of<IRiderProjectionStore>(), Mock.Of<IMotorcycleService>());
+
+        await service.CloseRentalAsync(rental.Id.ToString(), "rider-1", start.AddDays(9));
+
+        Assert.NotNull(persisted);
+        Assert.Equal(start.AddDays(9), persisted!.EndDate);
+        Assert.Equal(RentalOperations.Model.RentalStatus.Completed, persisted.Status);
+        Assert.Equal(210m, persisted.InitCost);
+    }
+
+    /// <summary>
+    /// Uma devolução anterior ao início não existe, e o billing não teria como
+    /// recusá-la: para ele seriam zero dias usados e o plano inteiro em multa --
+    /// a fatura mais cara possível, a partir de uma data impossível.
+    /// </summary>
+    [Fact]
+    public async Task CloseRental_BeforeTheRentalStarted_IsRefusedWithoutWriting()
+    {
+        var start = DateTime.UtcNow.Date;
+        var rental = new RentalOperations.Model.Rental
+        {
+            Id = Guid.NewGuid(),
+            MotorcycleId = Motorcycle,
+            UserId = "rider-1",
+            StartDate = start,
+            PredictedEndDate = start.AddDays(7),
+            InitCost = 210m
+        };
+        var repository = new Mock<IRentalRepository>();
+        repository.Setup(r => r.GetRentalByIdAsync(rental.Id.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rental);
+        var service = new RentalService(
+            repository.Object, Mock.Of<IMapper>(), Mock.Of<IRiderProjectionStore>(), Mock.Of<IMotorcycleService>());
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.CloseRentalAsync(rental.Id.ToString(), "rider-1", start.AddDays(-1)));
+        repository.Verify(r => r.UpdateRentalAsync(
+            It.IsAny<RentalOperations.Model.Rental>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
     /// O suficiente para o filtro ser observável. Estes testes são sobre quem
     /// pode ver o quê, não sobre o mapeamento -- que tem o seu próprio caminho.
     /// </summary>


### PR DESCRIPTION
Segunda metade do #137. O billing é dono da liquidação desde a [#183](https://github.com/iVega123/ProjectY/pull/183); esta PR é o rental-core soltando.

## O nome era o problema

`CalculateFinalCostAsync` virou `CloseRentalAsync`. Um `POST` chamado *calculate* que na verdade encerra o contrato eram dois contextos dividindo um método — o que sobra é uma transição de estado e uma data.

`final_cost`, `additional_costs` e `status_message` saem do modelo, do DTO, do mapper, de todos os comandos do repositório e da tabela `rentals`. A rota acompanha: `POST /api/Rental/calculate-final-cost` → `POST /api/Rental/close`.

## O que fica, e por quê

`InitCost` continua. **A distinção importa:** é o preço combinado do contrato, decidido quando o aluguel começa, e o billing precisa dele no evento para saber a diária que valia. O que saiu é o *outro* número — quanto se deve no fim — que era o calculado no lugar errado.

Ou seja: o rental-core continua precificando o contrato. Ele parou de liquidar.

## A consequência, dita em vez de escondida

**O valor devido passa a ser eventualmente consistente.** Fechar devolve o aluguel fechado, não a fatura; ela existe alguns instantes depois, quando a relay publica e o billing liquida.

Está no doc do método e no runbook, que também diz o que significa um aluguel fechado sem nota depois de a relay drenar: o billing está atrasado ou recusou o evento, e o log dele diz qual.

## Uma validação nova

Fechar antes do início agora é recusado. O billing **não teria como pegar**: para ele seriam zero dias usados e o plano inteiro em multa — a fatura mais cara possível, a partir de uma data impossível. A data é entrada de usuário, e a validação pertence a quem a recebe.

## O schema

`004_settlement_moves_to_billing.sql` derruba as três colunas. **001 e 002 ficam como estão** — eles descrevem o que era verdade quando foram escritos, e editá-los faria a história dizer que a liquidação nunca esteve aqui. Ela esteve.

## Testes novos

- **`ClosedEventCarriesEverythingTheSettlementNeeds`** — o contrato com o billing. Ele recusa um `rental.closed` sem `ended_at_ms` ou `plan_days`, e calcula errado sem as outras duas datas. Este teste faz um campo removido do evento aparecer aqui em vez de virar uma fatura errada.
- **`CloseRental_RecordsTheDateAndStatusWithoutSettling`** — devolução dois dias atrasada de propósito: era exatamente o caso em que a versão anterior somava R$ 50/dia e escrevia a frase explicando a soma.
- **`CloseRental_BeforeTheRentalStarted_IsRefusedWithoutWriting`**.

## Verificação

| | |
|---|---|
| rental-core | **137** testes (eram 134) |
| api-gateway | **46** testes, `cargo fmt` limpo |
| formatação | `dotnet format --verify-no-changes` sai 0 |
| schema | aplicado **duas vezes** ao CockroachDB e ao PostgreSQL; a invariante de reserva dupla continua valendo nos dois |

Conferi as colunas depois da migração nos dois engines: `rentals` tem 10 colunas e nenhuma delas é de dinheiro liquidado.

## Fora do escopo, de propósito

**Nada consegue ler uma fatura por HTTP ainda.** O billing servi-la exige verificar o esquema de identidade do gateway em Kotlin — um limite de segurança reimplementado numa segunda linguagem, que merece PR e revisão próprias. É a próxima. O console compondo a tela é o #138, que é explicitamente dono disso.

Uma nota também no `AUDITORIA-ARQUITETURA-SEGURANCA.md`: o achado C4 está fechado e apontava para `CalculateFinalCostAsync`. O relatório é um registro datado e não foi reescrito, mas um achado de segurança fechado que aponta para um método inexistente deixa de ser verificável — então a nota diz o nome novo e que a comparação de proprietário é a mesma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
