### PR TITLE
feat(billing): a nota fica legível, e o envelope do portão é verificado em Kotlin

### DIFF
--- a/docker-compose.polyglot.yml
+++ b/docker-compose.polyglot.yml
@@ -96,6 +96,13 @@ services:
       BILLING_DATABASE_URL: jdbc:postgresql://cockroachdb:26257/projecty?sslmode=disable&user=root
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       SCHEMA_REGISTRY_URL: http://schema-registry:8080/apis/ccompat/v7
+      # A leitura da fatura passa pelo portão, e o billing confere o envelope
+      # que ele assina. A audiência precisa bater com
+      # GATEWAY_JWT_AUDIENCE_BILLING no docker-compose.yml, onde está escrito
+      # por que ela é a do rental-core.
+      GATEWAY_IDENTITY_SIGNING_KEY: "${GATEWAY_IDENTITY_SIGNING_KEY:?Set GATEWAY_IDENTITY_SIGNING_KEY}"
+      GATEWAY_IDENTITY_SIGNING_KEY_ID: local-v1
+      BILLING_IDENTITY_AUDIENCE: projecty.rental-core
       OTEL_SERVICE_NAME: billing
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
       OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -329,16 +329,33 @@ services:
       GATEWAY_UPSTREAM_RIDER_MANAGER: http://rider-manager:8000
       GATEWAY_UPSTREAM_MOTO_HUB: http://rental-core:8200
       GATEWAY_UPSTREAM_RENTAL_OPERATIONS: http://rental-core:8200
+      # O billing vive no overlay poliglota. Sem ele de pé, /api/invoices
+      # responde 502 -- e não impede o portão de subir, que é o que importa.
+      GATEWAY_UPSTREAM_BILLING: http://billing:8094
       GATEWAY_UPSTREAM_AUTH_GATE_TIMEOUT_MS: "1500"
       GATEWAY_UPSTREAM_RIDER_MANAGER_TIMEOUT_MS: "2000"
       GATEWAY_UPSTREAM_MOTO_HUB_TIMEOUT_MS: "2000"
       GATEWAY_UPSTREAM_RENTAL_OPERATIONS_TIMEOUT_MS: "2500"
+      GATEWAY_UPSTREAM_BILLING_TIMEOUT_MS: "2000"
       GATEWAY_JWKS_URL: http://auth-gate:8080/.well-known/jwks.json
       GATEWAY_JWT_ISSUER: projecty.identity
       GATEWAY_JWT_AUDIENCE_AUTH_GATE: projecty.auth-gate
       GATEWAY_JWT_AUDIENCE_RIDER_MANAGER: projecty.rider-manager
       GATEWAY_JWT_AUDIENCE_MOTO_HUB: projecty.rental-core
       GATEWAY_JWT_AUDIENCE_RENTAL_OPERATIONS: projecty.rental-core
+      # A mesma audiência do rental-core, e não uma nova, deliberadamente.
+      #
+      # Esta string faz duas coisas: valida o aud do token e vira a audiência
+      # do envelope que o portão assina. Uma audiência própria para o billing
+      # exigiria um segundo token para a mesma tela -- o console guarda um só,
+      # e não tem credenciais para pedir outro. A fatura é a liquidação de um
+      # aluguel que o chamador já tem token para ler.
+      #
+      # É um afrouxamento real: um token do rental-core serve no billing. O
+      # #136 troca este esquema inteiro (EdDSA com JWKS, um emissor), e a
+      # fronteira certa se desenha lá, uma vez, em vez de aqui, com uma sexta
+      # chave HMAC para um esquema que já está de saída.
+      GATEWAY_JWT_AUDIENCE_BILLING: projecty.rental-core
       GATEWAY_IDENTITY_SIGNING_KEY: ${GATEWAY_IDENTITY_SIGNING_KEY:?GATEWAY_IDENTITY_SIGNING_KEY is required}
       GATEWAY_IDENTITY_SIGNING_KEY_ID: local-v1
       GATEWAY_REDIS_URL: redis://redis:6379/

--- a/docs/adr/0009-exactly-once-effect.md
+++ b/docs/adr/0009-exactly-once-effect.md
@@ -141,6 +141,11 @@ than a recomputed projection, and because it crosses a process and language
 boundary: billing shares no transaction, connection pool, or runtime with the
 producer, so it can only hold if the outbox and inbox contract is real.
 
+billing exposes no write route, and that is part of the guarantee rather than an
+omission. An invoice is issued only by consuming `rental.closed`, inside the
+inbox transaction; an HTTP endpoint that could also issue one would be a second
+path to the same effect, and a second path is where exactly-once leaks.
+
 A second, independent guard sits under it. The inbox deduplicates *messages*;
 `one_invoice_per_rental` deduplicates *rentals*. They fail differently — a
 replay from offset zero after inbox retention has swept the row carries a new

--- a/docs/runbooks/polyglot-services.md
+++ b/docs/runbooks/polyglot-services.md
@@ -112,6 +112,25 @@ if another request has already closed the rental, the losing request returns
 HTTP 409. Closing again returns the stored rental unchanged; only the winning
 update enqueues `rental.closed`.
 
+The invoice itself is read through the gateway, from billing:
+
+```
+GET /api/invoices/{rentalId}
+GET /api/invoices?rentalIds=a,b,c
+```
+
+Both are read-only and both filter to the caller unless the identity envelope
+carries the `Admin` role. Someone else's invoice answers 404, not 403: the
+difference between those two responses tells a scanner which ids exist.
+
+billing verifies the gateway identity envelope of ADR 0008 the same way the .NET
+services do — it is a second implementation of that check, in Kotlin, and the
+canonical string is pinned on both sides: a test in the gateway asserts what it
+signs for an invoice route, and `GatewayIdentityTest` in billing asserts what it
+accepts, against an envelope the gateway actually produced. Its audience must
+equal `GATEWAY_JWT_AUDIENCE_BILLING`; today both are `projecty.rental-core`, and
+`docker-compose.yml` says why.
+
 Since #137 that endpoint is `POST /api/Rental/close`, and it computes no money.
 It records the end date and the status; what is owed is decided by billing from
 the event, which makes the amount eventually consistent by design. Closing

--- a/services/api-gateway/src/config.rs
+++ b/services/api-gateway/src/config.rs
@@ -22,6 +22,7 @@ pub struct ResilienceConfig {
     pub rider_manager: UpstreamResilienceConfig,
     pub moto_hub: UpstreamResilienceConfig,
     pub rental_operations: UpstreamResilienceConfig,
+    pub billing: UpstreamResilienceConfig,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -71,6 +72,7 @@ pub struct Audiences {
     pub rider_manager: String,
     pub moto_hub: String,
     pub rental_operations: String,
+    pub billing: String,
 }
 
 #[derive(Clone)]
@@ -120,6 +122,7 @@ pub struct Upstreams {
     pub rider_manager: Url,
     pub moto_hub: Url,
     pub rental_operations: Url,
+    pub billing: Url,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -128,6 +131,7 @@ pub enum UpstreamName {
     RiderManager,
     MotoHub,
     RentalOperations,
+    Billing,
 }
 
 impl Config {
@@ -148,6 +152,7 @@ impl Config {
                 rider_manager: required_url("GATEWAY_UPSTREAM_RIDER_MANAGER")?,
                 moto_hub: required_url("GATEWAY_UPSTREAM_MOTO_HUB")?,
                 rental_operations: required_url("GATEWAY_UPSTREAM_RENTAL_OPERATIONS")?,
+                billing: required_url("GATEWAY_UPSTREAM_BILLING")?,
             },
             auth: AuthConfig {
                 jwks_url: required_absolute_url("GATEWAY_JWKS_URL")?,
@@ -157,6 +162,7 @@ impl Config {
                     rider_manager: required_value("GATEWAY_JWT_AUDIENCE_RIDER_MANAGER")?,
                     moto_hub: required_value("GATEWAY_JWT_AUDIENCE_MOTO_HUB")?,
                     rental_operations: required_value("GATEWAY_JWT_AUDIENCE_RENTAL_OPERATIONS")?,
+                    billing: required_value("GATEWAY_JWT_AUDIENCE_BILLING")?,
                 },
                 jwks_cache_ttl: duration_from_env("GATEWAY_JWKS_CACHE_TTL_SECS", 300)?,
                 unknown_kid_refresh_interval: duration_from_env(
@@ -191,6 +197,10 @@ impl Config {
                 rider_manager: upstream_resilience_from_env("RIDER_MANAGER", 2000)?,
                 moto_hub: upstream_resilience_from_env("MOTO_HUB", 2000)?,
                 rental_operations: upstream_resilience_from_env("RENTAL_OPERATIONS", 2500)?,
+                // A leitura da nota é uma consulta por chave primária numa JVM
+                // que já está de pé. Ela não merece o orçamento da criação de
+                // aluguel, que fala com o banco, a projeção e o outbox.
+                billing: upstream_resilience_from_env("BILLING", 2000)?,
             },
         })
     }
@@ -218,6 +228,8 @@ impl Upstreams {
             Some((UpstreamName::MotoHub, &self.moto_hub))
         } else if path == "/api/rental" || path.starts_with("/api/rental/") {
             Some((UpstreamName::RentalOperations, &self.rental_operations))
+        } else if path == "/api/invoices" || path.starts_with("/api/invoices/") {
+            Some((UpstreamName::Billing, &self.billing))
         } else {
             None
         }
@@ -231,6 +243,7 @@ impl Audiences {
             UpstreamName::RiderManager => &self.rider_manager,
             UpstreamName::MotoHub => &self.moto_hub,
             UpstreamName::RentalOperations => &self.rental_operations,
+            UpstreamName::Billing => &self.billing,
         }
     }
 }
