### PR TITLE
feat(console): compose the rental screen, and lock the batches with a contract

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -45,6 +45,34 @@ Once `topics.json` exists in the base revision, CI registers that revision first
 and checks the proposed schema against it under FULL. The negative control is
 sent to the compatibility endpoint only, never registered.
 
+## Read contracts
+
+`reads.json` is the console's declaration of the reads its rental screen makes:
+path, the name of the ids parameter, the batch cap, and the fields it uses.
+
+It exists because [ADR 0014](../docs/adr/0014-read-aggregation-at-the-bff.md)
+makes batch reads a contract rather than an optimisation — without them the N+1
+does not disappear, it moves from the browser into the BFF. The definition of
+done in #138 is that removing one turns a test red before it turns a screen
+blank, and that is only true if the tests read the declaration instead of
+repeating it.
+
+Each provider verifies itself against this same file, against its own running
+handler:
+
+| Provider | Test |
+|---|---|
+| rental-core | `Motorcycles/Integration/MotorcycleBatchReadContractTests.cs` |
+| identity | `internal/api/reads_test.go` |
+| billing | `InvoiceApiTest.o lote responde o que o console declarou` |
+
+The consumer is checked too: `services/console/test/compose.test.ts` asserts the
+screen calls nothing that is not declared here, and that the page size equals
+every declared batch cap.
+
+A field renamed on one side, or an endpoint deleted, fails on the other side —
+which is the whole point of writing it down once.
+
 ## Validation
 
 `node --test contracts/check.test.mjs` checks conventions.

--- a/contracts/reads.json
+++ b/contracts/reads.json
@@ -1,0 +1,36 @@
+{
+  "consumer": "console",
+  "screen": "rentals",
+  "why": "ADR 0014 makes batch reads a contract and not an optimisation: without them the N+1 does not disappear, it moves from the browser into the BFF. This file is the consumer's declaration, and each provider verifies it against its own running handler. Removing one of these turns a provider test red before it turns the screen blank.",
+  "pageSize": 100,
+  "reads": [
+    {
+      "name": "motorcycles by id",
+      "provider": "rental-core",
+      "method": "GET",
+      "path": "/api/motorcycles/batch",
+      "idsParameter": "ids",
+      "batched": true,
+      "maxBatch": 100,
+      "fields": ["id", "model", "year", "licensePlate"]
+    },
+    {
+      "name": "invoices by rental id",
+      "provider": "billing",
+      "method": "GET",
+      "path": "/api/invoices",
+      "idsParameter": "rentalIds",
+      "batched": true,
+      "maxBatch": 100,
+      "fields": ["rentalId", "currency", "totalMinor", "adjustmentMinor", "reason", "daysUsed"]
+    },
+    {
+      "name": "the caller's own rider record",
+      "provider": "identity",
+      "method": "GET",
+      "path": "/api/riders/{id}",
+      "batched": false,
+      "fields": ["userId", "name", "cnhType", "verified"]
+    }
+  ]
+}

--- a/docs/measurements/bff-hop.json
+++ b/docs/measurements/bff-hop.json
@@ -1,0 +1,28 @@
+{
+  "measuredAt": "2026-09-09T12:40:25.465Z",
+  "fixture": "projecty-load",
+  "rounds": 40,
+  "pace": 700,
+  "path": "/api/motorcycles/batch?ids=00000000-0000-0000-0000-000000000000",
+  "viaGateway": {
+    "p50": 9.25,
+    "p95": 12.11,
+    "p99": 49.39
+  },
+  "viaService": {
+    "p50": 4.05,
+    "p95": 5.47,
+    "p99": 5.67
+  },
+  "hopCostMs": {
+    "p50": 5.2,
+    "p95": 6.64
+  },
+  "compositionCalls": 3,
+  "includes": [
+    "verificação EdDSA contra o JWKS que o portão cacheia",
+    "limitação de taxa: uma ida ao Redis por requisição",
+    "assinatura do envelope do ADR 0008",
+    "um salto de rede a mais"
+  ]
+}

--- a/docs/measurements/polyglot-api.json
+++ b/docs/measurements/polyglot-api.json
@@ -1,224 +1,105 @@
 {
-  "measuredAt": "2026-09-06T15:33:03.775Z",
+  "measuredAt": "2026-09-09T12:40:43.525Z",
   "action": {
     "index": 0,
-    "plate": "KAA8412",
+    "plate": "KAA8914",
     "status": 200,
-    "duration": 39.88703300000634,
-    "traceId": "180f29be46c44c8157c08614630f8796",
+    "duration": 203.4948330000043,
+    "traceId": "fc3160e5dc7c307895cfd7344ec39d31",
     "detail": "Created with Success!"
   },
-  "rentalId": "6a9d87a78357007aee869ba2",
+  "rentalId": "2918a9d9-d2c3-4705-b322-48dc69d7d093",
   "position": {
     "latitude": -3.119,
     "longitude": -60.021,
-    "recorded_at": 1788708777636
+    "recorded_at": 1788957637358
   },
   "services": [
     "api-gateway",
-    "rental-operations",
-    "rider-manager",
-    "moto-hub",
+    "rental-core",
     "risk-pricing",
     "telemetry"
   ],
   "spans": [
     {
-      "id": "7smNWLUzR1g=",
-      "parentId": "aoF1tWEPcaI=",
+      "id": "h3aeCTMx5+k=",
+      "parentId": "ZG0j5I/hwqQ=",
       "service": "api-gateway",
       "name": "gateway.request",
-      "start": 1788708775437.2974,
-      "duration": 35.72864,
+      "start": 1788957635043.7314,
+      "duration": 134.301184,
       "error": false
     },
     {
-      "id": "fxmHD96dKzU=",
-      "parentId": "7smNWLUzR1g=",
+      "id": "Jxpjdb4b22M=",
+      "parentId": "h3aeCTMx5+k=",
       "service": "api-gateway",
       "name": "gateway.upstream",
-      "start": 1788708775444.7314,
-      "duration": 28.25856,
+      "start": 1788957635048.6182,
+      "duration": 129.377024,
       "error": false
     },
     {
-      "id": "8l9n5/LuAgE=",
-      "parentId": "fxmHD96dKzU=",
-      "service": "rental-operations",
+      "id": "PBuDjEE/9Jg=",
+      "parentId": "Jxpjdb4b22M=",
+      "service": "rental-core",
       "name": "POST api/Rental/create",
-      "start": 1788708775445.147,
-      "duration": 27.769344,
+      "start": 1788957635049.0635,
+      "duration": 129.052928,
       "error": false
     },
     {
-      "id": "uiQPbMKEnew=",
-      "parentId": "8l9n5/LuAgE=",
-      "service": "rental-operations",
-      "name": "find RentalOperationsDB.Rentals",
-      "start": 1788708775451.0632,
-      "duration": 1.686272,
+      "id": "I7vqqGmtnUo=",
+      "parentId": "PBuDjEE/9Jg=",
+      "service": "rental-core",
+      "name": "projecty",
+      "start": 1788957635145.5254,
+      "duration": 2.082304,
       "error": false
     },
     {
-      "id": "+2ho47OwvgI=",
-      "parentId": "uiQPbMKEnew=",
-      "service": "rental-operations",
-      "name": "find",
-      "start": 1788708775451.2048,
-      "duration": 1.486592,
-      "error": false
-    },
-    {
-      "id": "MpBI0m67T0Q=",
-      "parentId": "8l9n5/LuAgE=",
-      "service": "rental-operations",
-      "name": "GET",
-      "start": 1788708775453.2654,
-      "duration": 7.204096,
-      "error": false
-    },
-    {
-      "id": "HBeZhZMWCBE=",
-      "parentId": "MpBI0m67T0Q=",
-      "service": "rider-manager",
-      "name": "GET api/Riders/{userId}",
-      "start": 1788708775454.6199,
-      "duration": 5.730304,
-      "error": false
-    },
-    {
-      "id": "mtXot9RDrK4=",
-      "parentId": "HBeZhZMWCBE=",
-      "service": "rider-manager",
-      "name": "RiderManagerDB",
-      "start": 1788708775456.2478,
-      "duration": 1.864192,
-      "error": false
-    },
-    {
-      "id": "j3BEmgv34eg=",
-      "parentId": "HBeZhZMWCBE=",
-      "service": "rider-manager",
-      "name": "RiderManagerDB",
-      "start": 1788708775458.5032,
-      "duration": 1.42464,
-      "error": false
-    },
-    {
-      "id": "OMKz4SN8Dt0=",
-      "parentId": "8l9n5/LuAgE=",
-      "service": "rental-operations",
-      "name": "GET",
-      "start": 1788708775462.844,
-      "duration": 4.668416,
-      "error": false
-    },
-    {
-      "id": "vEC7P+/LBJc=",
-      "parentId": "OMKz4SN8Dt0=",
-      "service": "moto-hub",
-      "name": "GET api/Motorcycles/{licensePlate}",
-      "start": 1788708775463.8162,
-      "duration": 3.68768,
-      "error": false
-    },
-    {
-      "id": "FhaNAu4O3eI=",
-      "parentId": "vEC7P+/LBJc=",
-      "service": "moto-hub",
-      "name": "MotoHubDB",
-      "start": 1788708775465.2446,
-      "duration": 1.692928,
-      "error": false
-    },
-    {
-      "id": "hOWxT/ggacE=",
-      "parentId": "8l9n5/LuAgE=",
-      "service": "rental-operations",
-      "name": "insert RentalOperationsDB.MotorcycleClaims",
-      "start": 1788708775467.7715,
-      "duration": 1.033728,
-      "error": false
-    },
-    {
-      "id": "KKROqb9HcE4=",
-      "parentId": "hOWxT/ggacE=",
-      "service": "rental-operations",
-      "name": "insert",
-      "start": 1788708775467.9402,
-      "duration": 0.797184,
-      "error": false
-    },
-    {
-      "id": "hwRU7rmgu0E=",
-      "parentId": "8l9n5/LuAgE=",
-      "service": "rental-operations",
-      "name": "insert RentalOperationsDB.Rentals",
-      "start": 1788708775468.883,
-      "duration": 0.777472,
-      "error": false
-    },
-    {
-      "id": "ozGNS2W5rlQ=",
-      "parentId": "hwRU7rmgu0E=",
-      "service": "rental-operations",
-      "name": "insert",
-      "start": 1788708775468.9868,
-      "duration": 0.645376,
-      "error": false
-    },
-    {
-      "id": "dZ4wtfiUfBw=",
-      "parentId": "8l9n5/LuAgE=",
-      "service": "rental-operations",
+      "id": "PVzAsoZM5+w=",
+      "parentId": "PBuDjEE/9Jg=",
+      "service": "rental-core",
       "name": "publish rental.started",
-      "start": 1788708776502.5718,
-      "duration": 7.9552,
+      "start": 1788957636346.9983,
+      "duration": 41.142784,
       "error": false
     },
     {
-      "id": "ilGd2nIF4vw=",
-      "parentId": "dZ4wtfiUfBw=",
-      "service": "rental-operations",
-      "name": "update RentalOperationsDB.Rentals",
-      "start": 1788708776509.2297,
-      "duration": 1.275392,
+      "id": "FISy1bkep1c=",
+      "parentId": "PVzAsoZM5+w=",
+      "service": "rental-core",
+      "name": "POST",
+      "start": 1788957636352.308,
+      "duration": 16.951808,
       "error": false
     },
     {
-      "id": "0EviuGeOWj8=",
-      "parentId": "ilGd2nIF4vw=",
-      "service": "rental-operations",
-      "name": "update",
-      "start": 1788708776509.4211,
-      "duration": 1.00224,
-      "error": false
-    },
-    {
-      "id": "BFZpdvRu2/8=",
-      "parentId": "dZ4wtfiUfBw=",
+      "id": "i5DYG1xPlzE=",
+      "parentId": "PVzAsoZM5+w=",
       "service": "risk-pricing",
       "name": "process rental.started",
-      "start": 1788708776509.6528,
-      "duration": 5.60896,
+      "start": 1788957636381.438,
+      "duration": 4.673792,
       "error": false
     },
     {
-      "id": "D2gcu+Tu5xI=",
-      "parentId": "BFZpdvRu2/8=",
+      "id": "h0JYMbu4Wwc=",
+      "parentId": "i5DYG1xPlzE=",
       "service": "risk-pricing",
       "name": "publish risk.scored",
-      "start": 1788708776515.47,
-      "duration": 1.516288,
+      "start": 1788957636386.2324,
+      "duration": 10.337792,
       "error": false
     },
     {
-      "id": "gC0P9aoYhH8=",
-      "parentId": "dZ4wtfiUfBw=",
+      "id": "e39PUFRlfEg=",
+      "parentId": "PVzAsoZM5+w=",
       "service": "telemetry",
       "name": "kafka tracking event",
-      "start": 1788708777312.9924,
-      "duration": 3.292928,
+      "start": 1788957636541.7007,
+      "duration": 2.92608,
       "error": false
     }
   ],
@@ -226,6 +107,6 @@
     "p99": null,
     "queue": 0,
     "limited": 0,
-    "measuredAt": "2026-09-06T15:33:03.774Z"
+    "measuredAt": "2026-09-09T12:40:43.523Z"
   }
 }