@@ -242,16 +255,18 @@ impl ResilienceConfig {
             UpstreamName::RiderManager => self.rider_manager,
             UpstreamName::MotoHub => self.moto_hub,
             UpstreamName::RentalOperations => self.rental_operations,
+            UpstreamName::Billing => self.billing,
         }
     }
 }
 
 impl UpstreamName {
-    pub const ALL: [Self; 4] = [
+    pub const ALL: [Self; 5] = [
         Self::AuthGate,
         Self::RiderManager,
         Self::MotoHub,
         Self::RentalOperations,
+        Self::Billing,
     ];
 
     pub const fn as_str(self) -> &'static str {
@@ -260,6 +275,7 @@ impl UpstreamName {
             Self::RiderManager => "rider_manager",
             Self::MotoHub => "moto_hub",
             Self::RentalOperations => "rental_operations",
+            Self::Billing => "billing",
         }
     }
 }
@@ -453,6 +469,7 @@ mod tests {
             rider_manager: Url::parse("http://rider-manager:8000/").unwrap(),
             moto_hub: Url::parse("http://moto-hub:8100/").unwrap(),
             rental_operations: Url::parse("http://rental-operations:8200/").unwrap(),
+            billing: Url::parse("http://billing:8094/").unwrap(),
         }
     }
 
@@ -476,7 +493,12 @@ mod tests {
             upstreams.resolve("/api/rental/user").map(|route| route.0),
             Some(UpstreamName::RentalOperations)
         );
+        assert_eq!(
+            upstreams.resolve("/api/invoices/abc").map(|route| route.0),
+            Some(UpstreamName::Billing)
+        );
         assert!(upstreams.resolve("/api/authentic-looking").is_none());
+        assert!(upstreams.resolve("/api/invoiced").is_none());
         assert!(upstreams.resolve("/api/rider/123").is_none());
         assert!(upstreams.resolve("/api/motorcycle/ABC1234").is_none());
         assert!(upstreams.resolve("/health/ready").is_none());

--- a/services/api-gateway/src/lib.rs
+++ b/services/api-gateway/src/lib.rs
@@ -808,7 +808,8 @@ mod tests {
                 auth_gate: upstream.clone(),
                 rider_manager: upstream.clone(),
                 moto_hub: upstream.clone(),
-                rental_operations: upstream,
+                rental_operations: upstream.clone(),
+                billing: upstream,
             },
             auth: AuthConfig {
                 jwks_url: Url::parse("http://127.0.0.1:1/.well-known/jwks.json").unwrap(),
@@ -818,6 +819,7 @@ mod tests {
                     rider_manager: "projecty.rider-manager".to_owned(),
                     moto_hub: "projecty.moto-hub".to_owned(),
                     rental_operations: "projecty.rental-operations".to_owned(),
+                    billing: "projecty.billing".to_owned(),
                 },
                 jwks_cache_ttl: Duration::from_secs(300),
                 unknown_kid_refresh_interval: Duration::from_secs(5),
@@ -846,6 +848,7 @@ mod tests {
                 rider_manager: test_resilience_config(),
                 moto_hub: test_resilience_config(),
                 rental_operations: test_resilience_config(),
+                billing: test_resilience_config(),
             },
         }
     }
@@ -1753,6 +1756,55 @@ mod tests {
         mac.verify_slice(&URL_SAFE_NO_PAD.decode(signature).unwrap())
             .unwrap();
         assert_eq!(state.jwks_requests.load(Ordering::SeqCst), 1);
+    }
+
+    /// A mesma prova, para o billing.
+    ///
+    /// A verificação do envelope existe duas vezes -- em C# e, desde o #137, em
+    /// Kotlin -- e a string canônica é o ponto em que as duas podem divergir sem
+    /// que nada quebre até alguém entrar. Este teste fixa o que o portão assina
+    /// para uma rota de fatura; o lado Kotlin fixa um envelope real produzido por
+    /// ele. Uma divergência falha de um dos dois lados em vez de virar acesso.
+    #[tokio::test]
+    async fn signs_invoice_reads_for_the_billing_audience() {
+        let issuer = TestIssuer::new("billing-key");
+        let (upstream, _state) = spawn_security_upstream(Some(issuer.jwks())).await;
+        let mut config = test_config(upstream.clone());
+        config.auth.jwks_url = upstream.join(".well-known/jwks.json").unwrap();
+        let app = build_app(config).unwrap();
+        let token = issuer.token("projecty.billing", &["Rider"]);
+        let response = app
+            .oneshot(
+                HttpRequest::get("/api/invoices?rentalIds=a,b")
+                    .header(AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        let issued_at = body["issued_at"].as_str().unwrap();
+        let signature = body["signature"]
+            .as_str()
+            .unwrap()
+            .strip_prefix("v1=")
+            .unwrap();
+        let canonical = format!(
+            "v1
+local-v1
+rider-123
+Rider
+{issued_at}
+GET
+/api/invoices?rentalIds=a,b
+projecty.billing"
+        );
+        let mut mac = Hmac::<Sha256>::new_from_slice(&[b'x'; 32]).unwrap();
+        mac.update(canonical.as_bytes());
+        mac.verify_slice(&URL_SAFE_NO_PAD.decode(signature).unwrap())
+            .unwrap();
     }
 
     #[tokio::test]

--- a/services/api-gateway/src/policy.rs
+++ b/services/api-gateway/src/policy.rs
@@ -41,6 +41,10 @@ pub fn access_for(method: &Method, path: &str, upstream: UpstreamName) -> Access
         UpstreamName::MotoHub => Access::Admin,
         UpstreamName::RiderManager if rider_admin_route(method, &path) => Access::Admin,
         UpstreamName::RentalOperations if rental_admin_route(method, &path) => Access::Admin,
+        // O billing não tem API de escrita, e o portão não deveria fingir que
+        // tem. Qualquer coisa que não seja leitura para lá só faz sentido vinda
+        // de um administrador -- e hoje não faz sentido nenhum.
+        UpstreamName::Billing if method != Method::GET => Access::Admin,
         _ => Access::Authenticated,
     }
 }
@@ -137,6 +141,35 @@ mod tests {
             access_for(&Method::POST, "/api/motorcycles", UpstreamName::MotoHub),
             Access::Admin
         );
+    }
+
+    /// A fatura é do piloto, e ler a própria não exige ser administrador.
+    ///
+    /// Quem filtra por dono é o billing, com a identidade que este portão
+    /// assina -- aqui a decisão é só "precisa estar autenticado". O que o portão
+    /// nega é escrita: o billing não tem API de escrita, e rotear uma para lá
+    /// fingiria que tem.
+    #[test]
+    fn a_rider_may_read_invoices_but_not_write_them() {
+        assert_eq!(
+            access_for(
+                &Method::GET,
+                "/api/invoices/rental-1",
+                UpstreamName::Billing
+            ),
+            Access::Authenticated
+        );
+        assert_eq!(
+            access_for(&Method::GET, "/api/invoices", UpstreamName::Billing),
+            Access::Authenticated
+        );
+        for method in [Method::POST, Method::PUT, Method::DELETE, Method::PATCH] {
+            assert_eq!(
+                access_for(&method, "/api/invoices/rental-1", UpstreamName::Billing),
+                Access::Admin,
+                "{method} on an invoice must not be a rider route"
+            );
+        }
     }
 
     #[test]

--- a/services/api-gateway/src/resilience.rs
+++ b/services/api-gateway/src/resilience.rs
@@ -106,6 +106,7 @@ pub struct ResilienceRegistry {
     rider_manager: Arc<UpstreamPolicy>,
     moto_hub: Arc<UpstreamPolicy>,
     rental_operations: Arc<UpstreamPolicy>,
+    billing: Arc<UpstreamPolicy>,
 }
 
 impl ResilienceRegistry {
@@ -115,6 +116,7 @@ impl ResilienceRegistry {
             rider_manager: Arc::new(UpstreamPolicy::new(config.rider_manager)),
             moto_hub: Arc::new(UpstreamPolicy::new(config.moto_hub)),
             rental_operations: Arc::new(UpstreamPolicy::new(config.rental_operations)),
+            billing: Arc::new(UpstreamPolicy::new(config.billing)),
         }
     }
 
@@ -124,6 +126,7 @@ impl ResilienceRegistry {
             UpstreamName::RiderManager => self.rider_manager.clone(),
             UpstreamName::MotoHub => self.moto_hub.clone(),
             UpstreamName::RentalOperations => self.rental_operations.clone(),
+            UpstreamName::Billing => self.billing.clone(),
         }
     }
 

--- a/services/billing/src/main/kotlin/projecty/billing/GatewayIdentity.kt
+++ b/services/billing/src/main/kotlin/projecty/billing/GatewayIdentity.kt
@@ -1,0 +1,158 @@
+package projecty.billing
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.time.Clock
+import java.time.Duration
+import java.util.Base64
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * O envelope de identidade do ADR 0008, verificado aqui.
+ *
+ * O portão é a única fronteira que valida um token; para trás dele ele assina um
+ * envelope HMAC por requisição, e cada serviço confere. Isto é a segunda
+ * implementação da conferência -- a primeira é `Shared/Security/
+ * GatewayIdentityAuthentication.cs` -- e uma segunda implementação de um limite
+ * de segurança é uma coisa que se assume de olhos abertos: qualquer divergência
+ * entre as duas é uma porta.
+ *
+ * Por isso ela é literal. A string canônica é copiada campo a campo, na mesma
+ * ordem, com o mesmo separador; o conjunto de caracteres aceitos é o mesmo; a
+ * janela de tempo é a mesma; a comparação é de tempo constante. O teste
+ * `GatewayIdentityTest` carrega vetores gerados pelo assinante do portão, e é
+ * ele que faz uma divergência aparecer como falha em vez de como acesso.
+ *
+ * Não reimplementa a assinatura -- só a verificação. O billing não fala com
+ * ninguém para trás dele, e uma chave que só verifica é uma chave que não
+ * emite.
+ */
+class GatewayIdentity(
+    private val signingKey: ByteArray,
+    private val signingKeyId: String,
+    private val audience: String,
+    private val maximumAge: Duration = Duration.ofSeconds(30),
+    private val clockSkew: Duration = Duration.ofSeconds(5),
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    init {
+        require(signingKey.size >= 32) { "The gateway identity signing key must contain at least 32 bytes." }
+        require(audience.isNotBlank()) { "The gateway identity audience is required." }
+    }
+
+    /**
+     * Quem está chamando, segundo o portão.
+     *
+     * `Admin` compara sem diferenciar maiúsculas porque é o que o
+     * `ClaimsPrincipal.IsInRole` do lado .NET faz -- e as duas camadas
+     * discordarem sobre quem é administrador seria pior do que qualquer das duas
+     * regras isolada.
+     */
+    data class Caller(val subject: String, val roles: List<String>) {
+        val isAdmin: Boolean get() = roles.any { it.equals(ADMIN_ROLE, ignoreCase = true) }
+    }
+
+    /**
+     * O chamador, ou null quando o envelope não vale. Nunca uma exceção com a
+     * razão: quem não passou não precisa saber por qual dos sete motivos.
+     */
+    fun verify(
+        header: (String) -> List<String>,
+        method: String,
+        pathAndQuery: String,
+    ): Caller? {
+        val values = HEADERS.map { header(it) }
+        if (values.any { it.size != 1 }) return null
+        val (keyId, subject, roles, issuedAtValue, signature) = values.map { it[0] }
+
+        if (keyId != signingKeyId) return null
+        if (!isSafeComponent(keyId, 128)) return null
+        if (!isSafeComponent(subject, 512)) return null
+        // NumberStyles.None do lado .NET: só dígitos. `toLongOrNull` aceitaria um
+        // sinal, e um carimbo negativo passaria pela janela de tempo por baixo.
+        if (!DIGITS.matches(issuedAtValue)) return null
+        val issuedAt = issuedAtValue.toLongOrNull() ?: return null
+
+        val now = clock.instant().epochSecond
+        if (issuedAt > now + clockSkew.seconds) return null
+        if (issuedAt < now - maximumAge.seconds) return null
+
+        val parsedRoles = parseRoles(roles) ?: return null
+
+        val canonical =
+            listOf(
+                "v1",
+                keyId,
+                subject,
+                roles,
+                issuedAtValue,
+                method,
+                pathAndQuery,
+                audience,
+            ).joinToString("\n")
+        if (!verifySignature(canonical, signature)) return null
+
+        return Caller(subject, parsedRoles)
+    }
+
+    private fun verifySignature(
+        canonical: String,
+        signature: String,
+    ): Boolean {
+        if (!signature.startsWith("v1=")) return false
+        val supplied =
+            try {
+                // O portão remove o preenchimento; o decodificador de URL do Java
+                // aceita a entrada sem ele e recusa comprimentos impossíveis.
+                Base64.getUrlDecoder().decode(signature.substring(3))
+            } catch (_: IllegalArgumentException) {
+                return false
+            }
+        val expected =
+            Mac.getInstance("HmacSHA256").run {
+                init(SecretKeySpec(signingKey, "HmacSHA256"))
+                doFinal(canonical.toByteArray(StandardCharsets.UTF_8))
+            }
+        // MessageDigest.isEqual é de tempo constante desde o Java 7, e é o que
+        // impede alguém de descobrir a assinatura um byte por vez.
+        return MessageDigest.isEqual(expected, supplied)
+    }
+
+    private fun parseRoles(value: String): List<String>? {
+        if (value.isEmpty()) return emptyList()
+        if (value.length > 1024) return null
+        val roles = value.split(",")
+        return if (roles.size <= 32 && roles.all { isSafeComponent(it, 512) }) roles else null
+    }
+
+    companion object {
+        const val KEY_ID_HEADER = "x-identity-key-id"
+        const val SUBJECT_HEADER = "x-identity-subject"
+        const val ROLES_HEADER = "x-identity-roles"
+        const val ISSUED_AT_HEADER = "x-identity-issued-at"
+        const val SIGNATURE_HEADER = "x-identity-signature"
+        const val ADMIN_ROLE = "Admin"
+
+        /** A ordem é a do envelope, e é ela que o `destructuring` acima assume. */
+        val HEADERS =
+            listOf(KEY_ID_HEADER, SUBJECT_HEADER, ROLES_HEADER, ISSUED_AT_HEADER, SIGNATURE_HEADER)
+
+        private val DIGITS = Regex("^[0-9]+$")
+
+        /**
+         * ASCII imprimível menos o espaço e menos a vírgula.
+         *
+         * A vírgula fica de fora porque é o separador dos papéis: aceita-la
+         * deixaria um papel chamado "a,Admin" virar dois na leitura de quem
+         * separa, que é exatamente uma escalada de privilégio.
+         */
+        fun isSafeComponent(
+            value: String,
+            maximumLength: Int,
+        ): Boolean =
+            value.isNotEmpty() &&
+                value.length <= maximumLength &&
+                value.all { it in '!'..'+' || it in '-'..'~' }
+    }
+}