--- a/docs/runbooks/polyglot-services.md
+++ b/docs/runbooks/polyglot-services.md
@@ -38,6 +38,38 @@ delivery, then resume writes. To roll back, use the previous applications and
 drain or replay any new pending commands before reverting producers; no queue is
 automatically removed. This is a queue naming update, independent of #130.
 
+### The rental screen is composed in the console
+
+Since #138 the console assembles one screen from four services, server-side.
+One page costs **four calls**, and the number does not move with the number of
+rows: the page itself, then a batch for the motorcycles, a batch for the
+invoices, and the caller's own rider record — the last three in parallel.
+
+That composition lives in the BFF and not in the gateway, and the reason is
+change rate rather than language: the gateway changes rarely and fails closed;
+read composition changes with every screen and fails soft
+([ADR 0014](../adr/0014-read-aggregation-at-the-bff.md)).
+
+`contracts/reads.json` is the console's declaration of those reads, and each
+provider has a test that reads that file and checks its own handler — so
+deleting a batch endpoint turns a test red before it turns the screen blank.
+
+**When a provider is down, the row loses that field and the page still
+renders.** The screen says which one:
+
+```
+3 in the current page · without invoices
+```
+
+A 404 is not a degradation — it is an answer. An admin has no rider record, and
+the screen says nothing is missing.
+
+The extra hop through the gateway is measured, not assumed:
+[`docs/measurements/bff-hop.json`](../measurements/bff-hop.json). Reproduce it
+against a prepared fixture with `services/console/test/hop-cost.mjs`; keep the
+probe under the gateway's 120 requests per minute or it measures the rate
+limiter instead of the hop.
+
 ### Prepare the fixture
 
 ```powershell

--- a/scripts/Run-LoadTest.ps1
+++ b/scripts/Run-LoadTest.ps1
@@ -92,8 +92,13 @@ try {
     if ($Polyglot) { $startServices += @('console', 'telemetry', 'risk-pricing') }
     Compose up @build -d --wait --wait-timeout 300 @startServices
     # Only this generated project and its fresh, separately named volumes are touched.
-    Get-Content load/fixtures/seed-rental-core.sql -Raw | docker compose -p $project -f $fixture exec -T cockroachdb cockroach sql --insecure --database=projecty
-    if ($LASTEXITCODE) { throw 'Rental-core fixture failed.' }
+    #
+    # O arquivo entra por copia, e nao pelo pipe. O Windows PowerShell 5.1
+    # escreve um BOM ao canalizar texto para um processo nativo, e o cockroach
+    # recusa o arquivo inteiro com um erro de sintaxe no primeiro caractere --
+    # um caractere que nao esta no arquivo. Copiar tira o host do caminho.
+    Compose cp load/fixtures/seed-rental-core.sql cockroachdb:/tmp/seed-rental-core.sql
+    Compose exec -T cockroachdb cockroach sql --insecure --database=projecty --file /tmp/seed-rental-core.sql
     Compose exec -T redis redis-cli FLUSHDB
     & "$PSScriptRoot/Invoke-Chaos.ps1" reset -Url 'http://127.0.0.1:18474'
     if ($PrepareOnly) { $exitCode = 0; return }

--- a/services/api-gateway/src/policy.rs
+++ b/services/api-gateway/src/policy.rs
@@ -206,6 +206,21 @@ mod tests {
         }
     }
 
+    /// O lote que o console usa para compor a tela de aluguéis. Ele é N vezes
+    /// "esta moto", e não o catálogo -- classificá-lo como Admin recusaria o
+    /// piloto na borda e deixaria a tela sem modelo nem ano.
+    #[test]
+    fn a_rider_may_resolve_the_motorcycles_on_their_own_screen() {
+        assert_eq!(
+            access_for(
+                &Method::GET,
+                "/api/motorcycles/batch",
+                UpstreamName::MotoHub
+            ),
+            Access::Authenticated
+        );
+    }
+
     #[test]
     fn a_rider_may_read_one_motorcycle_but_not_the_fleet() {
         // Alugar exige saber qual moto se está alugando. Listar a frota, não.

--- a/services/billing/src/test/kotlin/projecty/billing/DeclaredRead.kt
+++ b/services/billing/src/test/kotlin/projecty/billing/DeclaredRead.kt
@@ -1,0 +1,60 @@
+package projecty.billing
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.io.File
+
+/**
+ * A declaração do consumidor, lida do arquivo em vez de repetida aqui.
+ *
+ * O #138 pede que remover um endpoint de lote deixe um teste vermelho antes de
+ * deixar uma tela em branco. Isso só vale se o teste souber o que a tela pede,
+ * e a única forma de saber é ler a mesma declaração que o console lê --
+ * `contracts/reads.json`. Repetir os nomes de campo aqui provaria apenas que
+ * este arquivo concorda consigo mesmo.
+ */
+data class DeclaredRead(
+    val method: String,
+    val path: String,
+    val idsParameter: String?,
+    val maxBatch: Int?,
+    val fields: List<String>,
+) {
+    companion object {
+        fun of(
+            provider: String,
+            path: String,
+        ): DeclaredRead {
+            val document = ObjectMapper().readTree(locate())
+            for (read in document["reads"]) {
+                if (read["provider"].asText() == provider && read["path"].asText() == path) {
+                    return DeclaredRead(
+                        method = read["method"].asText(),
+                        path = read["path"].asText(),
+                        idsParameter = read["idsParameter"]?.asText(),
+                        maxBatch = read["maxBatch"]?.asInt(),
+                        fields = read["fields"].map { it.asText() },
+                    )
+                }
+            }
+            error(
+                "contracts/reads.json declares no $provider read at $path. " +
+                    "If the console stopped asking for it, delete the endpoint; " +
+                    "if it still asks, restore the declaration.",
+            )
+        }
+
+        /**
+         * Sobe até achar o arquivo. O diretório de trabalho de um teste Gradle é
+         * o do módulo, e um caminho relativo fixo quebra ao mover o módulo.
+         */
+        private fun locate(): File {
+            var directory: File? = File(".").absoluteFile
+            while (directory != null) {
+                val candidate = File(directory, "contracts/reads.json")
+                if (candidate.isFile) return candidate
+                directory = directory.parentFile
+            }
+            error("contracts/reads.json was not found above ${File(".").absolutePath}")
+        }
+    }
+}

--- a/services/billing/src/test/kotlin/projecty/billing/InvoiceApiTest.kt
+++ b/services/billing/src/test/kotlin/projecty/billing/InvoiceApiTest.kt
@@ -190,6 +190,42 @@ class InvoiceApiTest {
 
     // ------------------------------------------------------------------ apoio
 
+    /**
+     * O lote responde com tudo o que o console declarou precisar.
+     *
+     * Os nomes dos campos vêm de `contracts/reads.json`, e não desta classe:
+     * renomear `totalMinor` aqui deixa este teste vermelho sem que ninguém
+     * precise lembrar de atualizá-lo, que é a diferença entre um contrato e um
+     * comentário.
+     */
+    @Test
+    fun `o lote responde o que o console declarou`() {
+        val declared = DeclaredRead.of("billing", InvoiceApi.BASE)
+        assertEquals("GET", declared.method)
+        assertEquals(InvoiceReads.MAX_BATCH_SIZE, declared.maxBatch)
+
+        val first = seed("rider-contract")
+        val second = seed("rider-contract")
+
+        val response =
+            get(
+                "${InvoiceApi.BASE}?${declared.idsParameter}=${first.rentalId},${second.rentalId}",
+                "rider-contract",
+            )
+
+        assertEquals(200, response.statusCode())
+        val invoices = json.readTree(response.body())
+        assertEquals(2, invoices.size())
+        for (invoice in invoices) {
+            for (field in declared.fields) {
+                assertTrue(
+                    invoice.has(field),
+                    "contracts/reads.json declares '$field', and the batch did not answer with it.",
+                )
+            }
+        }
+    }
+
     private fun get(
         pathAndQuery: String,
         subject: String,

--- a/services/console/README.md
+++ b/services/console/README.md
@@ -1,0 +1,118 @@
+# console
+
+O BFF. Ele compõe a tela e não decide nada sobre segurança.
+
+Em Next.js, e a divisão importa mais do que a moldura: tudo que fala com o
+resto do sistema roda no **servidor** deste serviço, com o token do usuário num
+cookie `httpOnly`. O navegador nunca vê o token e nunca chama um serviço
+diretamente.
+
+## Por que a composição mora aqui
+
+O [ADR 0014](../../docs/adr/0014-read-aggregation-at-the-bff.md) decide isto, e
+a razão é taxa de mudança, não linguagem:
+
+| | Portão | Agregação de leitura |
+|---|---|---|
+| Muda | raramente -- é fronteira de segurança | toda vez que uma tela muda |
+| Falha | **fechado** -- sem token válido, sem entrada | **suave** -- renderiza o que chegou |
+
+Costurar Aluguel a Piloto dentro do portão acoplaria um artefato que muda toda
+semana ao que valida token. O BFF pode saber a forma da tela porque ele é
+implantado **com** a tela.
+
+O console continua chamando pelo portão, com o token do usuário. Falar direto
+com os serviços faria dele um segundo lugar que decide quem é quem -- que é
+exatamente o que o ADR 0008 existe para impedir.
+
+## A tela de aluguéis
+
+Uma página custa **quatro chamadas**, e o número não muda com o número de
+linhas:
+
+| | |
+|---|---|
+| `GET /api/Rental/user` | a página de aluguéis |
+| `GET /api/motorcycles/batch?ids=` | modelo e ano das motos da página |
+| `GET /api/invoices?rentalIds=` | o que cada aluguel fechado custou de verdade |
+| `GET /api/riders/{id}` | o nome de quem está logado |
+
+As três últimas saem **em paralelo**, então a tela paga a mais lenta e não a
+soma. `test/compose.test.ts` conta as chamadas com uma linha e com cem e exige o
+mesmo resultado: é o que impede um `await` dentro de um `map` de voltar sem que
+ninguém perceba.
+
+O padrão DataLoader sobreviveu; a tecnologia não. O que ele faz de fato é juntar
+as chaves de uma requisição numa chamada só -- e isso exige um endpoint de lote
+do outro lado. Por isso o #138 trata os lotes como **contrato**: sem eles o N+1
+não desaparece, só se muda do navegador para cá.
+
+A leitura do piloto é única e não em lote de propósito: a tela mostra os
+aluguéis de quem pediu, então o conjunto de pilotos de uma página tem sempre
+tamanho um. Pedir o lote -- que é rota de administrador -- para um id só seria
+usar a permissão maior para a pergunta menor.
+
+### Falhar suave
+
+Um provedor fora do ar deixa a linha **sem aquele campo**, e a tela diz o que
+faltou:
+
+```
+3 in the current page · without invoices
+```
+
+Ela não apaga a página. Essa é a metade do ADR 0014 que costuma sumir na
+implementação, e tem teste: `a provider that is down leaves the row without that
+field, not without the page`.
+
+**404 é resposta, não falha.** Um administrador não tem registro de piloto, e
+dizer "sem piloto" para ele está certo; dizer "o identity caiu" seria mentira, e
+mentira que aparece toda vez que ele entra. O fixture de carga achou isso -- o
+sujeito do token dele não é um piloto cadastrado, e a tela anunciava degradação
+a cada requisição.
+
+## O contrato de leitura
+
+`contracts/reads.json` é a declaração do consumidor: caminho, nome do parâmetro
+de ids, teto do lote e os campos que a tela usa. Cada provedor tem um teste que
+lê **esse mesmo arquivo** e verifica o próprio handler contra ele -- em Go, em
+Kotlin e em C#.
+
+Isso é o que faz "remover um lote deixa um teste vermelho antes de deixar uma
+tela em branco" ser verdade em vez de intenção. Uma cópia dos nomes de campo
+dentro de cada teste provaria apenas que o teste concorda consigo mesmo.
+
+O tamanho de página do console e o teto dos lotes são o **mesmo número**, e há
+teste fixando a igualdade: subir um sem o outro deixaria a última linha da
+página sem moto, em silêncio.
+
+## O preço do salto extra
+
+O ADR 0014 aceita uma consequência e manda medi-la: a chamada passa pelo portão
+em vez de ir direto. O número está em
+[`docs/measurements/bff-hop.json`](../../docs/measurements/bff-hop.json), e o
+que o produz é `test/hop-cost.mjs`, que pede a mesma leitura das duas formas do
+mesmo lugar -- assinando o envelope do ADR 0008 à mão no caminho direto, para
+não medir "com autenticação" contra "sem".
+
+## Rodar
+
+```bash
+npm ci
+npm test          # composição, contratos e limites de entrada
+npm run typecheck
+npm run build
+```
+
+Os testes de pilha exigem o fixture `projecty-load` de pé; o runbook em
+[`docs/runbooks/polyglot-services.md`](../../docs/runbooks/polyglot-services.md)
+tem a sequência.
+
+## Configuração
+
+| Variável | |
+|---|---|
+| `GATEWAY_URL` | `http://api-gateway:8090` |
+| `CONSOLE_ORIGIN` | de onde o navegador chama, e o que o `sameOrigin` exige |
+| `TELEMETRY_TICKET_KEY` | assina o ticket de rastreamento e a permissão de trace, mínimo 32 bytes |
+| `TELEMETRY_PUBLIC_URL` | o WebSocket que o navegador abre |