--- a/services/billing/src/main/kotlin/projecty/billing/InvoiceApi.kt
+++ b/services/billing/src/main/kotlin/projecty/billing/InvoiceApi.kt
@@ -1,0 +1,149 @@
+package projecty.billing
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpHandler
+import org.slf4j.LoggerFactory
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+
+/**
+ * A leitura da nota, atrás do portão.
+ *
+ * Duas rotas, e a segunda existe por contrato e não por desempenho: o #138 diz
+ * que compor uma tela não pode custar uma requisição por linha, e sem o lote o
+ * N+1 não desaparece -- só se muda do navegador para o BFF.
+ *
+ *   GET /api/invoices/{rentalId}
+ *   GET /api/invoices?rentalIds=a,b,c
+ *
+ * Não há rota de escrita. Uma nota é emitida pelo consumo de `rental.closed`, na
+ * mesma transação do inbox; um POST aqui seria um segundo caminho para o mesmo
+ * efeito, e o segundo caminho é onde a garantia de exatamente-uma-vez vaza.
+ */
+class InvoiceApi(
+    private val reads: InvoiceReads,
+    private val identity: GatewayIdentity,
+) : HttpHandler {
+    private val log = LoggerFactory.getLogger(InvoiceApi::class.java)
+    private val json = ObjectMapper()
+
+    override fun handle(exchange: HttpExchange) {
+        exchange.use {
+            try {
+                respond(exchange)
+            } catch (error: Exception) {
+                // A mensagem da exceção pode carregar a consulta, o host ou o
+                // papel do banco. O cliente recebe o código; o motivo fica no log.
+                log.error("Invoice read failed", error)
+                write(exchange, 500, mapOf("detail" to "The invoice could not be read."))
+            }
+        }
+    }
+
+    private fun respond(exchange: HttpExchange) {
+        if (exchange.requestMethod != "GET") {
+            write(exchange, 405, mapOf("detail" to "Invoices are read-only."))
+            return
+        }
+
+        val caller =
+            identity.verify(
+                { exchange.requestHeaders[it] ?: emptyList() },
+                "GET",
+                pathAndQuery(exchange.requestURI),
+            )
+        if (caller == null) {
+            write(exchange, 401, mapOf("detail" to "A valid gateway identity envelope is required."))
+            return
+        }
+
+        val single = exchange.requestURI.rawPath.removePrefix(BASE).trim('/')
+        if (single.isNotEmpty()) {
+            val rentalId = runCatching { UUID.fromString(single) }.getOrNull()
+            if (rentalId == null) {
+                write(exchange, 400, mapOf("detail" to "'$single' is not a rental id."))
+                return
+            }
+            val found = reads.byRentalIds(listOf(rentalId), caller.subject, caller.isAdmin)
+            if (found.isEmpty()) {
+                // 404 e não 403 mesmo quando a nota existe e é de outro: a
+                // diferença entre as duas respostas é um oráculo de existência.
+                write(exchange, 404, mapOf("detail" to "No invoice for rental $single."))
+            } else {
+                write(exchange, 200, found.first())
+            }
+            return
+        }
+
+        val requested =
+            query(exchange.requestURI)["rentalIds"]
+                ?.split(',')
+                ?.map { it.trim() }
+                ?.filter { it.isNotEmpty() }
+                .orEmpty()
+        if (requested.isEmpty()) {
+            write(exchange, 400, mapOf("detail" to "At least one rental id is required."))
+            return
+        }
+        if (requested.size > InvoiceReads.MAX_BATCH_SIZE) {
+            write(
+                exchange,
+                400,
+                mapOf("detail" to "A batch may request at most ${InvoiceReads.MAX_BATCH_SIZE} rental ids."),
+            )
+            return
+        }
+        val ids = requested.map { runCatching { UUID.fromString(it) }.getOrNull() }
+        val unparseable = requested.zip(ids).firstOrNull { it.second == null }?.first
+        if (unparseable != null) {
+            write(exchange, 400, mapOf("detail" to "'$unparseable' is not a rental id."))
+            return
+        }
+
+        write(exchange, 200, reads.byRentalIds(ids.filterNotNull(), caller.subject, caller.isAdmin))
+    }
+
+    private fun write(
+        exchange: HttpExchange,
+        status: Int,
+        body: Any,
+    ) {
+        val bytes = json.writeValueAsBytes(body)
+        exchange.responseHeaders.add("Content-Type", "application/json; charset=utf-8")
+        exchange.sendResponseHeaders(status, bytes.size.toLong())
+        exchange.responseBody.write(bytes)
+    }
+
+    companion object {
+        const val BASE = "/api/invoices"
+
+        /**
+         * O caminho como o portão o assinou.
+         *
+         * Cru, e não decodificado: o portão assina a URI que envia, e uma
+         * requisição que só bate depois de decodificada não é a mesma que ele
+         * assinou. Ele já recusa caminho com `%` antes de assinar (o
+         * `is_canonical_path`), então na prática os dois são iguais -- usar o cru
+         * é o que mantém a igualdade verdadeira e não uma coincidência.
+         */
+        fun pathAndQuery(uri: URI): String = uri.rawPath + (uri.rawQuery?.let { "?$it" } ?: "")
+
+        fun query(uri: URI): Map<String, String> =
+            uri.rawQuery
+                ?.split('&')
+                ?.mapNotNull { pair ->
+                    val separator = pair.indexOf('=')
+                    if (separator <= 0) {
+                        null
+                    } else {
+                        decode(pair.substring(0, separator)) to decode(pair.substring(separator + 1))
+                    }
+                }
+                ?.toMap()
+                .orEmpty()
+
+        private fun decode(value: String): String = java.net.URLDecoder.decode(value, StandardCharsets.UTF_8)
+    }
+}

--- a/services/billing/src/main/kotlin/projecty/billing/InvoiceReads.kt
+++ b/services/billing/src/main/kotlin/projecty/billing/InvoiceReads.kt
@@ -1,0 +1,86 @@
+package projecty.billing
+
+import java.util.UUID
+import javax.sql.DataSource
+
+/** A nota como quem a lê precisa dela. Centavos, como o contrato do evento. */
+data class InvoiceView(
+    val invoiceId: String,
+    val rentalId: String,
+    val riderId: String,
+    val currency: String,
+    val planDays: Int,
+    val daysUsed: Int,
+    val agreedMinor: Long,
+    val adjustmentMinor: Long,
+    val totalMinor: Long,
+    val reason: String,
+    val riderName: String?,
+    val issuedAtMs: Long,
+)
+
+/**
+ * A leitura das notas.
+ *
+ * O filtro por dono é feito no SQL, e não depois em memória, por dois motivos:
+ * a linha alheia não chega a atravessar o processo, e não existe um caminho em
+ * que alguém acrescente um retorno antes do filtro.
+ *
+ * Um id que não pertence a quem pediu vira ausência, não 403 -- a mesma escolha
+ * do lote de aluguéis do #138. Recusar diria "esta nota existe, mas não é sua",
+ * que é precisamente o que alguém varrendo ids quer ouvir.
+ */
+class InvoiceReads(private val dataSource: DataSource) {
+    fun byRentalIds(
+        rentalIds: Collection<UUID>,
+        riderId: String,
+        isAdmin: Boolean,
+    ): List<InvoiceView> {
+        if (rentalIds.isEmpty()) return emptyList()
+        val owned = if (isAdmin) "" else " AND rider_id = ?"
+        return dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                """
+                SELECT id, rental_id, rider_id, currency, plan_days, days_used,
+                       agreed_minor, adjustment_minor, total_minor, reason, rider_name, issued_at
+                  FROM invoices
+                 WHERE rental_id = ANY(?)$owned
+                 ORDER BY issued_at DESC
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setArray(1, connection.createArrayOf("uuid", rentalIds.toTypedArray()))
+                if (!isAdmin) statement.setString(2, riderId)
+                statement.executeQuery().use { rows ->
+                    buildList {
+                        while (rows.next()) {
+                            add(
+                                InvoiceView(
+                                    invoiceId = rows.getString(1),
+                                    rentalId = rows.getString(2),
+                                    riderId = rows.getString(3),
+                                    currency = rows.getString(4),
+                                    planDays = rows.getInt(5),
+                                    daysUsed = rows.getInt(6),
+                                    agreedMinor = rows.getLong(7),
+                                    adjustmentMinor = rows.getLong(8),
+                                    totalMinor = rows.getLong(9),
+                                    reason = rows.getString(10),
+                                    riderName = rows.getString(11),
+                                    issuedAtMs = rows.getTimestamp(12).time,
+                                ),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * O mesmo teto do lote de aluguéis, e pelo mesmo motivo: um lote sem
+         * limite é uma consulta arbitrária escrita pelo cliente.
+         */
+        const val MAX_BATCH_SIZE = 100
+    }
+}

--- a/services/billing/src/main/kotlin/projecty/billing/Main.kt
+++ b/services/billing/src/main/kotlin/projecty/billing/Main.kt
@@ -6,6 +6,8 @@ import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import org.slf4j.LoggerFactory
 import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+import java.time.Duration
 import java.util.concurrent.atomic.AtomicBoolean
 
 private val log = LoggerFactory.getLogger("billing")
@@ -27,6 +29,18 @@ fun main() {
             },
         )
 
+    val identity =
+        GatewayIdentity(
+            signingKey = env("GATEWAY_IDENTITY_SIGNING_KEY").toByteArray(StandardCharsets.UTF_8),
+            signingKeyId = System.getenv("GATEWAY_IDENTITY_SIGNING_KEY_ID") ?: "local-v1",
+            // Sem padrão: a audiência do envelope precisa ser exatamente a que o
+            // portão assina para este upstream, e um padrão silencioso aqui seria
+            // um 401 sem explicação sempre que as duas divergissem.
+            audience = env("BILLING_IDENTITY_AUDIENCE"),
+            maximumAge = Duration.ofSeconds(30),
+            clockSkew = Duration.ofSeconds(5),
+        )
+
     val bootstrap = env("KAFKA_BOOTSTRAP_SERVERS")
     val invoices = Invoices(dataSource)
     val consumer = RentalClosedConsumer.kafka(bootstrap, invoices, stopping)
@@ -42,6 +56,9 @@ fun main() {
                 val idleMs = System.currentTimeMillis() - consumer.lastPollAtMs.get()
                 if (idleMs < 30_000) exchange.reply(200, "ready") else exchange.reply(503, "stalled for ${idleMs}ms")
             }
+            // As rotas de saúde não passam pelo portão e continuam abertas; a
+            // leitura da nota passa, e exige o envelope assinado.
+            createContext(InvoiceApi.BASE, InvoiceApi(InvoiceReads(dataSource), identity))
             createContext("/invoices/count") { it.reply(200, consumer.issued.get().toString()) }
             createContext("/invoices/skipped") { it.reply(200, consumer.skipped.get().toString()) }
             start()

--- a/services/billing/src/test/kotlin/projecty/billing/ExactlyOnceTest.kt
+++ b/services/billing/src/test/kotlin/projecty/billing/ExactlyOnceTest.kt
@@ -1,21 +1,10 @@
 package projecty.billing
 
-import com.zaxxer.hikari.HikariConfig
-import com.zaxxer.hikari.HikariDataSource
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
-import org.junit.jupiter.api.TestInstance
-import org.testcontainers.containers.GenericContainer
-import org.testcontainers.utility.DockerImageName
 import project_y.events.Invoice.InvoiceIssued
-import java.nio.file.Files
-import java.nio.file.Path
 import java.sql.Connection
-import java.sql.DriverManager
 import java.sql.SQLException
 import java.util.UUID
-import javax.sql.DataSource
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -30,54 +19,9 @@ import kotlin.test.assertTrue
  * competindo pela mesma mensagem terminarem com uma nota, não duas. Em READ
  * COMMITTED este teste passaria por sorte.
  */
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ExactlyOnceTest {
-    private var container: GenericContainer<*>? = null
-    private lateinit var endpoint: String
-    private lateinit var dataSource: HikariDataSource
-    private lateinit var invoices: Invoices
-
-    @BeforeAll
-    fun start() {
-        // Um CockroachDB já de pé, quando houver, e um container quando não.
-        //
-        // O Testcontainers precisa falar com o daemon, e nem toda máquina de
-        // desenvolvimento expõe o socket de dentro de um container -- o Docker
-        // Desktop no Windows não expõe. O CI roda pelo caminho de cima; a
-        // variável existe para rodar o teste à mão sem ele.
-        endpoint = System.getenv("BILLING_TEST_COCKROACH") ?: startCockroach()
-
-        val root = url("defaultdb")
-        awaitReady(root)
-        applyFile(root, "000_bootstrap.cockroach.sql")
-        val app = url("projecty")
-        for (file in listOf("001_schema.sql", "002_rental_core.sql", "003_billing.sql")) applyFile(app, file)
-
-        dataSource =
-            HikariDataSource(
-                HikariConfig().apply {
-                    jdbcUrl = app
-                    maximumPoolSize = 4
-                },
-            )
-        invoices = Invoices(dataSource)
-    }
-
-    private fun startCockroach(): String {
-        val started =
-            GenericContainer(DockerImageName.parse("cockroachdb/cockroach:v26.3.1"))
-                .withCommand("start-single-node", "--insecure")
-                .withExposedPorts(26257)
-        started.start()
-        container = started
-        return "${started.host}:${started.getMappedPort(26257)}"
-    }
-
-    @AfterAll
-    fun stop() {
-        if (this::dataSource.isInitialized) dataSource.close()
-        container?.stop()
-    }
+    private val dataSource = TestDatabase.dataSource
+    private val invoices = Invoices(dataSource)
 
     @Test
     @Tag("ADR-0009#settlement-inbox")
@@ -215,33 +159,5 @@ class ExactlyOnceTest {
             }
         }
 
-    private fun <T> query(body: (Connection) -> T): T = (dataSource as DataSource).connection.use(body)
-
-    private fun url(database: String) = "jdbc:postgresql://$endpoint/$database?sslmode=disable&user=root"
-
-    private fun awaitReady(url: String) {
-        var last: Exception? = null
-        repeat(60) {
-            try {
-                DriverManager.getConnection(url).use { connection ->
-                    connection.createStatement().use { it.execute("SELECT 1") }
-                }
-                return
-            } catch (error: SQLException) {
-                last = error
-                Thread.sleep(1_000)
-            }
-        }
-        throw IllegalStateException("CockroachDB did not become ready", last)
-    }
-
-    private fun applyFile(
-        url: String,
-        file: String,
-    ) {
-        val sql = Files.readString(Path.of("../../deploy/db/sql", file))
-        DriverManager.getConnection(url).use { connection ->
-            connection.createStatement().use { it.execute(sql) }
-        }
-    }
+    private fun <T> query(body: (Connection) -> T): T = dataSource.connection.use(body)
 }

--- a/services/billing/src/test/kotlin/projecty/billing/GatewayIdentityTest.kt
+++ b/services/billing/src/test/kotlin/projecty/billing/GatewayIdentityTest.kt
@@ -1,0 +1,169 @@
+package projecty.billing
+
+import java.nio.charset.StandardCharsets
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * A verificação do envelope, contra um envelope de verdade.
+ *
+ * O vetor abaixo não foi escrito à mão: saiu do próprio portão, pelo caminho de
+ * assinatura dele, no teste `signs_invoice_reads_for_the_billing_audience`
+ * (services/api-gateway/src/lib.rs). Isso é o que o torna útil -- um vetor que
+ * eu mesmo assinasse provaria apenas que esta classe concorda consigo mesma, e
+ * o risco de uma segunda implementação não é esse. É a string canônica divergir.
+ *
+ * As duas pontas ficam presas: o teste em Rust fixa o que o portão assina para
+ * uma rota de fatura, e este fixa o que esta classe aceita. Uma mudança de um
+ * dos lados falha de algum dos dois em vez de virar uma porta aberta.
+ */
+class GatewayIdentityTest {
+    private val key = "x".repeat(32).toByteArray(StandardCharsets.UTF_8)
+    private val issuedAt = 1_788_905_813L
+    private val signature = "v1=LyyXb6bQDnqqgS4Ue9Am2Ccq6Uhv4-OWN70fb_Olim8"
+    private val path = "/api/invoices?rentalIds=a,b"
+
+    private fun identity(
+        audience: String = "projecty.billing",
+        keyId: String = "local-v1",
+        atSecond: Long = issuedAt,
+    ) = GatewayIdentity(
+        signingKey = key,
+        signingKeyId = keyId,
+        audience = audience,
+        maximumAge = Duration.ofSeconds(30),
+        clockSkew = Duration.ofSeconds(5),
+        clock = Clock.fixed(Instant.ofEpochSecond(atSecond), ZoneOffset.UTC),
+    )
+
+    private fun envelope(
+        keyId: String = "local-v1",
+        subject: String = "rider-123",
+        roles: String = "Rider",
+        issued: String = issuedAt.toString(),
+        signed: String = signature,
+    ) = mapOf(
+        GatewayIdentity.KEY_ID_HEADER to listOf(keyId),
+        GatewayIdentity.SUBJECT_HEADER to listOf(subject),
+        GatewayIdentity.ROLES_HEADER to listOf(roles),
+        GatewayIdentity.ISSUED_AT_HEADER to listOf(issued),
+        GatewayIdentity.SIGNATURE_HEADER to listOf(signed),
+    )
+
+    private fun GatewayIdentity.check(
+        headers: Map<String, List<String>>,
+        method: String = "GET",
+        pathAndQuery: String = path,
+    ) = verify({ headers[it] ?: emptyList() }, method, pathAndQuery)
+
+    @Test
+    fun `o envelope que o portao assinou e aceito`() {
+        val caller = identity().check(envelope())
+
+        assertNotNull(caller)
+        assertEquals("rider-123", caller.subject)
+        assertEquals(listOf("Rider"), caller.roles)
+        assertTrue(!caller.isAdmin)
+    }
+
+    @Test
+    fun `um byte trocado na assinatura recusa`() {
+        val tampered = signature.dropLast(1) + if (signature.last() == 'A') 'B' else 'A'
+
+        assertNull(identity().check(envelope(signed = tampered)))
+    }
+
+    /**
+     * A parte que um envelope roubado tentaria: a assinatura vale, mas para
+     * outra requisição. Trocar o caminho, o método ou o serviço de destino
+     * precisa invalidá-la -- senão um envelope emitido para ler uma fatura serve
+     * para qualquer coisa que o portão roteie.
+     */
+    @Test
+    fun `a assinatura nao vale para outro caminho, metodo ou destinatario`() {
+        assertNull(identity().check(envelope(), pathAndQuery = "/api/invoices?rentalIds=a,c"))
+        assertNull(identity().check(envelope(), pathAndQuery = "/api/invoices"))
+        assertNull(identity().check(envelope(), method = "POST"))
+        assertNull(identity(audience = "projecty.rental-operations").check(envelope()))
+    }
+
+    @Test
+    fun `o assunto e os papeis fazem parte do que foi assinado`() {
+        assertNull(identity().check(envelope(subject = "rider-124")))
+        assertNull(identity().check(envelope(roles = "Admin")))
+    }
+
+    @Test
+    fun `um envelope velho ou vindo do futuro recusa`() {
+        // A janela é 30s para trás e 5s de folga para frente, como no lado .NET.
+        assertNotNull(identity(atSecond = issuedAt + 30).check(envelope()))
+        assertNull(identity(atSecond = issuedAt + 31).check(envelope()))
+        assertNotNull(identity(atSecond = issuedAt - 5).check(envelope()))
+        assertNull(identity(atSecond = issuedAt - 6).check(envelope()))
+    }
+
+    @Test
+    fun `um key id diferente recusa antes de qualquer conta`() {
+        assertNull(identity(keyId = "local-v2").check(envelope()))
+    }
+
+    @Test
+    fun `um envelope incompleto ou repetido recusa`() {
+        for (header in GatewayIdentity.HEADERS) {
+            assertNull(identity().check(envelope() - header), "faltando $header")
+        }
+        // Dois valores para o mesmo header é a forma clássica de fazer duas
+        // camadas lerem coisas diferentes: uma pega o primeiro, a outra o último.
+        val duplicated =
+            envelope() + (GatewayIdentity.SUBJECT_HEADER to listOf("rider-123", "attacker"))
+        assertNull(identity().check(duplicated))
+    }
+
+    /**
+     * Um carimbo negativo passaria pela borda de baixo da janela se fosse lido
+     * como número com sinal. O lado .NET usa NumberStyles.None; aqui a regex faz
+     * o mesmo.
+     */
+    @Test
+    fun `um carimbo que nao e so digitos recusa`() {
+        for (bad in listOf("-1788905813", "+1788905813", " 1788905813", "1788905813 ", "0x1")) {
+            assertNull(identity().check(envelope(issued = bad)), bad)
+        }
+    }
+
+    @Test
+    fun `a virgula nao pode aparecer dentro de um papel`() {
+        // Se a vírgula fosse aceita como caractere de papel, "a,Admin" chegaria
+        // como um papel só do lado de quem assina e como dois do lado de quem
+        // separa -- e o segundo seria Admin.
+        assertTrue(!GatewayIdentity.isSafeComponent("a,Admin", 512))
+        assertTrue(!GatewayIdentity.isSafeComponent("with space", 512))
+        assertTrue(!GatewayIdentity.isSafeComponent("", 512))
+        assertTrue(GatewayIdentity.isSafeComponent("Admin", 512))
+    }
+
+    @Test
+    fun `Admin e reconhecido sem diferenciar maiusculas, como no lado NET`() {
+        assertTrue(GatewayIdentity.Caller("s", listOf("admin")).isAdmin)
+        assertTrue(GatewayIdentity.Caller("s", listOf("Rider", "ADMIN")).isAdmin)
+        assertTrue(!GatewayIdentity.Caller("s", listOf("Rider")).isAdmin)
+        assertTrue(!GatewayIdentity.Caller("s", listOf("Administrator")).isAdmin)
+    }
+
+    @Test
+    fun `uma chave curta demais nao constroi o verificador`() {
+        val error =
+            runCatching {
+                GatewayIdentity("short".toByteArray(), "local-v1", "projecty.billing")
+            }.exceptionOrNull()
+
+        assertTrue(error is IllegalArgumentException)
+    }
+}

--- a/services/billing/src/test/kotlin/projecty/billing/InvoiceApiTest.kt
+++ b/services/billing/src/test/kotlin/projecty/billing/InvoiceApiTest.kt
@@ -1,0 +1,262 @@
+package projecty.billing
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.sun.net.httpserver.HttpServer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import java.net.InetSocketAddress
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.util.Base64
+import java.util.UUID
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A leitura da nota pela borda: quem pode ver o quê, e o que é recusado.
+ *
+ * O envelope é assinado aqui, e isso é deliberado -- o assunto desta classe é o
+ * comportamento da rota, não a verificação. Que a verificação concorda com o
+ * portão de verdade é o que o `GatewayIdentityTest` prova, contra um envelope
+ * que saiu dele.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class InvoiceApiTest {
+    private val key = "k".repeat(32).toByteArray(StandardCharsets.UTF_8)
+    private val audience = "projecty.billing"
+    private val json = ObjectMapper()
+    private val http = HttpClient.newHttpClient()
+    private lateinit var server: HttpServer
+    private lateinit var base: String
+
+    @BeforeAll
+    fun start() {
+        val identity = GatewayIdentity(key, "local-v1", audience)
+        server =
+            HttpServer.create(InetSocketAddress(0), 0).apply {
+                createContext(InvoiceApi.BASE, InvoiceApi(InvoiceReads(TestDatabase.dataSource), identity))
+                start()
+            }
+        base = "http://127.0.0.1:${server.address.port}"
+    }
+
+    @AfterAll
+    fun stop() = server.stop(0)
+
+    @Test
+    fun `o dono le a propria nota`() {
+        val invoice = seed("rider-api-a")
+
+        val response = get("${InvoiceApi.BASE}/${invoice.rentalId}", "rider-api-a")
+
+        assertEquals(200, response.statusCode())
+        val body = json.readTree(response.body())
+        assertEquals(invoice.rentalId, body["rentalId"].asText())
+        assertEquals(13_800L, body["totalMinor"].asLong())
+        assertEquals("BRL", body["currency"].asText())
+    }
+
+    /**
+     * 404 e não 403, mesmo existindo.
+     *
+     * A diferença entre as duas respostas diz "esta nota existe, mas não é sua",
+     * que é exatamente o que alguém varrendo ids quer ouvir. A resposta precisa
+     * ser indistinguível da de um id inexistente.
+     */
+    @Test
+    fun `a nota de outro piloto e indistinguivel de uma que nao existe`() {
+        val theirs = seed("rider-api-b")
+
+        val existing = get("${InvoiceApi.BASE}/${theirs.rentalId}", "rider-api-c")
+        val absent = get("${InvoiceApi.BASE}/${UUID.randomUUID()}", "rider-api-c")
+
+        assertEquals(404, existing.statusCode())
+        assertEquals(404, absent.statusCode())
+        // O corpo só difere no id que o próprio chamador enviou: nada na
+        // resposta diz se a nota existe.
+        assertEquals(
+            existing.body().replace(theirs.rentalId, "ID"),
+            absent.body().replace(Regex("[0-9a-f-]{36}"), "ID"),
+        )
+    }
+
+    @Test
+    fun `um administrador le a nota de qualquer um`() {
+        val theirs = seed("rider-api-d")
+
+        val response = get("${InvoiceApi.BASE}/${theirs.rentalId}", "an-admin", roles = "Admin")
+
+        assertEquals(200, response.statusCode())
+        assertEquals(theirs.rentalId, json.readTree(response.body())["rentalId"].asText())
+    }
+
+    @Test
+    fun `o lote devolve as do chamador e omite as alheias`() {
+        val mine = seed("rider-api-e")
+        val alsoMine = seed("rider-api-e")
+        val theirs = seed("rider-api-f")
+
+        val response =
+            get(
+                "${InvoiceApi.BASE}?rentalIds=${mine.rentalId},${alsoMine.rentalId},${theirs.rentalId}",
+                "rider-api-e",
+            )
+
+        assertEquals(200, response.statusCode())
+        val returned = json.readTree(response.body()).map { it["rentalId"].asText() }.toSet()
+        assertEquals(setOf(mine.rentalId, alsoMine.rentalId), returned)
+    }
+
+    @Test
+    fun `um lote acima do teto e recusado em vez de servido`() {
+        val ids = (0 until InvoiceReads.MAX_BATCH_SIZE + 1).joinToString(",") { UUID.randomUUID().toString() }
+
+        val response = get("${InvoiceApi.BASE}?rentalIds=$ids", "rider-api-g")
+
+        // Um lote sem teto é uma consulta arbitrária escrita pelo cliente.
+        assertEquals(400, response.statusCode())
+    }
+
+    @Test
+    fun `um lote vazio ou com id ilegivel e recusado`() {
+        assertEquals(400, get("${InvoiceApi.BASE}?rentalIds=", "rider-api-h").statusCode())
+        assertEquals(400, get(InvoiceApi.BASE, "rider-api-h").statusCode())
+        assertEquals(400, get("${InvoiceApi.BASE}?rentalIds=not-a-guid", "rider-api-h").statusCode())
+        assertEquals(400, get("${InvoiceApi.BASE}/not-a-guid", "rider-api-h").statusCode())
+    }
+
+    @Test
+    fun `sem o envelope do portao nao se le nada`() {
+        val mine = seed("rider-api-i")
+
+        val response =
+            http.send(
+                HttpRequest.newBuilder(URI.create(base + InvoiceApi.BASE + "/" + mine.rentalId)).GET().build(),
+                HttpResponse.BodyHandlers.ofString(),
+            )
+
+        assertEquals(401, response.statusCode())
+        assertTrue(!response.body().contains(mine.rentalId))
+    }
+
+    /**
+     * O envelope é assinado para um caminho. Reapresentá-lo noutro é o ataque
+     * que a assinatura existe para impedir, e a rota precisa recusá-lo mesmo com
+     * a chave certa.
+     */
+    @Test
+    fun `um envelope assinado para outro caminho nao serve`() {
+        val mine = seed("rider-api-j")
+        val signedFor = "${InvoiceApi.BASE}/${UUID.randomUUID()}"
+
+        val response =
+            http.send(
+                envelope(
+                    HttpRequest.newBuilder(URI.create("$base${InvoiceApi.BASE}/${mine.rentalId}")).GET(),
+                    "rider-api-j",
+                    "Rider",
+                    signedFor,
+                ).build(),
+                HttpResponse.BodyHandlers.ofString(),
+            )
+
+        assertEquals(401, response.statusCode())
+    }
+
+    @Test
+    fun `escrever numa nota nao e uma rota`() {
+        val response =
+            http.send(
+                envelope(
+                    HttpRequest.newBuilder(URI.create(base + InvoiceApi.BASE))
+                        .POST(HttpRequest.BodyPublishers.ofString("{}")),
+                    "rider-api-k",
+                    "Rider",
+                    InvoiceApi.BASE,
+                ).build(),
+                HttpResponse.BodyHandlers.ofString(),
+            )
+
+        assertEquals(405, response.statusCode())
+    }
+
+    // ------------------------------------------------------------------ apoio
+
+    private fun get(
+        pathAndQuery: String,
+        subject: String,
+        roles: String = "Rider",
+    ): HttpResponse<String> =
+        http.send(
+            envelope(
+                HttpRequest.newBuilder(URI.create(base + pathAndQuery)).GET(),
+                subject,
+                roles,
+                pathAndQuery,
+            ).build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+
+    private fun envelope(
+        builder: HttpRequest.Builder,
+        subject: String,
+        roles: String,
+        pathAndQuery: String,
+        method: String = "GET",
+    ): HttpRequest.Builder {
+        val issuedAt = Instant.now().epochSecond.toString()
+        val canonical =
+            listOf("v1", "local-v1", subject, roles, issuedAt, method, pathAndQuery, audience)
+                .joinToString("\n")
+        val signature =
+            Mac.getInstance("HmacSHA256").run {
+                init(SecretKeySpec(key, "HmacSHA256"))
+                Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(doFinal(canonical.toByteArray(StandardCharsets.UTF_8)))
+            }
+        return builder
+            .header(GatewayIdentity.KEY_ID_HEADER, "local-v1")
+            .header(GatewayIdentity.SUBJECT_HEADER, subject)
+            .header(GatewayIdentity.ROLES_HEADER, roles)
+            .header(GatewayIdentity.ISSUED_AT_HEADER, issuedAt)
+            .header(GatewayIdentity.SIGNATURE_HEADER, "v1=$signature")
+    }
+
+    private fun seed(riderId: String): ClosedRental {
+        val rentalId = UUID.randomUUID().toString()
+        val start = 1_767_225_600_000L
+        val rental =
+            ClosedRental(
+                eventId = "$rentalId:rental.closed:v1",
+                rentalId = rentalId,
+                riderId = riderId,
+                currency = "BRL",
+                agreedTotalMinor = 21_000L,
+                planDays = 7,
+                startedAtMs = start,
+                predictedEndAtMs = start + 7 * 86_400_000L,
+                endedAtMs = start + 4 * 86_400_000L,
+                riderName = "Ada Lovelace",
+                traceParent = null,
+            )
+        val settled =
+            Settlement.settle(
+                rental.agreedTotalMinor,
+                rental.planDays,
+                rental.startedAtMs,
+                rental.predictedEndAtMs,
+                rental.endedAtMs,
+            )
+        val issued = Invoices(TestDatabase.dataSource).issue(rental.eventId, rental, settled)
+        assertEquals(Outcome.ISSUED, issued.outcome, "a fixture precisa realmente emitir a nota")
+        return rental
+    }
+}

--- a/services/billing/src/test/kotlin/projecty/billing/TestDatabase.kt
+++ b/services/billing/src/test/kotlin/projecty/billing/TestDatabase.kt
@@ -1,0 +1,102 @@
+package projecty.billing
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+import java.nio.file.Files
+import java.nio.file.Path
+import java.sql.DriverManager
+import java.sql.SQLException
+
+/**
+ * Um CockroachDB por JVM, com o schema de `deploy/db/sql` aplicado.
+ *
+ * CockroachDB e não PostgreSQL porque as garantias que estes testes verificam
+ * dependem do nível de isolamento: SERIALIZABLE é o padrão lá. Em READ
+ * COMMITTED o teste de exatamente-uma-vez passaria por sorte.
+ *
+ * O container é compartilhado entre as classes de teste de propósito: subir um
+ * banco por classe triplicaria o tempo do CI para provar a mesma coisa.
+ */
+object TestDatabase {
+    private var container: GenericContainer<*>? = null
+
+    val dataSource: HikariDataSource by lazy {
+        // Um CockroachDB já de pé, quando houver, e um container quando não.
+        //
+        // O Testcontainers precisa falar com o daemon, e nem toda máquina de
+        // desenvolvimento expõe o socket de dentro de um container -- o Docker
+        // Desktop no Windows não expõe. O CI roda pelo caminho de baixo; a
+        // variável existe para rodar os testes à mão sem ele.
+        val endpoint = System.getenv("BILLING_TEST_COCKROACH") ?: startCockroach()
+        val root = url(endpoint, "defaultdb")
+        awaitReady(root)
+        applyFile(root, "000_bootstrap.cockroach.sql")
+        val app = url(endpoint, "projecty")
+        for (file in SCHEMA) applyFile(app, file)
+
+        HikariDataSource(
+            HikariConfig().apply {
+                jdbcUrl = app
+                maximumPoolSize = 4
+            },
+        ).also {
+            Runtime.getRuntime().addShutdownHook(
+                Thread {
+                    it.close()
+                    container?.stop()
+                },
+            )
+        }
+    }
+
+    private val SCHEMA =
+        listOf(
+            "001_schema.sql",
+            "002_rental_core.sql",
+            "003_billing.sql",
+            "004_settlement_moves_to_billing.sql",
+        )
+
+    private fun startCockroach(): String {
+        val started =
+            GenericContainer(DockerImageName.parse("cockroachdb/cockroach:v26.3.1"))
+                .withCommand("start-single-node", "--insecure")
+                .withExposedPorts(26257)
+        started.start()
+        container = started
+        return "${started.host}:${started.getMappedPort(26257)}"
+    }
+
+    private fun url(
+        endpoint: String,
+        database: String,
+    ) = "jdbc:postgresql://$endpoint/$database?sslmode=disable&user=root"
+
+    private fun awaitReady(url: String) {
+        var last: Exception? = null
+        repeat(60) {
+            try {
+                DriverManager.getConnection(url).use { connection ->
+                    connection.createStatement().use { it.execute("SELECT 1") }
+                }
+                return
+            } catch (error: SQLException) {
+                last = error
+                Thread.sleep(1_000)
+            }
+        }
+        throw IllegalStateException("CockroachDB did not become ready", last)
+    }
+
+    private fun applyFile(
+        url: String,
+        file: String,
+    ) {
+        val sql = Files.readString(Path.of("../../deploy/db/sql", file))
+        DriverManager.getConnection(url).use { connection ->
+            connection.createStatement().use { it.execute(sql) }
+        }
+    }
+}


### PR DESCRIPTION
Última peça do #137. O billing era dono da liquidação e nada conseguia lê-la; agora ele serve a nota pelo portão — o que exigiu verificar o envelope de identidade do ADR 0008 numa segunda linguagem.

## A parte que merece revisão de verdade

Uma verificação de segurança escrita duas vezes é uma verificação que pode discordar de si mesma. E a discordância **não aparece como build quebrado** — aparece como alguém entrando.

Então o verificador em Kotlin copia o C# literalmente:

| | |
|---|---|
| string canônica | campo a campo, mesma ordem, mesmo separador |
| caracteres aceitos | ASCII imprimível **menos espaço e menos vírgula** — um papel não pode contrabandear o separador |
| janela de tempo | 30s para trás, 5s de folga para frente |
| comparação | tempo constante (`MessageDigest.isEqual`) |
| headers | exatamente um valor cada, para duas camadas não lerem coisas diferentes de um header repetido |

### Como isso fica preso

Dois testes que se encontram no meio:

- **No gateway**, `signs_invoice_reads_for_the_billing_audience` fixa o que ele assina para uma rota de fatura.
- **No billing**, `GatewayIdentityTest` fixa o que ele aceita — **contra um envelope que este gateway realmente produziu**, `issued_at` e assinatura inclusos, congelado com relógio fixo.

Um vetor que eu mesmo assinasse provaria só que o verificador concorda consigo mesmo, e concordar consigo mesmo não é o risco.

## As rotas

```
GET /api/invoices/{rentalId}
GET /api/invoices?rentalIds=a,b,c
```

- **A nota de outro responde 404, não 403** — byte a byte igual à de um id inexistente. A diferença entre as duas respostas é um oráculo de existência para quem varre ids. Tem teste comparando os dois corpos.
- **Lote com teto de 100**, mesmo motivo do lote de aluguéis: sem teto é uma consulta arbitrária escrita pelo cliente.
- **O filtro por dono é SQL**, não filtragem depois. A linha alheia não atravessa o processo, e não existe caminho em que alguém acrescente um retorno antes do filtro.

## Não há rota de escrita, e isso é a garantia

Uma nota é emitida **só** pelo consumo de `rental.closed`, dentro da transação do inbox. Um endpoint que também pudesse emitir seria o segundo caminho para o mesmo efeito — e o segundo caminho é exatamente onde o exatamente-uma-vez vaza. O portão concorda: qualquer coisa que não seja `GET` para o billing é rota de administrador.

## Um afrouxamento deliberado, escrito onde ele mora

`GATEWAY_JWT_AUDIENCE_BILLING` é **`projecty.rental-core`**, não uma audiência própria. Ou seja: um token do rental-core serve no billing.

Não é descuido, é escolha. Essa string faz duas coisas — valida o `aud` do token **e** vira a audiência do envelope que o portão assina. Uma audiência própria exigiria um segundo token para a mesma tela, e o console guarda um só, sem credenciais para pedir outro.

O #136 troca esse esquema de HMAC por audiência inteiro (EdDSA com JWKS, um emissor). A fronteira certa se desenha lá, uma vez, em vez de eu acrescentar uma sexta chave a um esquema que já está de saída. O comentário está no `docker-compose.yml`, ao lado do valor.

## Verificação

| | |
|---|---|
| billing | **34** testes (eram 14): +11 de identidade, +9 da API |
| api-gateway | **48** testes, `cargo fmt` e `clippy` limpos |
| ktlint | limpo |
| Compose | os três modelos validam |
| imagem | builda |

Também troquei um container por classe de teste por um **CockroachDB compartilhado na JVM** — subir um banco por classe triplicaria o tempo do CI para provar a mesma coisa.

## O que sobra do #137

Nada. A liquidação tem dono ([#183](https://github.com/iVega123/ProjectY/pull/183)), o rental-core parou de calcular dinheiro ([#184](https://github.com/iVega123/ProjectY/pull/184)), e a nota é legível. O console compondo a tela é o **#138**, que é explicitamente dono disso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