--- a/services/console/app/api/session/route.ts
+++ b/services/console/app/api/session/route.ts
@@ -1,5 +1,5 @@
 import { cookies } from 'next/headers';
-import { failure, origin, sameOrigin, session, upstream } from '../../../lib/server';
+import { composedSession, failure, origin, sameOrigin, upstream } from '../../../lib/server';
 export async function POST(request:Request) {
   try {
     sameOrigin(request);
@@ -11,5 +11,5 @@ export async function POST(request:Request) {
     return Response.json({signedIn:true});
   } catch(error) {return failure(error)}
 }
-export async function GET(request:Request) {try {const data = await session(new URL(request.url).searchParams.get('cursor') ?? ''); return Response.json({userId:data.userId,rentals:data.rentals})} catch(error) {return failure(error)}}
+export async function GET(request:Request) {try {const data = await composedSession(new URL(request.url).searchParams.get('cursor') ?? ''); return Response.json({userId:data.userId,rentals:data.page,rider:data.page.rider})} catch(error) {return failure(error)}}
 export async function DELETE(request:Request) {try {sameOrigin(request); (await cookies()).delete('projecty-session'); return Response.json({signedIn:false})} catch(error) {return failure(error)}}

--- a/services/console/app/page.tsx
+++ b/services/console/app/page.tsx
@@ -1,9 +1,12 @@
 'use client';
 import { useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
-import type { Attempt, Metrics, Position, Rental, Span } from '../lib/types';
+import type { Attempt, Composed, Metrics, Position, RiderCard, Span } from '../lib/types';
 const LiveMap = dynamic(() => import('./map'), {ssr:false});
 const money = (n:number) => new Intl.NumberFormat('en-US',{style:'currency',currency:'BRL'}).format(n);
+// A nota vem em centavos, como o contrato do evento. Dividir na borda é o
+// último lugar onde isso acontece, e o único que mostra o número a alguém.
+const minor = (n:number, currency:string) => new Intl.NumberFormat('en-US',{style:'currency',currency}).format(n/100);
 async function json(url:string, init?:RequestInit) {
   const response = await fetch(url,init); const body = await response.json();
   if (!response.ok) throw new Error(body.error ?? 'Request failed');
@@ -11,7 +14,11 @@ async function json(url:string, init?:RequestInit) {
 }
 export default function Console() {
   const [user,setUser] = useState('');
-  const [rentals,setRentals] = useState<Rental[]>([]);
+  const [rentals,setRentals] = useState<Composed[]>([]);
+  const [rider,setRider] = useState<RiderCard|null>(null);
+  // O que a composição não conseguiu trazer. A tela renderiza o que chegou e
+  // diz o que faltou, em vez de fingir que a página está completa -- ADR 0014.
+  const [missing,setMissing] = useState<string[]>([]);
   const [selected,setSelected] = useState('');
   const [cursor,setCursor] = useState('');
   const [nextCursor,setNextCursor] = useState<string|null>(null);
@@ -37,7 +44,8 @@ export default function Console() {
     const data = await json('/api/session'+(pageCursor?'?cursor='+encodeURIComponent(pageCursor):''));
     setCursor(pageCursor); setNextCursor(data.rentals.nextCursor);
     setUser(data.userId); setRentals(data.rentals.items);
-    setSelected(current => data.rentals.items.some((r:Rental)=>r.rentalId===current) ? current : data.rentals.items.find((r:Rental) => !r.actualEndDate)?.rentalId || '');
+    setRider(data.rider ?? null); setMissing(data.rentals.missing ?? []);
+    setSelected(current => data.rentals.items.some((r:Composed)=>r.rentalId===current) ? current : data.rentals.items.find((r:Composed) => !r.actualEndDate)?.rentalId || '');
   }
   useEffect(() => {
     setNow(Date.now());
@@ -136,7 +144,7 @@ export default function Console() {
   const traceLength=spans.length ? Math.max(...spans.map(s=>s.start+s.duration))-traceStart : 1;
   return <div className="shell">
     <aside className="rail"><a className="brand" href="/" aria-label="ProjectY home">Y<span>↗</span></a><div className="rail-word">OPERATIONS</div><span className="rail-foot">PY / 10</span></aside>
-    <main><header><div className="breadcrumb">PROJECT Y <span>/</span> OPERATIONS CONSOLE</div><div className="header-state"><i className={user?'dot':'dot muted'}/>{user?'Session connected':'Sign-in required'}</div></header>
+    <main><header><div className="breadcrumb">PROJECT Y <span>/</span> OPERATIONS CONSOLE</div><div className="header-state"><i className={user?'dot':'dot muted'}/>{user?(rider?rider.name+' · CNH '+rider.cnhType:'Session connected'):'Sign-in required'}</div></header>
       <section className="intro"><div><div className="eyebrow">THE SYSTEM, IN MOTION</div><h1>Watch every move<span>.</span></h1><p>From a rider on the street to the events behind the ride.</p></div><div className="clock">{new Date(now).toISOString().slice(11,19)}<small>UTC / LIVE WORKSPACE</small></div></section>
       {!user && <form className="login panel" onSubmit={login}><div><strong>Connect to your fleet</strong><p>Use an access token from your configured identity provider.</p></div><label className="token-input">Gateway access token<input name="token" type="password" required autoComplete="off" maxLength={8192}/></label><button>Connect ↗</button></form>}
       {error && <div className="error" role="alert">{error}<button className="text" onClick={()=>setError('')}>Dismiss ×</button></div>}
@@ -147,9 +155,9 @@ export default function Console() {
       {tab==='Load generator' && <section className="panel load-panel"><div className="section-heading"><div><div className="eyebrow">CONTROLLED LOAD</div><h2>Put the flow to work.</h2></div><span className="tag">MAX 100 / BATCH</span></div><p>Enter existing motorcycle plates, separated by spaces or commas. Each plate triggers one real rental attempt under your account.</p><label>Motorcycle plates<textarea rows={3} value={batch} onChange={e=>setBatch(e.target.value.toUpperCase())} placeholder="Enter plates from your test fleet"/></label><div className="load-actions"><span>{batch.trim()?batch.trim().split(/[\s,]+/).length:0} concurrent attempts · uses the dates below</span><button disabled={!user||busy||!batch.trim()} onClick={()=>run(batch.trim().split(/[\s,]+/))}>{busy?'Running…':'Run batch ↗'}</button></div><Results attempts={attempts} select={a=>{setTrace({...a});setTab('System x-ray')}}/></section>}
       <section className="action-bar panel"><div><div className="eyebrow">CREATE A RENTAL</div><strong>Set a journey in motion</strong></div><label>Licence plate<input value={plate} onChange={e=>setPlate(e.target.value.toUpperCase())} placeholder="Your motorcycle plate" maxLength={7}/></label><label>Start date<input type="date" value={start} onChange={e=>setStart(e.target.value)}/></label><label>Plan<select value={days} onChange={e=>setDays(Number(e.target.value))}>{[7,15,30,45].map(n=><option key={n} value={n}>{n} days</option>)}</select></label><button disabled={!user||busy||!plate} onClick={()=>run([plate])}>{busy?'Sending…':'Start rental ↗'}</button></section>
       {tab!=='Load generator' && attempts.length>0 && <section className="panel"><Results attempts={attempts} select={a=>{setTrace({...a});setTab('System x-ray')}}/></section>}
-      {rentals.length>0 && <section className="rental-list"><div className="section-heading"><h2>Your recent rentals</h2><span className="caption">{rentals.length} in the current page</span></div>{rentals.slice(0,5).map(r=><div className="rental-row" key={r.rentalId}><strong>{r.motorcycleLicencePlate}</strong><span>{r.startDate.slice(0,10)} → {r.predictedEndDate.slice(0,10)}</span><span>{money(r.originalTotalCost)}</span><span className="tag">{r.actualEndDate?'CLOSED':'ACTIVE'}</span></div>)}</section>}
+      {rentals.length>0 && <section className="rental-list"><div className="section-heading"><h2>Your recent rentals</h2><span className="caption">{rentals.length} in the current page{missing.length?' · without '+missing.join(' and '):''}</span></div>{rentals.slice(0,5).map(r=><div className="rental-row" key={r.rentalId}><strong>{r.motorcycleLicencePlate}<small>{r.motorcycle?r.motorcycle.model+' · '+r.motorcycle.year:'model unavailable'}</small></strong><span>{r.startDate.slice(0,10)} → {r.predictedEndDate.slice(0,10)}</span><span>{money(r.originalTotalCost)}<small>agreed</small></span><span>{r.invoice?minor(r.invoice.totalMinor,r.invoice.currency):'—'}<small>{r.invoice?r.invoice.reason:r.actualEndDate?'invoice pending':'not settled yet'}</small></span><span className="tag">{r.actualEndDate?'CLOSED':'ACTIVE'}</span></div>)}</section>}
       {user && <div className="load-actions"><button className="secondary" disabled={!cursor} onClick={()=>refresh().catch(e=>setError(String(e)))}>First rental page</button><button className="secondary" disabled={!nextCursor} onClick={()=>refresh(nextCursor!).catch(e=>setError(String(e)))}>Next rental page →</button></div>}
-      <footer><span>PROJECT Y <b>POLYGLOT OPERATIONS</b></span><span>Live data · UTC timestamps</span>{user&&<button className="text" onClick={async()=>{await fetch('/api/session',{method:'DELETE'});setUser('');setRentals([]);setSelected('');setMetrics(null)}}>Sign out ↗</button>}</footer>
+      <footer><span>PROJECT Y <b>POLYGLOT OPERATIONS</b></span><span>Live data · UTC timestamps</span>{user&&<button className="text" onClick={async()=>{await fetch('/api/session',{method:'DELETE'});setUser('');setRentals([]);setSelected('');setMetrics(null);setRider(null);setMissing([])}}>Sign out ↗</button>}</footer>
     </main></div>;
 }
 function Metric({label,value,unit,note}:{label:string;value:string;unit:string;note:string}) {return <div className="metric"><div className="eyebrow">{label}</div><div className="metric-value">{value}<span>{unit}</span></div><small>{note}</small></div>}

--- a/services/console/lib/compose.ts
+++ b/services/console/lib/compose.ts
@@ -1,0 +1,143 @@
+import type { Composed, Invoice, Motorcycle, Rental, RiderCard } from './types';
+
+/**
+ * A composição da tela de aluguéis.
+ *
+ * O ADR 0014 põe isto no BFF e não no portão, e a razão é a taxa de mudança: o
+ * portão muda raramente e falha FECHADO porque é a fronteira de segurança;
+ * compor uma leitura muda toda vez que a tela muda e falha SUAVE -- renderiza o
+ * que chegou. Misturar os dois faria cada campo novo numa tela virar um deploy
+ * do que valida token.
+ *
+ * O padrão DataLoader sobrevive; a tecnologia não. O que ele realmente faz é
+ * juntar as chaves de uma requisição numa CHAMADA só -- e isso exige um
+ * endpoint de lote do outro lado, que é por que o #138 trata os lotes como
+ * contrato e não como otimização. Sem eles o N+1 não desaparece: sai do
+ * navegador e entra aqui.
+ */
+
+/** O teto de um lote. É o mesmo tamanho de página que o console pede. */
+export const MAX_BATCH = 100;
+
+/** Quantos aluguéis uma página traz -- e, por isso, quantos ids um lote recebe. */
+export const PAGE_SIZE = 100;
+
+/**
+ * As chamadas que compor uma página custa, além da própria página.
+ *
+ * É um número, e não um limite: o teste conta as chamadas com 1 linha e com
+ * PAGE_SIZE linhas e exige o mesmo resultado. É assim que "bounded, independent
+ * of how many rows are on it" deixa de ser afirmação e vira medida.
+ */
+export const COMPOSITION_CALLS = 3;
+
+type Fetch = (path: string) => Promise<Response>;
+
+/** Ids distintos, na ordem em que apareceram, sem os vazios. */
+export function distinct(values: (string | null | undefined)[]): string[] {
+  return [...new Set(values.filter((value): value is string => !!value))];
+}
+
+/**
+ * O resultado de uma chamada da composição.
+ *
+ * `reached` separa "o serviço respondeu que não há" de "o serviço não
+ * respondeu". As duas produzem uma linha sem o campo, e só a segunda é uma
+ * degradação que a tela deve anunciar. Um administrador não tem registro de
+ * piloto: dizer "sem piloto" para ele estaria certo; dizer "o identity caiu"
+ * seria mentira, e mentira que aparece toda vez.
+ */
+type Reply<T> = {value: T; reached: boolean};
+
+async function collect<T>(call: Fetch, path: string): Promise<Reply<T[]>> {
+  try {
+    const response = await call(path);
+    if (!response.ok) return {value: [], reached: false};
+    const body = await response.json();
+    return Array.isArray(body) ? {value: body as T[], reached: true} : {value: [], reached: false};
+  } catch {
+    return {value: [], reached: false};
+  }
+}
+
+async function one<T>(call: Fetch, path: string): Promise<Reply<T | null>> {
+  try {
+    const response = await call(path);
+    // 404 é resposta: este identificador não tem registro. Ver Reply.
+    if (response.status === 404) return {value: null, reached: true};
+    if (!response.ok) return {value: null, reached: false};
+    return {value: (await response.json()) as T, reached: true};
+  } catch {
+    return {value: null, reached: false};
+  }
+}
+
+function index<T>(rows: T[], key: (row: T) => string): Map<string, T> {
+  return new Map(rows.map(row => [key(row), row]));
+}
+
+/**
+ * Compõe uma página de aluguéis.
+ *
+ * Três chamadas, em paralelo, seja a página de uma linha ou de cem:
+ *
+ *   1. as motos dos aluguéis     rental-core   lote por id
+ *   2. as notas dos aluguéis     billing       lote por rental_id
+ *   3. o piloto que está logado  identity      leitura única
+ *
+ * A terceira é única e não em lote de propósito: a tela mostra os aluguéis de
+ * QUEM PEDIU, então o conjunto de pilotos de uma página tem sempre tamanho um.
+ * Chamar o lote para um id só seria pedir a rota de administrador para uma
+ * pergunta que a rota do próprio dono responde.
+ */
+export async function compose(
+  rentals: Rental[],
+  callerId: string,
+  call: Fetch,
+): Promise<{ items: Composed[]; rider: RiderCard | null; missing: string[] }> {
+  const motorcycleIds = distinct(rentals.map(rental => rental.motorcycleId));
+  const rentalIds = distinct(rentals.map(rental => rental.rentalId));
+
+  // Sem linha nenhuma não há nada a compor, e um lote vazio é 400 do outro
+  // lado. Continuar traria só o piloto -- que a tela mostra mesmo vazia.
+  const [motorcycles, invoices, rider] = await Promise.all([
+    motorcycleIds.length
+      ? collect<Motorcycle>(call, '/api/motorcycles/batch?ids=' + ids(motorcycleIds))
+      : Promise.resolve<Reply<Motorcycle[]>>({value: [], reached: true}),
+    rentalIds.length
+      ? collect<Invoice>(call, '/api/invoices?rentalIds=' + ids(rentalIds))
+      : Promise.resolve<Reply<Invoice[]>>({value: [], reached: true}),
+    one<RiderCard>(call, '/api/riders/' + encodeURIComponent(callerId)),
+  ]);
+
+  const byMotorcycle = index(motorcycles.value, motorcycle => motorcycle.id);
+  const byRental = index(invoices.value, invoice => invoice.rentalId);
+
+  const missing: string[] = [];
+  if (!motorcycles.reached) missing.push('motorcycles');
+  if (!invoices.reached) missing.push('invoices');
+  if (!rider.reached) missing.push('rider');
+
+  return {
+    items: rentals.map(rental => ({
+      ...rental,
+      motorcycle: byMotorcycle.get(rental.motorcycleId) ?? null,
+      invoice: byRental.get(rental.rentalId) ?? null,
+    })),
+    rider: rider.value,
+    missing,
+  };
+}
+
+/**
+ * Os ids de um lote, cortados no teto.
+ *
+ * O corte não deveria acontecer: a página pede PAGE_SIZE e o lote aceita
+ * MAX_BATCH, que são o mesmo número por acordo entre os dois lados. O corte
+ * existe para que subir um dos dois sem o outro produza uma tela incompleta em
+ * vez de um 400 que apaga a página inteira -- e há teste fixando a igualdade,
+ * para que subir um dos dois sem o outro fique vermelho antes disso.
+ */
+function ids(values: string[]) {
+  return values.slice(0, MAX_BATCH).map(encodeURIComponent).join(',');
+}

--- a/services/console/lib/server.ts
+++ b/services/console/lib/server.ts
@@ -1,6 +1,7 @@
 import { cookies } from 'next/headers';
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
-import type { Attempt, RentalPage } from './types';
+import type { Attempt, ComposedPage, RentalPage } from './types';
+import { compose, PAGE_SIZE } from './compose';
 
 export const gateway = process.env.GATEWAY_URL ?? 'http://api-gateway:8090';
 export const origin = process.env.CONSOLE_ORIGIN ?? 'http://localhost:3001';
@@ -19,12 +20,21 @@ export async function upstream(path: string, value: string, init: RequestInit = 
 export async function session(cursor = ''): Promise<{token:string; userId:string; rentals:RentalPage}> {
   if(cursor.length > 2048) throw new Error('Invalid rental cursor');
   const value = await token();
-  const result = await upstream('/api/Rental/user?pageSize=100'+(cursor?'&cursor='+encodeURIComponent(cursor):''), value);
+  const result = await upstream('/api/Rental/user?pageSize='+PAGE_SIZE+(cursor?'&cursor='+encodeURIComponent(cursor):''), value);
   if (!result.ok) throw new Error(result.status === 429 ? 'Gateway rate limit; retry shortly.' : 'Session unavailable. Sign in again.');
   // Claims are read only after the gateway has validated signature, issuer, audience and revocation.
   const claims = JSON.parse(Buffer.from(value.split('.')[1], 'base64url').toString());
   if (typeof claims.sub !== 'string') throw new Error('Session has no subject');
   return {token:value, userId:claims.sub, rentals:await result.json()};
+}
+// A tela composta: a página de aluguéis mais o que os outros serviços sabem
+// sobre ela. A composição vive aqui, e não no portão -- ADR 0014, e a razão é a
+// taxa de mudança, não a linguagem.
+export async function composedSession(cursor = ''): Promise<{userId:string; page:ComposedPage}> {
+  const auth = await session(cursor);
+  const composition = await compose(auth.rentals.items, auth.userId,
+    path => upstream(path, auth.token));
+  return {userId:auth.userId, page:{...composition, nextCursor:auth.rentals.nextCursor}};
 }
 function signature(payload: string, domain: string) {
   const key = process.env.TELEMETRY_TICKET_KEY;

--- a/services/console/lib/types.ts
+++ b/services/console/lib/types.ts
@@ -1,6 +1,17 @@
 export type Rental = { rentalId: string; userId: string; motorcycleId: string; motorcycleLicencePlate: string;
   startDate: string; predictedEndDate: string; actualEndDate: string | null; originalTotalCost: number };
 export type RentalPage = {items: Rental[]; nextCursor: string | null};
+// Os campos abaixo são os que contracts/reads.json declara, e nada além. Um
+// campo a mais aqui é um campo que a tela usa sem ter pedido.
+export type Motorcycle = {id: string; model: string | null; year: number; licensePlate: string};
+export type Invoice = {rentalId: string; currency: string; totalMinor: number;
+  adjustmentMinor: number; reason: string; daysUsed: number};
+export type RiderCard = {userId: string; name: string; cnhType: string; verified: boolean};
+// O aluguel com o que os outros serviços sabem sobre ele. Ausente quer dizer
+// "não chegou", e a tela mostra a linha assim mesmo -- ver ADR 0014.
+export type Composed = Rental & {motorcycle: Motorcycle | null; invoice: Invoice | null};
+export type ComposedPage = {items: Composed[]; nextCursor: string | null;
+  rider: RiderCard | null; missing: string[]};
 export type Position = {latitude: number; longitude: number; recorded_at: number};
 export type Span = {id: string; parentId: string; service: string; name: string; start: number; duration: number; error: boolean};
 export type Attempt = {index: number; plate: string; status: number; duration: number; traceId: string; grant: string; detail: string};

--- a/services/console/test/compose.test.ts
+++ b/services/console/test/compose.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+import {test} from 'node:test';
+import {COMPOSITION_CALLS, MAX_BATCH, PAGE_SIZE, compose, distinct} from '../lib/compose.ts';
+import type {Rental} from '../lib/types.ts';
+
+const declaration = JSON.parse(readFileSync(new URL('../../../contracts/reads.json', import.meta.url), 'utf8'));
+
+function rentals(count:number):Rental[] {
+  return Array.from({length:count},(_,index)=>({
+    rentalId:'r'+index, userId:'rider-1', motorcycleId:'m'+index,
+    motorcycleLicencePlate:'ABC'+String(index).padStart(4,'0'),
+    startDate:'2026-09-01T00:00:00Z', predictedEndDate:'2026-09-08T00:00:00Z',
+    actualEndDate:null, originalTotalCost:210,
+  }));
+}
+
+/** Um duplo que grava cada caminho pedido e responde o que a rota responderia. */
+function recorder(reply:(path:string)=>unknown = () => []) {
+  const paths:string[] = [];
+  const call = async (path:string) => {
+    paths.push(path);
+    return new Response(JSON.stringify(reply(path)),{headers:{'Content-Type':'application/json'}});
+  };
+  return {paths,call};
+}
+
+/**
+ * A medida que o #138 pede: "a bounded number of downstream calls, independent
+ * of how many rows are on it — measured, not assumed". Uma linha e uma página
+ * cheia custam o mesmo, e o teste é o que impede alguém de escrever um `await`
+ * dentro do `map` sem perceber.
+ */
+test('composing a page costs the same number of calls at one row and at a full page',async()=>{
+  const single = recorder();
+  await compose(rentals(1),'rider-1',single.call);
+  const full = recorder();
+  await compose(rentals(PAGE_SIZE),'rider-1',full.call);
+
+  assert.equal(single.paths.length,COMPOSITION_CALLS);
+  assert.equal(full.paths.length,COMPOSITION_CALLS);
+  // E são um lote por provedor, não um pedido por linha.
+  assert.equal(full.paths.filter(path=>path.startsWith('/api/motorcycles/batch')).length,1);
+  assert.equal(full.paths.filter(path=>path.startsWith('/api/invoices')).length,1);
+  assert.equal(full.paths.filter(path=>path.startsWith('/api/riders/')).length,1);
+});
+
+/**
+ * O tamanho de página e o teto do lote são o mesmo número por acordo entre o
+ * console e os provedores. Subir um sem o outro deixaria a última linha da
+ * página sem moto, em silêncio -- então fica vermelho aqui primeiro.
+ */
+test('the page size and every declared batch cap are the same number',()=>{
+  assert.equal(PAGE_SIZE,MAX_BATCH);
+  assert.equal(declaration.pageSize,PAGE_SIZE);
+  for (const read of declaration.reads.filter((read:{batched:boolean})=>read.batched)) {
+    assert.equal(read.maxBatch,MAX_BATCH,read.name+' declares a different cap');
+  }
+});
+
+/** O que a tela pede é o que a declaração diz, e nada além. */
+test('the composed screen only calls what contracts/reads.json declares',async()=>{
+  const recorded = recorder();
+  await compose(rentals(3),'rider-1',recorded.call);
+
+  const declared = declaration.reads.map((read:{path:string})=>read.path);
+  for (const path of recorded.paths) {
+    const matched = declared.some((template:string)=>
+      path.startsWith(template.replace('/{id}','/')) || path.startsWith(template+'?'));
+    assert.ok(matched,path+' is not declared in contracts/reads.json');
+  }
+  assert.equal(recorded.paths.length,declaration.reads.length);
+});
+
+/**
+ * A postura de falha do ADR 0014: a agregação falha SUAVE. Uma nota que não
+ * chegou deixa a linha sem valor final e a tela diz o que faltou -- ela não
+ * apaga a página, que é o que o portão faria com a requisição inteira.
+ */
+test('a provider that is down leaves the row without that field, not without the page',async()=>{
+  const call = async (path:string) => path.startsWith('/api/invoices')
+    ? new Response('upstream unavailable',{status:503})
+    : new Response(JSON.stringify(path.startsWith('/api/riders/')?{userId:'rider-1',name:'Ada'}:[]),
+      {headers:{'Content-Type':'application/json'}});
+
+  const composed = await compose(rentals(2),'rider-1',call);
+
+  assert.equal(composed.items.length,2);
+  assert.equal(composed.items[0].invoice,null);
+  assert.deepEqual(composed.missing,['invoices']);
+  assert.equal(composed.rider?.name,'Ada');
+});
+
+test('a provider that throws is the same as one that refuses',async()=>{
+  const composed = await compose(rentals(1),'rider-1',async()=>{throw new Error('connect ECONNREFUSED')});
+  assert.equal(composed.items.length,1);
+  assert.deepEqual(composed.missing.sort(),['invoices','motorcycles','rider']);
+});
+
+/**
+ * 404 é resposta, não falha. Um administrador não tem registro de piloto, e a
+ * tela dizer "sem piloto" está certo -- dizer "o identity caiu" seria mentira,
+ * e mentira que aparece toda vez que um administrador entra.
+ *
+ * O fixture de carga achou isto: o sujeito do token dele não é um piloto
+ * cadastrado, e a tela anunciava degradação a cada requisição.
+ */
+test('a record that does not exist is an answer, not a degradation',async()=>{
+  const call = async (path:string) => path.startsWith('/api/riders/')
+    ? new Response('{"detail":"piloto nao encontrado"}',{status:404})
+    : new Response('[]',{headers:{'Content-Type':'application/json'}});
+
+  const composed = await compose(rentals(1),'an-admin',call);
+
+  assert.equal(composed.rider,null);
+  assert.deepEqual(composed.missing,[]);
+});
+
+/** Uma página vazia não gasta lote nenhum: um lote sem ids é 400 do outro lado. */
+test('an empty page asks for no batches',async()=>{
+  const recorded = recorder();
+  await compose([],'rider-1',recorded.call);
+  assert.deepEqual(recorded.paths,['/api/riders/rider-1']);
+});
+
+test('repeated ids are asked for once',async()=>{
+  assert.deepEqual(distinct(['a','a','b',null,undefined,'']),['a','b']);
+  const shared = rentals(3).map(rental=>({...rental,motorcycleId:'same-bike'}));
+  const recorded = recorder();
+  await compose(shared,'rider-1',recorded.call);
+  const batch = recorded.paths.find(path=>path.startsWith('/api/motorcycles/batch'))!;
+  assert.equal(batch,'/api/motorcycles/batch?ids=same-bike');
+});

--- a/services/console/test/hop-cost.mjs
+++ b/services/console/test/hop-cost.mjs
@@ -1,0 +1,117 @@
+// O preço do salto extra, medido.
+//
+// O ADR 0014 aceita uma consequência explícita: o console chama os serviços
+// ATRAVÉS do portão em vez de ao lado deles, porque a fronteira de confiança do
+// ADR 0008 é uma só. E diz o que fazer com essa consequência -- "it is
+// measurable: it belongs in the latency budget, not in a footnote".
+//
+// Este script é o número. Ele pede a MESMA leitura das duas formas, do mesmo
+// lugar, na rede do fixture `projecty-load`:
+//
+//   console -> api-gateway -> rental-core     como a tela faz
+//   console -> rental-core                    o que o salto custa a menos
+//
+// O caminho direto assina o envelope do ADR 0008 à mão, porque é o que o portão
+// faria. Sem isso a comparação mediria "com autenticação" contra "sem", que é
+// outra pergunta.
+import {createHmac} from 'node:crypto';
+import {writeFileSync} from 'node:fs';
+
+const gateway = process.env.GATEWAY_URL ?? 'http://api-gateway:8090';
+const direct = process.env.RENTAL_CORE_URL ?? 'http://rental-core:8200';
+const audience = process.env.RENTAL_CORE_AUDIENCE ?? 'projecty.rental-core';
+const keyId = process.env.GATEWAY_IDENTITY_SIGNING_KEY_ID ?? 'local-v1';
+const key = process.env.GATEWAY_IDENTITY_SIGNING_KEY;
+const token = process.env.ACCESS_TOKEN;
+const subject = process.env.SUBJECT ?? 'rider-1';
+const rounds = Number(process.env.ROUNDS ?? 40);
+// O portão limita a 120 requisições por minuto por chamador. Uma rajada mais
+// rápida que isso mediria a fila do limitador, não o salto -- e o 429 que ela
+// produz nem chega ao upstream.
+const pace = Number(process.env.PACE_MS ?? 700);
+if (!key || !token) throw new Error('GATEWAY_IDENTITY_SIGNING_KEY and ACCESS_TOKEN are required');
+
+// Uma leitura barata e real: o lote que a tela usa para resolver as motos. Um
+// id que não existe responde `[]` -- o assunto aqui é o caminho, não a linha.
+const path = '/api/motorcycles/batch?ids=00000000-0000-0000-0000-000000000000';
+
+function envelope(method, pathAndQuery, roles = 'Rider') {
+  const issuedAt = String(Math.floor(Date.now() / 1000));
+  const canonical = ['v1', keyId, subject, roles, issuedAt, method, pathAndQuery, audience].join('\n');
+  const signature = createHmac('sha256', key).update(canonical).digest('base64url');
+  return {
+    'x-identity-key-id': keyId,
+    'x-identity-subject': subject,
+    'x-identity-roles': roles,
+    'x-identity-issued-at': issuedAt,
+    'x-identity-signature': 'v1=' + signature,
+  };
+}
+
+async function timed(url, headers) {
+  const started = performance.now();
+  const response = await fetch(url, {headers});
+  await response.arrayBuffer();
+  const elapsed = performance.now() - started;
+  if (response.status === 429) {
+    throw new Error(url + ' answered 429: slow the probe down (PACE_MS), it is measuring the rate limiter');
+  }
+  if (!response.ok) throw new Error(url + ' answered ' + response.status);
+  return elapsed;
+}
+
+const throughGateway = () => timed(gateway + path, {Authorization: 'Bearer ' + token});
+const straightThere = () => timed(direct + path, envelope('GET', path));
+
+// Aquecimento: a primeira requisição paga conexão, JIT e o JWKS que o portão
+// ainda não cacheou. Medir isso mediria a subida, não o salto.
+for (let round = 0; round < 5; round++) {
+  await throughGateway();
+  await straightThere();
+}
+
+const viaGateway = [];
+const viaService = [];
+// Alternado, e não em blocos: uma máquina que fica lenta no meio da medição
+// atinge os dois lados igualmente em vez de só o segundo.
+for (let round = 0; round < rounds; round++) {
+  viaGateway.push(await throughGateway());
+  viaService.push(await straightThere());
+  await new Promise(resolve => setTimeout(resolve, pace));
+}
+
+const percentile = (values, fraction) => {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * fraction))];
+};
+const round2 = value => Math.round(value * 100) / 100;
+const summary = values => ({
+  p50: round2(percentile(values, 0.5)),
+  p95: round2(percentile(values, 0.95)),
+  p99: round2(percentile(values, 0.99)),
+});
+
+const report = {
+  measuredAt: new Date().toISOString(),
+  fixture: process.env.FIXTURE ?? 'projecty-load',
+  rounds,
+  pace,
+  path,
+  viaGateway: summary(viaGateway),
+  viaService: summary(viaService),
+  hopCostMs: {
+    p50: round2(percentile(viaGateway, 0.5) - percentile(viaService, 0.5)),
+    p95: round2(percentile(viaGateway, 0.95) - percentile(viaService, 0.95)),
+  },
+  // Três chamadas por tela, e o salto é pago em cada uma -- mas em paralelo,
+  // então a tela paga o mais lento dos três e não a soma.
+  compositionCalls: 3,
+  includes: [
+    'verificação EdDSA contra o JWKS que o portão cacheia',
+    'limitação de taxa: uma ida ao Redis por requisição',
+    'assinatura do envelope do ADR 0008',
+    'um salto de rede a mais',
+  ],
+};
+console.log(JSON.stringify(report, null, 2));
+if (process.env.REPORT_PATH) writeFileSync(process.env.REPORT_PATH, JSON.stringify(report, null, 2) + '\n');

--- a/services/identity/internal/api/reads_test.go
+++ b/services/identity/internal/api/reads_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A declaração do consumidor, lida do arquivo em vez de repetida aqui.
+//
+// O #138 pede que remover um endpoint de leitura deixe um teste vermelho antes
+// de deixar uma tela em branco. Isso só vale se o teste souber o que a tela
+// pede, e a única forma de saber é ler a mesma declaração que o console lê.
+// Repetir os nomes de campo aqui provaria que este arquivo concorda consigo
+// mesmo.
+type declaredRead struct {
+	Name         string   `json:"name"`
+	Provider     string   `json:"provider"`
+	Method       string   `json:"method"`
+	Path         string   `json:"path"`
+	IDsParameter string   `json:"idsParameter"`
+	Batched      bool     `json:"batched"`
+	MaxBatch     int      `json:"maxBatch"`
+	Fields       []string `json:"fields"`
+}
+
+func readContract(t *testing.T, provider, path string) declaredRead {
+	t.Helper()
+	raw, err := os.ReadFile(locateContract(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Reads []declaredRead `json:"reads"`
+	}
+	if err := json.Unmarshal(raw, &document); err != nil {
+		t.Fatal(err)
+	}
+	for _, read := range document.Reads {
+		if read.Provider == provider && read.Path == path {
+			return read
+		}
+	}
+	t.Fatalf("contracts/reads.json não declara leitura de %s em %s. "+
+		"Se o console deixou de pedir, apague a rota; se ainda pede, restaure a declaração.",
+		provider, path)
+	return declaredRead{}
+}
+
+// Sobe até achar o arquivo. O diretório de trabalho de um teste Go é o do
+// pacote, e um caminho relativo fixo quebra ao mover o pacote.
+func locateContract(t *testing.T) string {
+	t.Helper()
+	directory, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		candidate := filepath.Join(directory, "contracts", "reads.json")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(directory)
+		if parent == directory {
+			t.Fatal("contracts/reads.json não foi encontrado acima do pacote")
+		}
+		directory = parent
+	}
+}
+
+// TestTheRiderReadAnswersWhatTheConsoleDeclared: a tela de aluguéis mostra o
+// nome de quem está logado, e é esta rota que o diz.
+func TestTheRiderReadAnswersWhatTheConsoleDeclared(t *testing.T) {
+	declared := readContract(t, "identity", "/api/riders/{id}")
+	if declared.Method != http.MethodGet {
+		t.Fatalf("a declaração pede %s", declared.Method)
+	}
+
+	fixture := start(t)
+	fixture.register(t, http.StatusCreated)
+	id := fixture.lastID
+
+	response := fixture.send(fixture.envelope(t, http.MethodGet, "/api/riders/"+id, id, "Rider"))
+	if response.Code != http.StatusOK {
+		t.Fatalf("leitura recusada: %d %s", response.Code, response.Body)
+	}
+
+	var found map[string]any
+	decodeInto(t, response.Body.Bytes(), &found)
+	for _, field := range declared.Fields {
+		if _, present := found[field]; !present {
+			t.Fatalf("contracts/reads.json declara %q, e a resposta não trouxe: %v", field, found)
+		}
+	}
+}

--- a/services/rental-core/RentalCore/Motorcycles/Controllers/MotorcycleController.cs
+++ b/services/rental-core/RentalCore/Motorcycles/Controllers/MotorcycleController.cs
@@ -47,6 +47,53 @@ namespace MotoHub.Controllers
         /// A restrição :guid é o que separa esta rota da de placa. Nenhuma placa
         /// brasileira se parece com um UUID, então não há ambiguidade a resolver.
         /// </summary>
+        /// <summary>
+        /// As motos de uma tela, numa chamada.
+        ///
+        /// Existe por contrato, e não por desempenho. O aluguel passou a
+        /// referenciar a moto pelo id em #134 e carrega apenas a placa; modelo e
+        /// ano moram aqui. Sem o lote, compor uma página de aluguéis custa uma
+        /// requisição por linha -- o N+1 não desaparece, apenas se muda do
+        /// navegador para o BFF, que é exatamente o que o ADR 0014 recusa.
+        ///
+        /// Não é rota de administrador. Ela é N vezes "esta moto", e ler uma moto
+        /// já é do piloto que vai alugá-la; o catálogo inteiro é que continua
+        /// sendo inventário da frota.
+        ///
+        /// O segmento literal `batch` ganha da rota de placa na precedência do
+        /// roteamento, e nenhuma placa brasileira se parece com a palavra.
+        /// </summary>
+        [HttpGet("batch")]
+        public async Task<IActionResult> GetByIdsAsync([FromQuery] string? ids)
+        {
+            var requested = (ids ?? string.Empty)
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (requested.Length == 0)
+            {
+                return BadRequest("At least one motorcycle id is required.");
+            }
+            if (requested.Length > MotorcycleService.MaxBatchSize)
+            {
+                return BadRequest(
+                    $"A batch may request at most {MotorcycleService.MaxBatchSize} motorcycle ids.");
+            }
+
+            var parsed = new List<Guid>(requested.Length);
+            foreach (var candidate in requested)
+            {
+                if (!Guid.TryParse(candidate, out var id))
+                {
+                    return BadRequest($"'{candidate}' is not a motorcycle id.");
+                }
+                parsed.Add(id);
+            }
+
+            // Um id ausente vira ausência na lista, e não 404: uma tela compõe o
+            // que chegou, e uma moto que saiu do catálogo não pode apagar as
+            // outras linhas da página.
+            return Ok(await _motorcycleService.GetMotorcyclesByIdsAsync(parsed));
+        }
+
         [HttpGet("{id:guid}")]
         public async Task<IActionResult> GetByIdAsync(Guid id)
         {

--- a/services/rental-core/RentalCore/Motorcycles/Repositories/IMotorcycleRepository.cs
+++ b/services/rental-core/RentalCore/Motorcycles/Repositories/IMotorcycleRepository.cs
@@ -9,6 +9,7 @@ namespace MotoHub.Repositories
         Task<CursorPage<Motorcycle>> GetPageAsync(string? cursor, int? pageSize);
         Motorcycle? GetById(Guid id);
         Task<Motorcycle?> GetByIdAsync(Guid id);
+        Task<IReadOnlyList<Motorcycle>> GetByIdsAsync(IReadOnlyCollection<Guid> ids);
         void Add(Motorcycle motorcycle);
         void Update(Motorcycle motorcycle);
         bool LicensePlateExists(string licensePlate);

--- a/services/rental-core/RentalCore/Motorcycles/Repositories/MotorcycleRepository.cs
+++ b/services/rental-core/RentalCore/Motorcycles/Repositories/MotorcycleRepository.cs
@@ -50,6 +50,26 @@ namespace MotoHub.Repositories
             return await _context.Motorcycles.FindAsync(id);
         }
 
+        /// <summary>
+        /// As motos pedidas, numa consulta.
+        ///
+        /// Aposentada continua respondendo, ao contrário da paginação: um
+        /// aluguel antigo aponta para uma moto que saiu da frota, e omiti-la
+        /// deixaria a linha do histórico sem modelo nem placa. Listar a frota e
+        /// resolver uma referência são perguntas diferentes.
+        /// </summary>
+        public async Task<IReadOnlyList<Motorcycle>> GetByIdsAsync(IReadOnlyCollection<Guid> ids)
+        {
+            if (ids.Count == 0)
+            {
+                return [];
+            }
+            return await _context.Motorcycles
+                .AsNoTracking()
+                .Where(motorcycle => ids.Contains(motorcycle.Id))
+                .ToListAsync();
+        }
+
         public void Add(Motorcycle motorcycle)
         {
             _context.Motorcycles.Add(motorcycle);

--- a/services/rental-core/RentalCore/Motorcycles/Services/IMotorcycleService.cs
+++ b/services/rental-core/RentalCore/Motorcycles/Services/IMotorcycleService.cs
@@ -10,6 +10,7 @@ namespace MotoHub.Services
         Task<CursorPage<MotorcycleDTO>> GetMotorcyclesAsync(string? cursor, int? pageSize);
         Task<MotorcycleDTO?> GetMotorcycleByLicensePlateAsync(string licensePlate);
         Task<MotorcycleDTO?> GetMotorcycleByIdAsync(Guid id);
+        Task<IReadOnlyList<MotorcycleDTO>> GetMotorcyclesByIdsAsync(IReadOnlyCollection<Guid> ids);
         void CreateMotorcycle(MotorcycleDTO motorcycleDto);
         Task UpdateMotorcycleAsync(string licensePlate, string newLicencePlate);
         Task<OperationResult> DeleteMotorcycle(string licensePlate);

--- a/services/rental-core/RentalCore/Motorcycles/Services/MotorcycleService.cs
+++ b/services/rental-core/RentalCore/Motorcycles/Services/MotorcycleService.cs
@@ -49,6 +49,21 @@ namespace MotoHub.Services
             return _mapper.Map<MotorcycleDTO>(motorcycle);
         }
 
+        /// <summary>
+        /// Quantas motos um lote pode pedir de uma vez.
+        ///
+        /// O mesmo teto do lote de aluguéis, e o mesmo motivo: um lote sem teto
+        /// é uma consulta arbitrária escrita pelo cliente. O número acompanha o
+        /// tamanho de página do console de propósito -- uma tela cabe numa
+        /// chamada, e o #138 mede a tela por número de chamadas.
+        /// </summary>
+        public const int MaxBatchSize = 100;
+
+        public async Task<IReadOnlyList<MotorcycleDTO>> GetMotorcyclesByIdsAsync(IReadOnlyCollection<Guid> ids)
+        {
+            return _mapper.Map<IReadOnlyList<MotorcycleDTO>>(await _repository.GetByIdsAsync(ids));
+        }
+
         public void CreateMotorcycle(MotorcycleDTO motorcycleDto)
         {
             var motorcycle = _mapper.Map<Motorcycle>(motorcycleDto);

--- a/services/rental-core/RentalCoreTests/Motorcycles/Integration/CustomWebApplicationFactory.cs
+++ b/services/rental-core/RentalCoreTests/Motorcycles/Integration/CustomWebApplicationFactory.cs
@@ -109,12 +109,22 @@ namespace MotoHubTests.Integration
                 HttpRequestMessage request,
                 CancellationToken cancellationToken)
             {
-                if (request.Headers.Authorization is { Scheme: "Bearer", Parameter: "valid-admin" })
+                // Dois marcadores, e nao um: o lote de motos do #138 nao e rota
+                // de administrador, e provar isso exige um chamador que nao seja
+                // um. Assinar tudo como Admin faria o teste passar sem dizer
+                // nada sobre quem a rota deixa entrar.
+                var role = request.Headers.Authorization switch
+                {
+                    { Scheme: "Bearer", Parameter: "valid-admin" } => "Admin",
+                    { Scheme: "Bearer", Parameter: "valid-rider" } => "Rider",
+                    _ => null
+                };
+                if (role is not null)
                 {
                     var principal = new ClaimsPrincipal(new ClaimsIdentity(
                     [
                         new Claim(ClaimTypes.NameIdentifier, "test-user"),
-                        new Claim(ClaimTypes.Role, "Admin")
+                        new Claim(ClaimTypes.Role, role)
                     ], "TestGatewayIdentity"));
                     new GatewayIdentitySigner(GatewayIdentityKey, "test-v1")
                         .Sign(request, principal, GatewayIdentityAudience);

--- a/services/rental-core/RentalCoreTests/Motorcycles/Integration/MotorcycleBatchReadContractTests.cs
+++ b/services/rental-core/RentalCoreTests/Motorcycles/Integration/MotorcycleBatchReadContractTests.cs
@@ -1,0 +1,170 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using MotoHub.Data;
+using MotoHub.Models;
+using MotoHub.Services;
+using RentalCoreTests;
+
+namespace MotoHubTests.Integration;
+
+/// <summary>
+/// O lote de motos, contra a declaração do console.
+///
+/// O aluguel referencia a moto pelo id desde o #134 e carrega apenas a placa;
+/// modelo e ano moram aqui. Compor uma página de aluguéis sem este lote custa
+/// uma requisição por linha -- o N+1 sai do navegador e entra no BFF, que é o
+/// que o ADR 0014 recusa.
+///
+/// Os nomes dos campos vêm de <c>contracts/reads.json</c>, e não desta classe.
+/// Renomear um campo aqui deixa este teste vermelho sem que ninguém precise
+/// lembrar de atualizá-lo.
+/// </summary>
+public class MotorcycleBatchReadContractTests : IClassFixture<CustomWebApplicationFactory<Program>>
+{
+    private readonly CustomWebApplicationFactory<Program> _factory;
+    private static readonly ReadContract.Read Declared =
+        ReadContract.For("rental-core", "/api/motorcycles/batch");
+
+    public MotorcycleBatchReadContractTests(CustomWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Batch_AnswersWithEveryFieldTheConsoleDeclared()
+    {
+        var first = Seed("Honda CG 160", 2024);
+        var second = Seed("Yamaha Factor", 2023);
+        using var client = Rider();
+
+        var response = await client.GetAsync(Batch(first, second));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var motorcycles = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        Assert.Equal(2, motorcycles.GetArrayLength());
+        foreach (var motorcycle in motorcycles.EnumerateArray())
+        {
+            foreach (var field in Declared.Fields)
+            {
+                Assert.True(
+                    motorcycle.TryGetProperty(field, out _),
+                    $"contracts/reads.json declares '{field}', and the batch did not answer with it.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Ler UMA moto já é do piloto que vai alugá-la, e um lote de ids é N vezes
+    /// essa mesma leitura. O catálogo inteiro é que continua sendo inventário
+    /// da frota -- essa fronteira tem teste próprio.
+    /// </summary>
+    [Fact]
+    public async Task Batch_IsNotAnAdministratorRoute()
+    {
+        var motorcycle = Seed("Honda Biz", 2022);
+        using var rider = Rider();
+
+        var response = await rider.GetAsync(Batch(motorcycle));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Uma moto aposentada some da paginação e continua respondendo aqui: um
+    /// aluguel antigo aponta para ela, e omiti-la deixaria a linha do histórico
+    /// sem modelo nem placa.
+    /// </summary>
+    [Fact]
+    public async Task Batch_StillResolvesARetiredMotorcycle()
+    {
+        var retired = Seed("Honda Pop", 2015, retired: true);
+        using var client = Rider();
+
+        var response = await client.GetAsync(Batch(retired));
+
+        var motorcycles = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        Assert.Equal(1, motorcycles.GetArrayLength());
+    }
+
+    /// <summary>
+    /// Um id ausente vira ausência na lista, e não 404: uma tela compõe o que
+    /// chegou, e uma moto que não existe mais não pode apagar as outras linhas.
+    /// </summary>
+    [Fact]
+    public async Task Batch_OmitsWhatItCannotFindInsteadOfFailing()
+    {
+        var known = Seed("Honda Titan", 2021);
+        using var client = Rider();
+
+        var response = await client.GetAsync(Batch(known, Guid.NewGuid()));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var motorcycles = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        Assert.Equal(1, motorcycles.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task Batch_AboveTheDeclaredCap_IsRefusedRatherThanServed()
+    {
+        using var client = Rider();
+        var ids = Enumerable.Range(0, Declared.MaxBatch!.Value + 1).Select(_ => Guid.NewGuid());
+
+        var response = await client.GetAsync("/api/motorcycles/batch?ids=" + string.Join(',', ids));
+
+        // Um lote sem teto é uma consulta arbitrária escrita pelo cliente.
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(MotorcycleService.MaxBatchSize, Declared.MaxBatch!.Value);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-guid")]
+    public async Task Batch_WithoutUsableIds_IsRefused(string ids)
+    {
+        using var client = Rider();
+
+        var response = await client.GetAsync("/api/motorcycles/batch?ids=" + ids);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Batch_WithoutGatewayIdentity_IsUnauthorized()
+    {
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/motorcycles/batch?ids=" + Guid.NewGuid());
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private HttpClient Rider()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "valid-rider");
+        return client;
+    }
+
+    private static string Batch(params Guid[] ids) =>
+        "/api/motorcycles/batch?" + Declared.IdsParameter + "=" + string.Join(',', ids);
+
+    private Guid Seed(string model, int year, bool retired = false)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var motorcycle = new Motorcycle
+        {
+            LicensePlate = $"B{Random.Shared.Next(100000, 999999)}",
+            Model = model,
+            Year = year,
+            RegistrationDate = DateTime.UtcNow,
+            RetiredAtUtc = retired ? DateTime.UtcNow : null,
+            RetirementReason = retired ? "sold" : null
+        };
+        context.Motorcycles.Add(motorcycle);
+        context.SaveChanges();
+        return motorcycle.Id;
+    }
+}

--- a/services/rental-core/RentalCoreTests/ReadContract.cs
+++ b/services/rental-core/RentalCoreTests/ReadContract.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+
+namespace RentalCoreTests;
+
+/// <summary>
+/// A declaração do consumidor, lida do arquivo em vez de repetida aqui.
+///
+/// O #138 pede que remover um endpoint de lote deixe um teste vermelho antes de
+/// deixar uma tela em branco. Isso só é verdade se o teste souber o que a tela
+/// pede, e a única forma de ele saber é ler a mesma declaração que o console lê
+/// -- <c>contracts/reads.json</c>. Uma cópia dos nomes de campo aqui provaria
+/// que este arquivo concorda consigo mesmo.
+/// </summary>
+public static class ReadContract
+{
+    public static Read For(string provider, string path)
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(Locate()));
+        foreach (var read in document.RootElement.GetProperty("reads").EnumerateArray())
+        {
+            if (read.GetProperty("provider").GetString() == provider
+                && read.GetProperty("path").GetString() == path)
+            {
+                return new Read(
+                    read.GetProperty("method").GetString()!,
+                    read.GetProperty("path").GetString()!,
+                    read.TryGetProperty("idsParameter", out var parameter) ? parameter.GetString() : null,
+                    read.TryGetProperty("maxBatch", out var cap) ? cap.GetInt32() : null,
+                    [.. read.GetProperty("fields").EnumerateArray().Select(field => field.GetString()!)]);
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"contracts/reads.json declares no {provider} read at {path}. "
+            + "If the console stopped asking for it, delete the endpoint; if it still asks, restore the declaration.");
+    }
+
+    /// <summary>
+    /// Sobe do binário até achar o arquivo. O diretório de saída do teste muda
+    /// com o framework e a configuração, e um caminho relativo fixo quebra
+    /// sozinho no dia em que um deles muda.
+    /// </summary>
+    private static string Locate()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, "contracts", "reads.json");
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+            directory = directory.Parent;
+        }
+        throw new FileNotFoundException("contracts/reads.json was not found above " + AppContext.BaseDirectory);
+    }
+
+    public sealed record Read(
+        string Method,
+        string Path,
+        string? IdsParameter,
+        int? MaxBatch,
+        IReadOnlyList<string> Fields);
+}


### PR DESCRIPTION
Fecha o #138, e com ele o épico 9.

Uma tela montada a partir de quatro serviços, com um número de chamadas que **não muda com o número de linhas**.

## O que a tela ganhou

| | antes | agora |
|---|---|---|
| a moto | só a placa | modelo e ano |
| o custo | o **combinado** | o combinado **e o que de fato custou** |
| quem está logado | o `sub` do token | o nome do piloto |

O segundo é uma dívida do [#137](https://github.com/iVega123/ProjectY/issues/137). Quando o rental-core deixou de calcular dinheiro, o total final passou a viver no billing — e a tela seguia mostrando o preço combinado do plano como se fosse a conta. Um aluguel devolvido cedo aparecia pelo valor cheio.

## Quatro chamadas, e o teste que não deixa virarem N

```
GET /api/Rental/user                 a página
GET /api/motorcycles/batch?ids=      ┐
GET /api/invoices?rentalIds=         ├ em paralelo
GET /api/riders/{id}                 ┘
```

O padrão DataLoader sobreviveu; a tecnologia não. O que ele faz de fato é juntar as chaves de uma requisição numa **chamada só** — e isso exige um lote do outro lado. Por isso o #138 trata os lotes como contrato: **sem eles o N+1 não desaparece, só se muda do navegador para o BFF.**

E "bounded, independent of how many rows" não é afirmação:

> `composing a page costs the same number of calls at one row and at a full page`

Uma linha e cem linhas, mesma contagem. É o que impede um `await` dentro de um `map` de voltar sem ninguém perceber.

O tamanho de página do console e o teto dos lotes são o **mesmo número**, com teste fixando a igualdade — subir um sem o outro deixaria a última linha da página sem moto, em silêncio.

## O contrato, lido e não copiado

`contracts/reads.json` é a declaração do consumidor. Cada provedor tem um teste que lê **esse arquivo** e verifica o próprio handler contra ele:

| Provedor | |
|---|---|
| rental-core | `MotorcycleBatchReadContractTests.cs` |
| identity | `internal/api/reads_test.go` |
| billing | `o lote responde o que o console declarou` |
| console | `the composed screen only calls what contracts/reads.json declares` |

Repetir os nomes de campo dentro de cada teste provaria só que o teste concorda consigo mesmo. Lendo o mesmo arquivo, renomear `totalMinor` no billing deixa o teste do billing vermelho — sem que ninguém precise lembrar.

## O lote de motos

Novo no rental-core; os outros dois já existiam. Duas decisões:

- **Não é rota de administrador.** É N vezes "esta moto", e ler uma moto já é do piloto que vai alugá-la. O catálogo inteiro é que continua sendo inventário da frota. O portão precisou aprender o mesmo — era o segundo lugar onde as duas camadas podiam discordar em silêncio.
- **Uma moto aposentada continua respondendo.** Ela some da paginação, mas um aluguel antigo aponta para ela: omiti-la deixaria a linha do histórico sem modelo nem placa.

## O salto extra, medido

O ADR 0014 aceita a consequência de passar pelo portão e manda medi-la. **5,2 ms em p50, 6,6 ms em p95**, em `docs/measurements/bff-hop.json` — a mesma leitura pedida das duas formas, do mesmo lugar, assinando o envelope do ADR 0008 à mão no caminho direto para não comparar "com autenticação" contra "sem".

A primeira medição deu **46 ms**, e estava errada: a sonda passava das 120 requisições por minuto e media o limitador de taxa, não o salto. A sonda agora se ritma e recusa o 429 em vez de contá-lo como latência.

## O que subir a pilha revelou

**404 não é degradação — é resposta.** Um administrador não tem registro de piloto, e a tela anunciava "sem piloto" a cada requisição, como se o identity estivesse fora do ar. O fixture de carga achou isso porque o sujeito do token dele não é um piloto cadastrado. Agora as duas coisas são distinguidas, com teste.

E a falha suave do ADR 0014 foi observada de verdade, não só testada: sem o billing no fixture, a página renderizou com as linhas e disse `without invoices`. O portão recusaria a requisição inteira; a agregação mostra o que chegou.

## Dois consertos no caminho

**`Run-LoadTest.ps1` não rodava no Windows.** O PowerShell 5.1 escreve um BOM ao canalizar texto para um processo nativo, e o cockroach recusava o fixture inteiro com erro de sintaxe *no primeiro caractere* — um caractere que não está no arquivo. Passou a copiar o arquivo para dentro do container.

**A evidência do smoke poliglota estava mentindo.** A versionada ainda nomeava `moto-hub`, `rider-manager` e `rental-operations` — três serviços que não existem mais. Regravada com a captura desta execução.

## Duas coisas que eu não fingi

`GET /api/riders?ids=` e `GET /api/Rental/batch` **não têm consumidor**. A tela mostra os aluguéis de quem pediu, então o conjunto de pilotos de uma página tem sempre tamanho um — e os aluguéis já vêm da própria página. Um lote de pilotos precisaria de uma leitura de aluguéis **entre** pilotos, que não existe em lugar nenhum da API.

Preferi declarar só o que a tela chama a inventar um consumidor para justificar um endpoint. Está no #138 como observação, não escondido aqui.

## Verificação

| | |
|---|---|
| console | **10** testes, `tsc` limpo, build ok |
| rental-core | **145** testes (eram 137) |
| identity | todos os pacotes, contra um CockroachDB de verdade |
| billing | **35** testes, `ktlint` limpo |
| api-gateway | **54** testes, `fmt` e `clippy` limpos |
| Compose | os quatro modelos validam |
| scripts | `Test-PlatformModel` e `Test-CommandQueueNames` passam |
| pilha real | `stack-smoke.mjs` passou contra o fixture poliglota, com a tela composta |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
