### PR TITLE
feat(k8s): local Kubernetes and signed admission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,7 +697,8 @@ jobs:
           $tools = ./scripts/kind/Install-ProjectYKubernetesTools.ps1
           $policy = (& $tools.Kubectl kustomize deploy/platform/kyverno) -join "`n"
           if ($LASTEXITCODE -ne 0 -or
-              $policy -notmatch 'failureAction: Enforce' -or
+              $policy -notmatch '(?m)^  validationActions:\s*$' -or
+              $policy -notmatch '(?m)^  - Deny\s*$' -or
               $policy -notmatch 'mutateDigest: true' -or
               $policy -notmatch 'url: https://rekor.sigstore.dev') {
             throw 'The signed-image admission policy is not enforced.'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       has_rust_changes: ${{ steps.filter.outputs.api_gateway }}
       has_polyglot_changes: ${{ steps.filter.outputs.polyglot }}
       has_observability_changes: ${{ steps.filter.outputs.observability }}
+      has_kubernetes_changes: ${{ steps.filter.outputs.kubernetes }}
       image_matrix: ${{ steps.matrix.outputs.image_matrix }}
       has_image_changes: ${{ steps.matrix.outputs.has_image_changes }}
     steps:
@@ -186,6 +187,17 @@ jobs:
               - 'docker-compose.yml'
               - 'Tiltfile'
               - 'logstash/**'
+              - '.github/workflows/ci.yml'
+            kubernetes:
+              - 'deploy/base/**'
+              - 'deploy/kind/**'
+              - 'deploy/overlays/aws/**'
+              - 'deploy/overlays/selfhost/**'
+              - 'deploy/platform/kyverno/**'
+              - 'scripts/kind/**'
+              - 'scripts/Test-Kubernetes*.ps1'
+              - 'scripts/Test-ExternalSecrets.ps1'
+              - 'Tiltfile'
               - '.github/workflows/ci.yml'
             polyglot:
               - 'services/media-guard/**'
@@ -668,6 +680,82 @@ jobs:
           GITLEAKS_ENABLE_COMMENTS: "false"
           GITLEAKS_VERSION: 8.30.0
 
+  kubernetes-manifests:
+    name: Kubernetes manifests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Render and validate every deployment overlay
+        shell: pwsh
+        run: ./scripts/Test-KubernetesManifests.ps1
+
+      - name: Validate enforced signed-image policy
+        shell: pwsh
+        run: |
+          $tools = ./scripts/kind/Install-ProjectYKubernetesTools.ps1
+          $policy = (& $tools.Kubectl kustomize deploy/platform/kyverno) -join "`n"
+          if ($LASTEXITCODE -ne 0 -or $policy -notmatch 'validationFailureAction: Enforce') {
+            throw 'The signed-image admission policy is not enforced.'
+          }
+
+  kubernetes-security:
+    name: Kubernetes security acceptance
+    needs: changes
+    if: needs.changes.outputs.has_kubernetes_changes == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Generate ephemeral local credentials
+        shell: pwsh
+        run: ./scripts/New-LocalSecrets.ps1
+
+      - name: Provision kind, Calico and ingress
+        shell: pwsh
+        run: ./scripts/kind/Ensure-ProjectYCluster.ps1
+
+      - name: Install External Secrets and publish the local backend
+        shell: pwsh
+        run: |
+          ./scripts/kind/Install-ExternalSecrets.ps1
+          ./scripts/kind/Publish-LocalSecretBackend.ps1
+          $tools = ./scripts/kind/Install-ProjectYKubernetesTools.ps1
+          & $tools.Kubectl apply -f deploy/base/namespace.yaml
+          & $tools.Kubectl apply --namespace projecty -f deploy/base/serviceaccounts.yaml
+          & $tools.Kubectl apply -f deploy/overlays/selfhost/local-secret-store.yaml
+          & $tools.Kubectl apply --namespace projecty -f deploy/base/external-secrets.yaml
+          & $tools.Kubectl apply --namespace projecty -f deploy/base/network-policies.yaml
+
+      - name: Verify Pod Security, network ownership and secret synchronization
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path artifacts -Force | Out-Null
+          ./scripts/Test-KubernetesSecurity.ps1 | Tee-Object artifacts/kubernetes-isolation.json
+          ./scripts/Test-ExternalSecrets.ps1 | Tee-Object artifacts/external-secrets.json
+
+      - name: Verify signed-image admission
+        shell: pwsh
+        run: |
+          ./scripts/kind/Install-Kyverno.ps1
+          ./scripts/Test-SignedAdmission.ps1 | Tee-Object artifacts/signed-admission.json
+
+      - name: Upload reproducible acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kubernetes-security-${{ github.sha }}
+          path: artifacts
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Remove the ephemeral cluster
+        if: always()
+        shell: pwsh
+        run: ./scripts/kind/Remove-ProjectYCluster.ps1
+
   required:
     name: Required
     needs:
@@ -680,6 +768,8 @@ jobs:
       - images
       - publish
       - secrets
+      - kubernetes-manifests
+      - kubernetes-security
       - media-tests
       - telemetry-tests
       - risk-tests
@@ -699,6 +789,8 @@ jobs:
           IMAGES_RESULT: ${{ needs.images.result }}
           PUBLISH_RESULT: ${{ needs.publish.result }}
           SECRETS_RESULT: ${{ needs.secrets.result }}
+          KUBERNETES_RESULT: ${{ needs.kubernetes-manifests.result }}
+          KUBERNETES_SECURITY_RESULT: ${{ needs.kubernetes-security.result }}
           MEDIA_RESULT: ${{ needs.media-tests.result }}
           TELEMETRY_RESULT: ${{ needs.telemetry-tests.result }}
           RISK_RESULT: ${{ needs.risk-tests.result }}
@@ -716,6 +808,8 @@ jobs:
           [[ "$RUST_RESULT" == "success" || "$RUST_RESULT" == "skipped" ]]
           [[ "$IMAGES_RESULT" == "success" || "$IMAGES_RESULT" == "skipped" ]]
           [[ "$SECRETS_RESULT" == "success" ]]
+          [[ "$KUBERNETES_RESULT" == "success" ]]
+          [[ "$KUBERNETES_SECURITY_RESULT" == "success" || "$KUBERNETES_SECURITY_RESULT" == "skipped" ]]
           for result in "$MEDIA_RESULT" "$TELEMETRY_RESULT" "$RISK_RESULT" "$CONSOLE_RESULT" "$BILLING_RESULT"; do
             [[ "$result" == "success" || "$result" == "skipped" ]]
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -696,7 +696,7 @@ jobs:
         run: |
           $tools = ./scripts/kind/Install-ProjectYKubernetesTools.ps1
           $policy = (& $tools.Kubectl kustomize deploy/platform/kyverno) -join "`n"
-          if ($LASTEXITCODE -ne 0 -or $policy -notmatch 'validationFailureAction: Enforce') {
+          if ($LASTEXITCODE -ne 0 -or $policy -notmatch 'failureAction: Enforce') {
             throw 'The signed-image admission policy is not enforced.'
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -696,7 +696,10 @@ jobs:
         run: |
           $tools = ./scripts/kind/Install-ProjectYKubernetesTools.ps1
           $policy = (& $tools.Kubectl kustomize deploy/platform/kyverno) -join "`n"
-          if ($LASTEXITCODE -ne 0 -or $policy -notmatch 'failureAction: Enforce') {
+          if ($LASTEXITCODE -ne 0 -or
+              $policy -notmatch 'failureAction: Enforce' -or
+              $policy -notmatch 'mutateDigest: true' -or
+              $policy -notmatch 'url: https://rekor.sigstore.dev') {
             throw 'The signed-image admission policy is not enforced.'
           }
 

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ docs/images/console-test-failure.png
 # JVM build output (services/billing)
 **/.gradle/
 services/billing/build/
+
+# Pinned local Kubernetes tools downloaded by the Tilt bootstrap
+.tools/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,3 +7,11 @@ description = "ProjectY synthetic secret used to prove the CI gate"
 regex = '''PROJECTY_GITLEAKS_CANARY_[0-9A-F]{16}'''
 keywords = ["PROJECTY_GITLEAKS_CANARY_"]
 
+[[allowlists]]
+description = "kubectl availability condition is a CLI flag, not an API credential"
+targetRules = ["generic-api-key"]
+condition = "AND"
+regexTarget = "line"
+paths = ['''(^|/)scripts/kind/Install-ExternalSecrets\.ps1$''']
+regexes = ['''kubectl wait --namespace external-secrets --for=condition=Available deployment/external-secrets''']
+

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ source locations are in the
 | Data and messaging | CockroachDB for `rental-core`, PostgreSQL for the rest, RabbitMQ, and MinIO |
 | Active observability | Application OTLP exporters, OpenTelemetry Collector, Prometheus, Tempo, Loki, and Grafana |
 | Retired observability | The unauthenticated Elasticsearch, Logstash, and Kibana stack |
-| Platform integration | Root and `deploy/base` entrypoints share the real application topology; Tilt live updates all four .NET services |
+| Platform integration | Kustomize owns the shared Kubernetes topology with self-hosted and AWS overlays; Tilt provisions kind, Calico, ingress, External Secrets and signed-image admission |
 | Polyglot services | Rust media-guard, Elixir live telemetry, asynchronous Python risk/pricing and Next.js operations console |
 | Decision records | The design and implementation trail is indexed under [`docs/adr/`](docs/adr/README.md) |
 
@@ -106,13 +106,14 @@ Database-backed tests use the shared
 State-changing API retries follow the shared
 [`Idempotency-Key` contract](docs/api/idempotency.md).
 
-### Modernization development loop
+### Kubernetes development loop
 
-The root [`Tiltfile`](Tiltfile) organizes `docker-compose.yml` into
-infrastructure, observability, setup, and service groups. It requires Docker
-Compose 2.20 or newer, Tilt, and PowerShell (`powershell` on Windows or `pwsh`
-on macOS/Linux). Start the audited services behind the Rust gateway, with LGTM
-ready before application startup, using one command:
+The root [`Tiltfile`](Tiltfile) now uses Kubernetes by default. It bootstraps a
+pinned kind cluster, a local registry, Calico, ingress-nginx, External Secrets
+and Kyverno before deploying the shared `deploy/base` topology through the
+`selfhost` Kustomize overlay. See the
+[local Kubernetes runbook](docs/runbooks/local-kubernetes.md) for prerequisites,
+resource sizing, security proofs and troubleshooting. Start everything with:
 
 ```bash
 tilt up
@@ -129,15 +130,20 @@ To recover intentionally, stop the stack, remove volumes initialized with the
 old credentials, and run
 `powershell -ExecutionPolicy Bypass -File scripts/New-LocalSecrets.ps1 -Force`.
 
-The Tilt UI is at <http://localhost:10350> and the gateway listens at
-<http://localhost:8090>. Use `tilt down` to stop the stack. The one-shot EF Core
-migration containers appear as setup resources; infrastructure, the audited
-services and the temporary ELK stack are grouped separately.
+The Tilt UI is at <http://localhost:10350>; ingress serves the console and
+gateway at <http://localhost:8080>. `tilt down` removes the kind cluster and
+local registry, including their local data.
 
-Gateway source is synced into its Rust development image and rebuilt in place;
-the Compose container restarts after a successful incremental build. The
-release image built by CI uses the Dockerfile's final distroless, non-root stage
-instead of the toolchain-bearing development stage.
+Compose remains an explicit migration fallback:
+
+```bash
+tilt up -- --orchestrator=compose --full
+```
+
+The release images built by CI use the Dockerfiles' final non-root stages. CI
+also renders both Kubernetes overlays and runs an ephemeral-cluster acceptance
+that captures unsigned-image rejection, Pod Security enforcement, datastore
+isolation and External Secrets synchronization as downloadable evidence.
 
 There is not yet an honest cold-start time to publish. The first successful
 start must still be timed on a clean Docker cache with the hardware and network

--- a/Tiltfile
+++ b/Tiltfile
@@ -72,17 +72,24 @@ if orchestrator == 'kubernetes':
 
         k8s_yaml(kustomize('deploy/overlays/selfhost'))
 
+        local_resource(
+            'signed-admission',
+            cmd = script_prefix + ['-File', 'scripts/kind/Install-Kyverno.ps1'],
+            deps = ['deploy/platform/kyverno'],
+            labels = ['platform'],
+        )
+
         k8s_resource('cockroach-schema', resource_deps = ['cockroachdb'], labels = ['setup'])
         k8s_resource('kafka-topics', resource_deps = ['kafka'], labels = ['setup'])
         k8s_resource('cassandra-schema', resource_deps = ['cassandra'], labels = ['setup'])
         k8s_resource('schema-contracts', resource_deps = ['schema-registry', 'kafka-topics'], labels = ['setup'])
-        k8s_resource('identity', resource_deps = ['cockroach-schema', 'schema-contracts', 'media-guard'], labels = ['services'])
-        k8s_resource('rental-core', resource_deps = ['cockroach-schema', 'kafka-topics'], labels = ['services'])
-        k8s_resource('billing', resource_deps = ['cockroach-schema', 'schema-contracts'], labels = ['services'])
-        k8s_resource('risk-pricing', resource_deps = ['schema-contracts'], labels = ['services'])
-        k8s_resource('telemetry', resource_deps = ['cassandra-schema', 'kafka-topics'], labels = ['services'])
+        k8s_resource('identity', resource_deps = ['signed-admission', 'cockroach-schema', 'schema-contracts', 'media-guard'], labels = ['services'])
+        k8s_resource('rental-core', resource_deps = ['signed-admission', 'cockroach-schema', 'kafka-topics'], labels = ['services'])
+        k8s_resource('billing', resource_deps = ['signed-admission', 'cockroach-schema', 'schema-contracts'], labels = ['services'])
+        k8s_resource('risk-pricing', resource_deps = ['signed-admission', 'schema-contracts'], labels = ['services'])
+        k8s_resource('telemetry', resource_deps = ['signed-admission', 'cassandra-schema', 'kafka-topics'], labels = ['services'])
         k8s_resource('api-gateway', resource_deps = ['identity', 'rental-core'], labels = ['services'])
-        k8s_resource('console', resource_deps = ['api-gateway', 'telemetry'], labels = ['services'])
+        k8s_resource('console', resource_deps = ['signed-admission', 'api-gateway', 'telemetry'], labels = ['services'])
         k8s_resource('projecty', links = [link('http://localhost:8080', 'Console'), link('http://localhost:8080/health/ready', 'Gateway')])
 
         print('Tilt UI: http://localhost:10350')

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,222 +1,159 @@
 # ProjectY local development orchestration.
 #
-# The audited services remain the active topology while the strangler migration
-# replaces them one task at a time. The gateway is the first modernization
-# service and is the only public entry point added by this epic.
+# Kubernetes is the default path. Compose remains available during the migration
+# with `tilt up -- --orchestrator=compose`.
+
+load('ext://uibutton', 'cmd_button')
+
+config.define_string('orchestrator', usage = 'kubernetes (default) or compose')
+config.define_bool('full', usage = 'Include the complete polyglot topology in Compose mode')
+config.define_string_list('resources', args = True)
+settings = config.parse()
+config.set_enabled_resources(settings.get('resources', []))
+orchestrator = settings.get('orchestrator', 'kubernetes')
+full = settings.get('full', False)
+
+if orchestrator not in ['kubernetes', 'compose']:
+    fail('orchestrator must be `kubernetes` or `compose`')
 
 local_env_exists = os.path.exists('.env')
 rabbitmq_definitions_exist = os.path.exists('.rabbitmq-definitions.json')
-
 if local_env_exists != rabbitmq_definitions_exist:
-    existing_local_file = '.env' if local_env_exists else '.rabbitmq-definitions.json'
-    missing_local_file = '.rabbitmq-definitions.json' if local_env_exists else '.env'
-    partial_credentials_message = (
-        'Partial local credential set: %s exists but %s is missing. Tilt will not ' +
-        'rotate credentials automatically because persistent volumes may still use them. ' +
-        'Stop the stack, remove volumes initialized with the old credentials, then run ' +
+    existing = '.env' if local_env_exists else '.rabbitmq-definitions.json'
+    missing = '.rabbitmq-definitions.json' if local_env_exists else '.env'
+    fail(
+        'Partial local credential set: %s exists but %s is missing. Stop the stack, ' % (existing, missing) +
+        'remove volumes initialized with the old credentials, then run ' +
         '`powershell -ExecutionPolicy Bypass -File scripts/New-LocalSecrets.ps1 -Force`.'
-    ) % (existing_local_file, missing_local_file)
-    fail(partial_credentials_message)
+    )
 
-required_local_files = ['.env', '.rabbitmq-definitions.json']
-missing_local_files = [path for path in required_local_files if not os.path.exists(path)]
+missing_local_files = [path for path in ['.env', '.rabbitmq-definitions.json'] if not os.path.exists(path)]
 if missing_local_files and config.tilt_subcommand in ['up', 'ci']:
     print('Generating ignored local credentials for the first run...')
     local(
         ['pwsh', '-NoProfile', '-File', 'scripts/New-LocalSecrets.ps1'],
-        command_bat = [
-            'powershell',
-            '-NoProfile',
-            '-ExecutionPolicy',
-            'Bypass',
-            '-File',
-            'scripts\\New-LocalSecrets.ps1',
-        ],
+        command_bat = ['powershell', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', 'scripts\\New-LocalSecrets.ps1'],
         echo_off = True,
     )
 
-missing_local_files = [path for path in required_local_files if not os.path.exists(path)]
+missing_local_files = [path for path in ['.env', '.rabbitmq-definitions.json'] if not os.path.exists(path)]
 if missing_local_files:
-    missing_files_message = (
-        'Local credential generation did not create: %s. Run ' +
-        '`powershell -ExecutionPolicy Bypass -File scripts/New-LocalSecrets.ps1` ' +
-        'to inspect the underlying error.'
-    ) % ', '.join(missing_local_files)
-    fail(missing_files_message)
+    fail('Local credential generation did not create: %s' % ', '.join(missing_local_files))
 
-config.define_bool('full', usage = 'Include live telemetry, async risk/pricing and the console')
-config.define_string_list('resources', args = True)
-settings = config.parse()
-config.set_enabled_resources(settings.get('resources', []))
-full = settings.get('full', False)
-compose_files = ['docker-compose.yml', 'docker-compose.chaos.yml']
-if full:
-    compose_files.append('docker-compose.polyglot.yml')
+def build_application_images(target):
+    docker_build('projecty/api-gateway:dev', 'services/api-gateway', dockerfile = 'services/api-gateway/Dockerfile', target = target)
+    docker_build('projecty/media-guard:dev', 'services/media-guard', dockerfile = 'services/media-guard/Dockerfile', target = target)
+    docker_build('projecty/identity:dev', '.', dockerfile = 'services/identity/Dockerfile', target = target)
+    docker_build('projecty/rental-core:dev', '.', dockerfile = 'services/rental-core/RentalCore/Dockerfile', target = target)
+    docker_build('projecty/billing:dev', '.', dockerfile = 'services/billing/Dockerfile', target = target)
+    docker_build('projecty/risk-pricing:dev', '.', dockerfile = 'services/risk-pricing/Dockerfile', target = target)
+    docker_build('projecty/telemetry:dev', 'services/telemetry', dockerfile = 'services/telemetry/Dockerfile', target = target)
+    docker_build('projecty/console:dev', 'services/console', dockerfile = 'services/console/Dockerfile', target = target)
 
-docker_compose(
-    compose_files,
-    env_file = '.env',
-    project_name = 'projecty',
-)
+if orchestrator == 'kubernetes':
+    powershell = 'powershell' if os.name == 'nt' else 'pwsh'
+    script_prefix = [powershell, '-NoProfile']
+    if os.name == 'nt':
+        script_prefix += ['-ExecutionPolicy', 'Bypass']
 
-# Docker Compose workloads use restart_container(); the restart_process
-# extension does not support Compose resources. Development images keep their
-# source and language toolchain under /workspace so incremental builds happen
-# in-place instead of rebuilding an image.
-def configure_live_update(image, context, manifests, install_command, build_command = ''):
-    if not os.path.exists(context):
-        print('Live update pending service source: %s' % context)
-        return
+    if config.tilt_subcommand == 'down':
+        local(script_prefix + ['-File', 'scripts/kind/Remove-ProjectYCluster.ps1'])
+        print('ProjectY Kubernetes environment removed.')
+    else:
+        local(script_prefix + ['-File', 'scripts/kind/Ensure-ProjectYCluster.ps1'], echo_off = True)
+        allow_k8s_contexts('kind-projecty')
+        default_registry('localhost:5001')
 
-    update_steps = [
-        fall_back_on(context + '/Dockerfile'),
-        sync(context, '/workspace'),
-        run(install_command, trigger = manifests),
-    ]
-    if build_command:
-        update_steps.append(run(build_command))
-    update_steps.append(restart_container())
+        build_application_images('final')
+        docker_build('projecty/cockroach-schema:dev', 'deploy/db', dockerfile = 'deploy/db/Dockerfile')
+        docker_build('projecty/kafka-init:dev', 'deploy/kafka', dockerfile = 'deploy/kafka/Dockerfile')
+        docker_build('projecty/cassandra-init:dev', 'deploy/db/cassandra', dockerfile = 'deploy/db/cassandra/Dockerfile')
+        docker_build('projecty/schema-init:dev', 'contracts', dockerfile = 'contracts/Dockerfile')
+
+        k8s_yaml(kustomize('deploy/overlays/selfhost'))
+
+        k8s_resource('cockroach-schema', resource_deps = ['cockroachdb'], labels = ['setup'])
+        k8s_resource('kafka-topics', resource_deps = ['kafka'], labels = ['setup'])
+        k8s_resource('cassandra-schema', resource_deps = ['cassandra'], labels = ['setup'])
+        k8s_resource('schema-contracts', resource_deps = ['schema-registry', 'kafka-topics'], labels = ['setup'])
+        k8s_resource('identity', resource_deps = ['cockroach-schema', 'schema-contracts', 'media-guard'], labels = ['services'])
+        k8s_resource('rental-core', resource_deps = ['cockroach-schema', 'kafka-topics'], labels = ['services'])
+        k8s_resource('billing', resource_deps = ['cockroach-schema', 'schema-contracts'], labels = ['services'])
+        k8s_resource('risk-pricing', resource_deps = ['schema-contracts'], labels = ['services'])
+        k8s_resource('telemetry', resource_deps = ['cassandra-schema', 'kafka-topics'], labels = ['services'])
+        k8s_resource('api-gateway', resource_deps = ['identity', 'rental-core'], labels = ['services'])
+        k8s_resource('console', resource_deps = ['api-gateway', 'telemetry'], labels = ['services'])
+        k8s_resource('projecty', links = [link('http://localhost:8080', 'Console'), link('http://localhost:8080/health/ready', 'Gateway')])
+
+        print('Tilt UI: http://localhost:10350')
+        print('Console: http://localhost:8080')
+        print('Gateway: http://localhost:8080/health/ready')
+
+if orchestrator == 'compose':
+    compose_files = ['docker-compose.yml', 'docker-compose.chaos.yml']
+    if full:
+        compose_files.append('docker-compose.polyglot.yml')
+    docker_compose(compose_files, env_file = '.env', project_name = 'projecty')
+
+    def configure_live_update(image, context, manifests, install_command, build_command = ''):
+        update_steps = [
+            fall_back_on(context + '/Dockerfile'),
+            sync(context, '/workspace'),
+            run(install_command, trigger = manifests),
+        ]
+        if build_command:
+            update_steps.append(run(build_command))
+        update_steps.append(restart_container())
+        docker_build(image, context, dockerfile = context + '/Dockerfile', target = 'development', live_update = update_steps)
 
     docker_build(
-        image,
-        context,
-        dockerfile = context + '/Dockerfile',
-        target = 'development',
-        live_update = update_steps,
-    )
-
-def configure_dotnet_live_update(name, project, directory = None):
-    # The directory and the project stopped being the same name when moto-hub and
-    # rental-operations merged, so they are separate arguments now.
-    source = 'services/' + (directory or project) + '/' + project
-    docker_build(
-        'projecty/' + name + ':dev', '.',
-        dockerfile = source + '/Dockerfile', target = 'development',
+        'projecty/rental-core:dev', '.',
+        dockerfile = 'services/rental-core/RentalCore/Dockerfile', target = 'development',
         live_update = [
-            fall_back_on([source + '/Dockerfile', source + '/' + project + '.csproj', 'services/risk-pricing/pricing-policy.json']),
-            sync(source, '/src/' + source),
+            fall_back_on(['services/rental-core/RentalCore/Dockerfile', 'services/rental-core/RentalCore/RentalCore.csproj', 'services/risk-pricing/pricing-policy.json']),
+            sync('services/rental-core/RentalCore', '/src/services/rental-core/RentalCore'),
             sync('Shared', '/src/Shared'),
             sync('contracts', '/src/contracts'),
-            run('dotnet publish /src/' + source + '/' + project + '.csproj --configuration Release --output /app/publish --no-restore /p:UseAppHost=false'),
+            run('dotnet publish /src/services/rental-core/RentalCore/RentalCore.csproj --configuration Release --output /app/publish --no-restore /p:UseAppHost=false'),
             restart_container(),
         ],
     )
+    configure_live_update('projecty/api-gateway:dev', 'services/api-gateway', ['services/api-gateway/Cargo.toml', 'services/api-gateway/Cargo.lock'], 'cd /workspace && cargo fetch --locked', 'cd /workspace && cargo build --locked')
+    configure_live_update('projecty/media-guard:dev', 'services/media-guard', ['services/media-guard/Cargo.toml', 'services/media-guard/Cargo.lock'], 'cd /workspace && cargo fetch --locked', 'cd /workspace && cargo build --locked')
+    docker_build('projecty/identity:dev', '.', dockerfile = 'services/identity/Dockerfile', target = 'development')
 
-configure_dotnet_live_update('rental-core', 'RentalCore', 'rental-core')
+    infrastructure = ['toxiproxy', 'cockroachdb', 'redis', 'rabbitmq', 'minio']
+    observability = ['tempo', 'loki', 'otel-collector', 'prometheus', 'grafana']
+    setup = ['cockroach-init']
+    services = ['identity', 'rental-core', 'media-guard']
+    if full:
+        configure_live_update('projecty/telemetry:dev', 'services/telemetry', ['services/telemetry/mix.exs', 'services/telemetry/mix.lock'], 'cd /workspace && mix deps.get', 'cd /workspace && mix compile')
+        configure_live_update('projecty/console:dev', 'services/console', ['services/console/package.json', 'services/console/package-lock.json'], 'cd /workspace && npm ci')
+        docker_build('projecty/risk-pricing:dev', '.', dockerfile = 'services/risk-pricing/Dockerfile', target = 'development')
+        docker_build('projecty/billing:dev', '.', dockerfile = 'services/billing/Dockerfile', target = 'development')
+        infrastructure += ['kafka', 'cassandra', 'schema-registry']
+        setup += ['kafka-init', 'cassandra-init', 'schema-init']
+        services += ['telemetry', 'risk-pricing', 'console', 'billing']
 
-configure_live_update(
-    'projecty/api-gateway:dev',
-    'services/api-gateway',
-    ['services/api-gateway/Cargo.toml', 'services/api-gateway/Cargo.lock'],
-    'cd /workspace && cargo fetch --locked',
-    'cd /workspace && cargo build --locked',
-)
-configure_live_update(
-    'projecty/media-guard:dev',
-    'services/media-guard',
-    ['services/media-guard/Cargo.toml', 'services/media-guard/Cargo.lock'],
-    'cd /workspace && cargo fetch --locked',
-    'cd /workspace && cargo build --locked',
-)
-# O identity compila da raiz pelo mesmo motivo do billing: o teste aplica
-# deploy/db/sql, e a relay lê contracts/. O live update sincroniza o fonte e
-# reinicia -- `go run` recompila em segundos, e um binário Go não tem troca a
-# quente.
-docker_build(
-    'projecty/identity:dev', '.',
-    dockerfile = 'services/identity/Dockerfile', target = 'development',
-    live_update = [
-        fall_back_on(['services/identity/Dockerfile', 'services/identity/go.mod', 'services/identity/go.sum']),
-        sync('services/identity', '/src/services/identity'),
-        sync('contracts', '/src/contracts'),
-        restart_container(),
-    ],
-)
-infra_resources = ['toxiproxy', 'cockroachdb', 'redis', 'rabbitmq', 'minio']
-observability_resources = ['tempo', 'loki', 'otel-collector', 'prometheus', 'grafana']
-# O rental-core saiu daqui: o schema dele vem de deploy/db/sql, aplicado pelo
-# cockroach-init, e não de migrações do EF.
-setup_resources = ['cockroach-init']
-service_resources = ['identity', 'rental-core', 'media-guard']
+    for resource in infrastructure:
+        dc_resource(resource, labels = ['infra'])
+    for resource in observability:
+        links = [link('http://localhost:3000', 'Grafana')] if resource == 'grafana' else []
+        dc_resource(resource, labels = ['observability'], links = links)
+    for resource in setup:
+        dc_resource(resource, labels = ['setup'])
+    for resource in services:
+        dc_resource(resource, labels = ['services'], resource_deps = observability)
+    dc_resource('api-gateway', labels = ['services'], links = [link('http://localhost:8090/health/ready', 'Gateway')], resource_deps = observability)
 
-if full:
-    configure_live_update(
-        'projecty/telemetry:dev', 'services/telemetry',
-        ['services/telemetry/mix.exs', 'services/telemetry/mix.lock'],
-        'cd /workspace && mix deps.get', 'cd /workspace && mix compile',
-    )
-    configure_live_update(
-        'projecty/console:dev', 'services/console',
-        ['services/console/package.json', 'services/console/package-lock.json'],
-        'cd /workspace && npm ci',
-    )
-    docker_build(
-        'projecty/risk-pricing:dev', '.',
-        dockerfile = 'services/risk-pricing/Dockerfile', target = 'development',
-        live_update = [
-            fall_back_on(['services/risk-pricing/Dockerfile', 'services/risk-pricing/requirements.lock', 'contracts']),
-            sync('services/risk-pricing', '/workspace'), restart_container(),
-        ],
-    )
-    # O billing compila da raiz, como os .NET: o Gradle gera as classes de
-    # contracts/events e o teste aplica deploy/db/sql. Sem live update -- uma
-    # troca a quente de classes na JVM daria menos do que custaria explicar.
-    docker_build(
-        'projecty/billing:dev', '.',
-        dockerfile = 'services/billing/Dockerfile', target = 'development',
-    )
-    infra_resources += ['kafka', 'cassandra', 'schema-registry']
-    setup_resources += ['kafka-init', 'cassandra-init', 'schema-init']
-    service_resources += ['telemetry', 'risk-pricing', 'console', 'billing']
+    print('Tilt UI: http://localhost:10350')
+    print('Gateway: http://localhost:8090')
+    print('Grafana: http://localhost:3000')
+    if full:
+        print('Console: http://localhost:3001')
 
-for resource in infra_resources:
-    dc_resource(resource, labels = ['infra'])
-
-for resource in observability_resources:
-    resource_links = []
-    if resource == 'grafana':
-        resource_links = [link('http://localhost:3000', 'Grafana')]
-    dc_resource(resource, labels = ['observability'], links = resource_links)
-
-for resource in setup_resources:
-    dc_resource(resource, labels = ['setup'])
-
-for resource in service_resources:
-    dc_resource(
-        resource,
-        labels = ['services'],
-        resource_deps = observability_resources,
-    )
-
-dc_resource(
-    'api-gateway',
-    labels = ['services'],
-    links = [link('http://localhost:8090/health/ready', 'Gateway')],
-    resource_deps = observability_resources,
-)
-
-print('Tilt UI:  http://localhost:10350')
-print('Gateway:  http://localhost:8090')
-print('Grafana:  http://localhost:3000')
-if full:
-    print('Console:  http://localhost:3001')
-
-# Keep unavailable target-service drills visible and explicitly disabled.
-load('ext://uibutton', 'cmd_button')
-chaos_shell = 'powershell' if os.name == 'nt' else 'pwsh'
-chaos_prefix = [chaos_shell, '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', 'scripts/Invoke-ChaosDrill.ps1']
-for drill in read_json('deploy/chaos/drills.json'):
-    cmd_button(
-        'chaos-' + drill['id'],
-        resource = 'toxiproxy',
-        argv = chaos_prefix + [drill['id']],
-        text = drill['label'],
-        disabled = not drill['available'],
-    )
-    cmd_button(
-        'chaos-clear-' + drill['id'],
-        resource = 'toxiproxy',
-        argv = chaos_prefix + [drill['id'], '-Clear'],
-        text = 'Clear: ' + drill['label'],
-        disabled = not drill['available'],
-    )
+    chaos_shell = 'powershell' if os.name == 'nt' else 'pwsh'
+    chaos_prefix = [chaos_shell, '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', 'scripts/Invoke-ChaosDrill.ps1']
+    for drill in read_json('deploy/chaos/drills.json'):
+        cmd_button('chaos-' + drill['id'], resource = 'toxiproxy', argv = chaos_prefix + [drill['id']], text = drill['label'], disabled = not drill['available'])
+        cmd_button('chaos-clear-' + drill['id'], resource = 'toxiproxy', argv = chaos_prefix + [drill['id'], '-Clear'], text = 'Clear: ' + drill['label'], disabled = not drill['available'])

--- a/Tiltfile
+++ b/Tiltfile
@@ -60,7 +60,8 @@ if orchestrator == 'kubernetes':
         local(script_prefix + ['-File', 'scripts/kind/Remove-ProjectYCluster.ps1'])
         print('ProjectY Kubernetes environment removed.')
     else:
-        local(script_prefix + ['-File', 'scripts/kind/Ensure-ProjectYCluster.ps1'], echo_off = True)
+        if config.tilt_subcommand in ['up', 'ci']:
+            local(script_prefix + ['-File', 'scripts/kind/Ensure-ProjectYCluster.ps1'], echo_off = True)
         allow_k8s_contexts('kind-projecty')
         default_registry('localhost:5001')
 
@@ -73,24 +74,87 @@ if orchestrator == 'kubernetes':
         k8s_yaml(kustomize('deploy/overlays/selfhost'))
 
         local_resource(
+            'external-secrets-controller',
+            cmd = script_prefix + ['-File', 'scripts/kind/Install-ExternalSecrets.ps1'],
+            deps = ['scripts/kind/Install-ExternalSecrets.ps1'],
+            labels = ['platform'],
+        )
+        local_resource(
+            'local-secret-backend',
+            cmd = script_prefix + ['-File', 'scripts/kind/Publish-LocalSecretBackend.ps1'],
+            deps = ['.env', 'scripts/kind/Publish-LocalSecretBackend.ps1'],
+            resource_deps = ['external-secrets-controller'],
+            labels = ['platform'],
+        )
+        local_resource(
             'signed-admission',
             cmd = script_prefix + ['-File', 'scripts/kind/Install-Kyverno.ps1'],
             deps = ['deploy/platform/kyverno'],
             labels = ['platform'],
         )
 
-        k8s_resource('cockroach-schema', resource_deps = ['cockroachdb'], labels = ['setup'])
-        k8s_resource('kafka-topics', resource_deps = ['kafka'], labels = ['setup'])
-        k8s_resource('cassandra-schema', resource_deps = ['cassandra'], labels = ['setup'])
-        k8s_resource('schema-contracts', resource_deps = ['schema-registry', 'kafka-topics'], labels = ['setup'])
-        k8s_resource('identity', resource_deps = ['signed-admission', 'cockroach-schema', 'schema-contracts', 'media-guard'], labels = ['services'])
-        k8s_resource('rental-core', resource_deps = ['signed-admission', 'cockroach-schema', 'kafka-topics'], labels = ['services'])
-        k8s_resource('billing', resource_deps = ['signed-admission', 'cockroach-schema', 'schema-contracts'], labels = ['services'])
-        k8s_resource('risk-pricing', resource_deps = ['signed-admission', 'schema-contracts'], labels = ['services'])
-        k8s_resource('telemetry', resource_deps = ['signed-admission', 'cassandra-schema', 'kafka-topics'], labels = ['services'])
-        k8s_resource('api-gateway', resource_deps = ['identity', 'rental-core'], labels = ['services'])
-        k8s_resource('console', resource_deps = ['signed-admission', 'api-gateway', 'telemetry'], labels = ['services'])
-        k8s_resource('projecty', links = [link('http://localhost:8080', 'Console'), link('http://localhost:8080/health/ready', 'Gateway')])
+        workload_names = [
+            'api-gateway', 'identity', 'rental-core', 'media-guard', 'billing', 'risk-pricing', 'telemetry', 'console',
+            'cockroachdb', 'redis', 'rabbitmq', 'minio', 'kafka', 'cassandra', 'schema-registry',
+            'cockroach-schema', 'kafka-topics', 'cassandra-schema', 'schema-contracts',
+        ]
+        network_policy_names = [
+            'default-deny', 'allow-dns', 'ingress-only-reaches-edge', 'gateway-to-owned-dependencies',
+            'console-to-gateway', 'gateway-to-service-ingress', 'identity-to-owned-dependencies',
+            'identity-to-media-guard', 'rental-core-to-owned-dependencies', 'billing-to-owned-dependencies',
+            'risk-pricing-to-owned-dependencies', 'telemetry-to-owned-dependencies', 'cockroachdb-owners',
+            'rabbitmq-owner', 'redis-owners', 'minio-owners', 'kafka-clients', 'cassandra-clients',
+            'schema-registry-clients', 'data-service-egress', 'setup-to-data',
+        ]
+        platform_objects = [
+            'projecty:namespace', 'projecty-secrets:namespace',
+            'projecty-secret-reader:role:projecty-secrets', 'projecty-secret-reader:rolebinding:projecty-secrets',
+            'projecty-runtime:configmap:projecty', 'kafka-runtime:configmap:projecty', 'rabbitmq-runtime:configmap:projecty',
+            'external-secrets-reader:serviceaccount:projecty',
+        ]
+        platform_objects += [name + ':serviceaccount:projecty' for name in workload_names]
+        platform_objects += [name + ':networkpolicy:projecty' for name in network_policy_names]
+        k8s_resource(new_name = 'projecty-platform', objects = platform_objects, labels = ['platform'])
+        k8s_resource(
+            new_name = 'projecty-secret-store',
+            objects = ['projecty-secrets:secretstore:projecty'],
+            resource_deps = ['projecty-platform', 'external-secrets-controller', 'local-secret-backend'],
+            labels = ['platform'],
+        )
+        for secret in [
+            'api-gateway-secrets', 'identity-secrets', 'rental-core-secrets', 'billing-secrets',
+            'risk-pricing-secrets', 'telemetry-secrets', 'console-secrets', 'rabbitmq-secrets', 'minio-secrets',
+        ]:
+            k8s_resource(
+                new_name = secret,
+                objects = [secret + ':externalsecret:projecty'],
+                resource_deps = ['projecty-secret-store'],
+                labels = ['platform'],
+            )
+
+        for infrastructure_resource in ['cockroachdb', 'redis', 'kafka', 'cassandra', 'schema-registry']:
+            k8s_resource(infrastructure_resource, resource_deps = ['projecty-platform'], labels = ['infra'])
+        k8s_resource('rabbitmq', resource_deps = ['projecty-platform', 'rabbitmq-secrets'], labels = ['infra'])
+        k8s_resource('minio', resource_deps = ['projecty-platform', 'minio-secrets'], labels = ['infra'])
+        k8s_resource('cockroach-schema', resource_deps = ['projecty-platform', 'cockroachdb'], labels = ['setup'])
+        k8s_resource('kafka-topics', resource_deps = ['projecty-platform', 'kafka'], labels = ['setup'])
+        k8s_resource('cassandra-schema', resource_deps = ['projecty-platform', 'cassandra'], labels = ['setup'])
+        k8s_resource('schema-contracts', resource_deps = ['projecty-platform', 'schema-registry', 'kafka-topics'], labels = ['setup'])
+        k8s_resource('media-guard', resource_deps = ['projecty-platform', 'signed-admission'], labels = ['services'])
+        k8s_resource('identity', resource_deps = ['projecty-platform', 'signed-admission', 'identity-secrets', 'cockroach-schema', 'schema-contracts', 'media-guard'], labels = ['services'])
+        k8s_resource('rental-core', resource_deps = ['projecty-platform', 'signed-admission', 'rental-core-secrets', 'cockroach-schema', 'kafka-topics'], labels = ['services'])
+        k8s_resource('billing', resource_deps = ['projecty-platform', 'signed-admission', 'billing-secrets', 'cockroach-schema', 'schema-contracts'], labels = ['services'])
+        k8s_resource('risk-pricing', resource_deps = ['projecty-platform', 'signed-admission', 'risk-pricing-secrets', 'schema-contracts'], labels = ['services'])
+        k8s_resource('telemetry', resource_deps = ['projecty-platform', 'signed-admission', 'telemetry-secrets', 'cassandra-schema', 'kafka-topics'], labels = ['services'])
+        k8s_resource('api-gateway', resource_deps = ['projecty-platform', 'api-gateway-secrets', 'identity', 'rental-core'], labels = ['services'])
+        k8s_resource('console', resource_deps = ['projecty-platform', 'signed-admission', 'console-secrets', 'api-gateway', 'telemetry'], labels = ['services'])
+        k8s_resource(
+            new_name = 'projecty-edge',
+            objects = ['projecty:ingress:projecty'],
+            resource_deps = ['api-gateway', 'console', 'telemetry'],
+            links = [link('http://localhost:8080', 'Console'), link('http://localhost:8080/health/ready', 'Gateway')],
+            labels = ['services'],
+        )
 
         print('Tilt UI: http://localhost:10350')
         print('Console: http://localhost:8080')

--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:24-alpine
+WORKDIR /contracts
+COPY . .
+USER node
+ENTRYPOINT ["node", "/contracts/register.mjs"]

--- a/deploy/base/applications.yaml
+++ b/deploy/base/applications.yaml
@@ -9,6 +9,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: api-gateway, projecty.io/tier: edge}
     spec:
+      serviceAccountName: api-gateway
+      automountServiceAccountToken: false
       terminationGracePeriodSeconds: 30
       securityContext:
         runAsNonRoot: true
@@ -18,7 +20,7 @@ spec:
           image: projecty/api-gateway:dev
           envFrom:
             - configMapRef: {name: projecty-runtime}
-            - secretRef: {name: projecty-runtime}
+            - secretRef: {name: api-gateway-secrets}
           env: [{name: OTEL_SERVICE_NAME, value: api-gateway}]
           ports: [{name: http, containerPort: 8090}]
           startupProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5, failureThreshold: 24}
@@ -52,6 +54,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: identity, projecty.io/tier: service}
     spec:
+      serviceAccountName: identity
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         seccompProfile: {type: RuntimeDefault}
@@ -60,7 +64,7 @@ spec:
           image: projecty/identity:dev
           envFrom:
             - configMapRef: {name: projecty-runtime}
-            - secretRef: {name: projecty-runtime}
+            - secretRef: {name: identity-secrets}
           env: [{name: OTEL_SERVICE_NAME, value: identity}]
           ports: [{name: http, containerPort: 8095}]
           startupProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5, failureThreshold: 36}
@@ -94,6 +98,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: rental-core, projecty.io/tier: service}
     spec:
+      serviceAccountName: rental-core
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         seccompProfile: {type: RuntimeDefault}
@@ -102,7 +108,7 @@ spec:
           image: projecty/rental-core:dev
           envFrom:
             - configMapRef: {name: projecty-runtime}
-            - secretRef: {name: projecty-runtime}
+            - secretRef: {name: rental-core-secrets}
           env: [{name: OTEL_SERVICE_NAME, value: rental-core}]
           ports: [{name: http, containerPort: 8200}]
           startupProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5, failureThreshold: 36}
@@ -136,6 +142,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: media-guard, projecty.io/tier: service}
     spec:
+      serviceAccountName: media-guard
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         seccompProfile: {type: RuntimeDefault}
@@ -144,7 +152,6 @@ spec:
           image: projecty/media-guard:dev
           envFrom:
             - configMapRef: {name: projecty-runtime}
-            - secretRef: {name: projecty-runtime}
           env: [{name: OTEL_SERVICE_NAME, value: media-guard}]
           ports: [{name: http, containerPort: 8092}]
           startupProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 3, failureThreshold: 20}
@@ -178,6 +185,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: billing, projecty.io/tier: service}
     spec:
+      serviceAccountName: billing
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         seccompProfile: {type: RuntimeDefault}
@@ -186,7 +195,7 @@ spec:
           image: projecty/billing:dev
           envFrom:
             - configMapRef: {name: projecty-runtime}
-            - secretRef: {name: projecty-runtime}
+            - secretRef: {name: billing-secrets}
           env: [{name: OTEL_SERVICE_NAME, value: billing}]
           ports: [{name: http, containerPort: 8094}]
           startupProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5, failureThreshold: 36}
@@ -220,6 +229,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: risk-pricing, projecty.io/tier: service}
     spec:
+      serviceAccountName: risk-pricing
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
@@ -231,7 +242,7 @@ spec:
           image: projecty/risk-pricing:dev
           envFrom:
             - configMapRef: {name: projecty-runtime}
-            - secretRef: {name: projecty-runtime}
+            - secretRef: {name: risk-pricing-secrets}
           env: [{name: OTEL_SERVICE_NAME, value: risk-pricing}]
           ports: [{name: http, containerPort: 8093}]
           startupProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5, failureThreshold: 36}
@@ -267,8 +278,10 @@ spec:
     matchLabels: {app.kubernetes.io/name: telemetry}
   template:
     metadata:
-      labels: {app.kubernetes.io/name: telemetry, projecty.io/tier: service}
+      labels: {app.kubernetes.io/name: telemetry, projecty.io/tier: edge}
     spec:
+      serviceAccountName: telemetry
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
@@ -279,7 +292,7 @@ spec:
           image: projecty/telemetry:dev
           envFrom:
             - configMapRef: {name: projecty-runtime}
-            - secretRef: {name: projecty-runtime}
+            - secretRef: {name: telemetry-secrets}
           env: [{name: OTEL_SERVICE_NAME, value: telemetry}]
           ports: [{name: http, containerPort: 4000}]
           startupProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5, failureThreshold: 36}
@@ -313,6 +326,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: console, projecty.io/tier: edge}
     spec:
+      serviceAccountName: console
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         seccompProfile: {type: RuntimeDefault}
@@ -321,7 +336,7 @@ spec:
           image: projecty/console:dev
           envFrom:
             - configMapRef: {name: projecty-runtime}
-            - secretRef: {name: projecty-runtime}
+            - secretRef: {name: console-secrets}
           ports: [{name: http, containerPort: 3001}]
           startupProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5, failureThreshold: 36}
           readinessProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5}

--- a/deploy/base/applications.yaml
+++ b/deploy/base/applications.yaml
@@ -1,0 +1,344 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: api-gateway}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app.kubernetes.io/name: api-gateway}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: api-gateway, projecty.io/tier: edge}
+    spec:
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: api-gateway
+          image: projecty/api-gateway:dev
+          envFrom:
+            - configMapRef: {name: projecty-runtime}
+            - secretRef: {name: projecty-runtime}
+          env: [{name: OTEL_SERVICE_NAME, value: api-gateway}]
+          ports: [{name: http, containerPort: 8090}]
+          startupProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5, failureThreshold: 24}
+          readinessProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5}
+          livenessProbe: {httpGet: {path: /health/live, port: http}, periodSeconds: 10}
+          resources:
+            requests: {cpu: 50m, memory: 64Mi}
+            limits: {cpu: 500m, memory: 256Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: [ALL]}
+            readOnlyRootFilesystem: true
+          volumeMounts: [{name: tmp, mountPath: /tmp}]
+      volumes: [{name: tmp, emptyDir: {}}]
+---
+apiVersion: v1
+kind: Service
+metadata: {name: api-gateway}
+spec:
+  selector: {app.kubernetes.io/name: api-gateway}
+  ports: [{name: http, port: 8090, targetPort: http}]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: identity}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app.kubernetes.io/name: identity}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: identity, projecty.io/tier: service}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: identity
+          image: projecty/identity:dev
+          envFrom:
+            - configMapRef: {name: projecty-runtime}
+            - secretRef: {name: projecty-runtime}
+          env: [{name: OTEL_SERVICE_NAME, value: identity}]
+          ports: [{name: http, containerPort: 8095}]
+          startupProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5, failureThreshold: 36}
+          readinessProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5}
+          livenessProbe: {httpGet: {path: /health/live, port: http}, periodSeconds: 10}
+          resources:
+            requests: {cpu: 50m, memory: 64Mi}
+            limits: {cpu: 500m, memory: 256Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: [ALL]}
+            readOnlyRootFilesystem: true
+          volumeMounts: [{name: tmp, mountPath: /tmp}]
+      volumes: [{name: tmp, emptyDir: {}}]
+---
+apiVersion: v1
+kind: Service
+metadata: {name: identity}
+spec:
+  selector: {app.kubernetes.io/name: identity}
+  ports: [{name: http, port: 8095, targetPort: http}]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: rental-core}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app.kubernetes.io/name: rental-core}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: rental-core, projecty.io/tier: service}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: rental-core
+          image: projecty/rental-core:dev
+          envFrom:
+            - configMapRef: {name: projecty-runtime}
+            - secretRef: {name: projecty-runtime}
+          env: [{name: OTEL_SERVICE_NAME, value: rental-core}]
+          ports: [{name: http, containerPort: 8200}]
+          startupProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5, failureThreshold: 36}
+          readinessProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5}
+          livenessProbe: {httpGet: {path: /health/live, port: http}, periodSeconds: 10}
+          resources:
+            requests: {cpu: 100m, memory: 128Mi}
+            limits: {cpu: "1", memory: 512Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: [ALL]}
+            readOnlyRootFilesystem: true
+          volumeMounts: [{name: tmp, mountPath: /tmp}]
+      volumes: [{name: tmp, emptyDir: {}}]
+---
+apiVersion: v1
+kind: Service
+metadata: {name: rental-core}
+spec:
+  selector: {app.kubernetes.io/name: rental-core}
+  ports: [{name: http, port: 8200, targetPort: http}]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: media-guard}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app.kubernetes.io/name: media-guard}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: media-guard, projecty.io/tier: service}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: media-guard
+          image: projecty/media-guard:dev
+          envFrom:
+            - configMapRef: {name: projecty-runtime}
+            - secretRef: {name: projecty-runtime}
+          env: [{name: OTEL_SERVICE_NAME, value: media-guard}]
+          ports: [{name: http, containerPort: 8092}]
+          startupProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 3, failureThreshold: 20}
+          readinessProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5}
+          livenessProbe: {httpGet: {path: /health/live, port: http}, periodSeconds: 10}
+          resources:
+            requests: {cpu: 100m, memory: 64Mi}
+            limits: {cpu: "2", memory: 768Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: [ALL]}
+            readOnlyRootFilesystem: true
+          volumeMounts: [{name: tmp, mountPath: /tmp}]
+      volumes: [{name: tmp, emptyDir: {}}]
+---
+apiVersion: v1
+kind: Service
+metadata: {name: media-guard}
+spec:
+  selector: {app.kubernetes.io/name: media-guard}
+  ports: [{name: http, port: 8092, targetPort: http}]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: billing}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app.kubernetes.io/name: billing}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: billing, projecty.io/tier: service}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: billing
+          image: projecty/billing:dev
+          envFrom:
+            - configMapRef: {name: projecty-runtime}
+            - secretRef: {name: projecty-runtime}
+          env: [{name: OTEL_SERVICE_NAME, value: billing}]
+          ports: [{name: http, containerPort: 8094}]
+          startupProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5, failureThreshold: 36}
+          readinessProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5}
+          livenessProbe: {httpGet: {path: /health/live, port: http}, periodSeconds: 10}
+          resources:
+            requests: {cpu: 100m, memory: 192Mi}
+            limits: {cpu: "1", memory: 768Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: [ALL]}
+            readOnlyRootFilesystem: true
+          volumeMounts: [{name: tmp, mountPath: /tmp}]
+      volumes: [{name: tmp, emptyDir: {}}]
+---
+apiVersion: v1
+kind: Service
+metadata: {name: billing}
+spec:
+  selector: {app.kubernetes.io/name: billing}
+  ports: [{name: http, port: 8094, targetPort: http}]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: risk-pricing}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app.kubernetes.io/name: risk-pricing}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: risk-pricing, projecty.io/tier: service}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: risk-pricing
+          image: projecty/risk-pricing:dev
+          envFrom:
+            - configMapRef: {name: projecty-runtime}
+            - secretRef: {name: projecty-runtime}
+          env: [{name: OTEL_SERVICE_NAME, value: risk-pricing}]
+          ports: [{name: http, containerPort: 8093}]
+          startupProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5, failureThreshold: 36}
+          readinessProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5}
+          livenessProbe: {httpGet: {path: /health/live, port: http}, periodSeconds: 10}
+          resources:
+            requests: {cpu: 100m, memory: 128Mi}
+            limits: {cpu: "1", memory: 768Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: [ALL]}
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - {name: tmp, mountPath: /tmp}
+            - {name: state, mountPath: /data}
+      volumes:
+        - {name: tmp, emptyDir: {}}
+        - {name: state, emptyDir: {}}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: risk-pricing}
+spec:
+  selector: {app.kubernetes.io/name: risk-pricing}
+  ports: [{name: http, port: 8093, targetPort: http}]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: telemetry}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app.kubernetes.io/name: telemetry}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: telemetry, projecty.io/tier: service}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: telemetry
+          image: projecty/telemetry:dev
+          envFrom:
+            - configMapRef: {name: projecty-runtime}
+            - secretRef: {name: projecty-runtime}
+          env: [{name: OTEL_SERVICE_NAME, value: telemetry}]
+          ports: [{name: http, containerPort: 4000}]
+          startupProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5, failureThreshold: 36}
+          readinessProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5}
+          livenessProbe: {httpGet: {path: /health/live, port: http}, periodSeconds: 10}
+          resources:
+            requests: {cpu: 100m, memory: 128Mi}
+            limits: {cpu: "1", memory: 512Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: [ALL]}
+            readOnlyRootFilesystem: true
+          volumeMounts: [{name: tmp, mountPath: /tmp}]
+      volumes: [{name: tmp, emptyDir: {}}]
+---
+apiVersion: v1
+kind: Service
+metadata: {name: telemetry}
+spec:
+  selector: {app.kubernetes.io/name: telemetry}
+  ports: [{name: http, port: 4000, targetPort: http}]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: console}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app.kubernetes.io/name: console}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: console, projecty.io/tier: edge}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: console
+          image: projecty/console:dev
+          envFrom:
+            - configMapRef: {name: projecty-runtime}
+            - secretRef: {name: projecty-runtime}
+          ports: [{name: http, containerPort: 3001}]
+          startupProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5, failureThreshold: 36}
+          readinessProbe: {httpGet: {path: /health/ready, port: http}, periodSeconds: 5}
+          livenessProbe: {httpGet: {path: /health/live, port: http}, periodSeconds: 10}
+          resources:
+            requests: {cpu: 50m, memory: 128Mi}
+            limits: {cpu: "1", memory: 512Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: [ALL]}
+            readOnlyRootFilesystem: true
+          volumeMounts: [{name: tmp, mountPath: /tmp}]
+      volumes: [{name: tmp, emptyDir: {}}]
+---
+apiVersion: v1
+kind: Service
+metadata: {name: console}
+spec:
+  selector: {app.kubernetes.io/name: console}
+  ports: [{name: http, port: 3001, targetPort: http}]

--- a/deploy/base/configuration.yaml
+++ b/deploy/base/configuration.yaml
@@ -1,0 +1,91 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: projecty-runtime
+data:
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+  OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+  GATEWAY_BIND: 0.0.0.0:8090
+  GATEWAY_HEALTH_URL: http://127.0.0.1:8090/health/ready
+  GATEWAY_UPSTREAM_IDENTITY: http://identity:8095
+  GATEWAY_UPSTREAM_MOTO_HUB: http://rental-core:8200
+  GATEWAY_UPSTREAM_RENTAL_OPERATIONS: http://rental-core:8200
+  GATEWAY_UPSTREAM_BILLING: http://billing:8094
+  GATEWAY_UPSTREAM_IDENTITY_TIMEOUT_MS: "2000"
+  GATEWAY_UPSTREAM_MOTO_HUB_TIMEOUT_MS: "2000"
+  GATEWAY_UPSTREAM_RENTAL_OPERATIONS_TIMEOUT_MS: "2500"
+  GATEWAY_UPSTREAM_BILLING_TIMEOUT_MS: "2000"
+  GATEWAY_JWKS_URL: http://identity:8095/.well-known/jwks.json
+  GATEWAY_JWT_ISSUER: projecty.identity
+  GATEWAY_JWT_AUDIENCE_IDENTITY: projecty.identity
+  GATEWAY_JWT_AUDIENCE_MOTO_HUB: projecty.rental-core
+  GATEWAY_JWT_AUDIENCE_RENTAL_OPERATIONS: projecty.rental-core
+  GATEWAY_JWT_AUDIENCE_BILLING: projecty.billing
+  GATEWAY_IDENTITY_SIGNING_KEY_ID: local-v1
+  GATEWAY_REDIS_URL: redis://redis:6379/
+  GATEWAY_RATE_LIMIT_REDIS_TIMEOUT_MS: "100"
+  GATEWAY_RATE_LIMIT_GENERAL_CAPACITY: "120"
+  GATEWAY_RATE_LIMIT_GENERAL_REFILL_PER_MINUTE: "120"
+  GATEWAY_RATE_LIMIT_AUTH_CAPACITY: "10"
+  GATEWAY_RATE_LIMIT_AUTH_REFILL_PER_MINUTE: "5"
+  RUST_LOG: info,api_gateway=debug
+  IDENTITY_BIND: 0.0.0.0:8095
+  IDENTITY_DATABASE_URL: postgres://root@cockroachdb:26257/projecty?sslmode=disable
+  IDENTITY_PUBLIC_URL: http://identity:8095
+  IDENTITY_ISSUER: projecty.identity
+  IDENTITY_AUDIENCES: projecty.identity,projecty.rental-core,projecty.billing
+  IDENTITY_ENVELOPE_AUDIENCE: projecty.identity
+  IDENTITY_HEALTH_URL: http://127.0.0.1:8095/health/ready
+  MEDIA_GUARD_URL: http://media-guard:8092
+  MINIO_ENDPOINT: minio:9000
+  MINIO_BUCKET: my-bucket
+  KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+  SCHEMA_REGISTRY_URL: http://schema-registry:8080/apis/ccompat/v7
+  ASPNETCORE_ENVIRONMENT: Production
+  ASPNETCORE_URLS: http://+:8200
+  ConnectionStrings__Postgresql: Host=cockroachdb;Port=26257;Database=projecty;Username=root;SSL Mode=Disable
+  Redis__ConnectionString: redis:6379
+  GatewayIdentity__SigningKeyId: local-v1
+  Kafka__BootstrapServers: kafka:9092
+  Kafka__SchemaRegistryUrl: http://schema-registry:8080/apis/ccompat/v7
+  BILLING_DATABASE_URL: jdbc:postgresql://cockroachdb:26257/projecty?sslmode=disable&user=root
+  BILLING_IDENTITY_AUDIENCE: projecty.billing
+  GATEWAY_URL: http://api-gateway:8090
+  CONSOLE_ORIGIN: http://localhost:8080
+  TELEMETRY_PUBLIC_URL: ws://localhost:8080/socket/websocket
+  TEMPO_URL: http://tempo:3200
+  PROMETHEUS_URL: http://prometheus:9090
+  REDIS_URL: redis://redis:6379
+  CASSANDRA_HOST: cassandra
+  KAFKA_HOST: kafka
+  TELEMETRY_ORIGINS: //localhost:8080
+  S3_ENDPOINT: http://minio:9000
+  S3_BUCKET: my-bucket
+  AWS_DEFAULT_REGION: us-east-1
+  STATE_PATH: /data/risk.db
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rabbitmq-runtime
+data:
+  RABBITMQ_DEFAULT_VHOST: projecty-rental
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-runtime
+data:
+  KAFKA_NODE_ID: "1"
+  KAFKA_PROCESS_ROLES: broker,controller
+  KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+  KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+  KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+  KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+  KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+  KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+  KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+  KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "1"
+  KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: "1"
+  KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+  CLUSTER_ID: 5L6g3nShT-eMCtK--X86sw

--- a/deploy/base/external-secrets.yaml
+++ b/deploy/base/external-secrets.yaml
@@ -1,0 +1,118 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: api-gateway-secrets}
+spec:
+  refreshInterval: 1h
+  secretStoreRef: {name: projecty-secrets, kind: SecretStore}
+  target: {name: api-gateway-secrets, creationPolicy: Owner}
+  data:
+    - secretKey: GATEWAY_IDENTITY_SIGNING_KEY
+      remoteRef: {key: projecty-runtime-source, property: GATEWAY_IDENTITY_SIGNING_KEY}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: identity-secrets}
+spec:
+  refreshInterval: 1h
+  secretStoreRef: {name: projecty-secrets, kind: SecretStore}
+  target: {name: identity-secrets, creationPolicy: Owner}
+  data:
+    - secretKey: GATEWAY_IDENTITY_SIGNING_KEY
+      remoteRef: {key: projecty-runtime-source, property: GATEWAY_IDENTITY_SIGNING_KEY}
+    - secretKey: IDENTITY_KEY_ENCRYPTION_KEY
+      remoteRef: {key: projecty-runtime-source, property: IDENTITY_KEY_ENCRYPTION_KEY}
+    - secretKey: IDENTITY_ADMIN_PASSWORD
+      remoteRef: {key: projecty-runtime-source, property: IDENTITY_ADMIN_PASSWORD}
+    - secretKey: MINIO_ACCESS_KEY
+      remoteRef: {key: projecty-runtime-source, property: MINIO_ACCESS_KEY}
+    - secretKey: MINIO_SECRET_KEY
+      remoteRef: {key: projecty-runtime-source, property: MINIO_SECRET_KEY}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: rental-core-secrets}
+spec:
+  refreshInterval: 1h
+  secretStoreRef: {name: projecty-secrets, kind: SecretStore}
+  target: {name: rental-core-secrets, creationPolicy: Owner}
+  data:
+    - secretKey: GatewayIdentity__SigningKey
+      remoteRef: {key: projecty-runtime-source, property: GatewayIdentity__SigningKey}
+    - secretKey: RabbitMQ__UserName
+      remoteRef: {key: projecty-runtime-source, property: RabbitMQ__UserName}
+    - secretKey: RabbitMQ__Password
+      remoteRef: {key: projecty-runtime-source, property: RabbitMQ__Password}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: billing-secrets}
+spec:
+  refreshInterval: 1h
+  secretStoreRef: {name: projecty-secrets, kind: SecretStore}
+  target: {name: billing-secrets, creationPolicy: Owner}
+  data:
+    - secretKey: GATEWAY_IDENTITY_SIGNING_KEY
+      remoteRef: {key: projecty-runtime-source, property: GATEWAY_IDENTITY_SIGNING_KEY}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: risk-pricing-secrets}
+spec:
+  refreshInterval: 1h
+  secretStoreRef: {name: projecty-secrets, kind: SecretStore}
+  target: {name: risk-pricing-secrets, creationPolicy: Owner}
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef: {key: projecty-runtime-source, property: AWS_ACCESS_KEY_ID}
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef: {key: projecty-runtime-source, property: AWS_SECRET_ACCESS_KEY}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: telemetry-secrets}
+spec:
+  refreshInterval: 1h
+  secretStoreRef: {name: projecty-secrets, kind: SecretStore}
+  target: {name: telemetry-secrets, creationPolicy: Owner}
+  data:
+    - secretKey: TELEMETRY_SECRET_KEY_BASE
+      remoteRef: {key: projecty-runtime-source, property: TELEMETRY_SECRET_KEY_BASE}
+    - secretKey: TELEMETRY_TICKET_KEY
+      remoteRef: {key: projecty-runtime-source, property: TELEMETRY_TICKET_KEY}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: console-secrets}
+spec:
+  refreshInterval: 1h
+  secretStoreRef: {name: projecty-secrets, kind: SecretStore}
+  target: {name: console-secrets, creationPolicy: Owner}
+  data:
+    - secretKey: TELEMETRY_TICKET_KEY
+      remoteRef: {key: projecty-runtime-source, property: TELEMETRY_TICKET_KEY}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: rabbitmq-secrets}
+spec:
+  refreshInterval: 1h
+  secretStoreRef: {name: projecty-secrets, kind: SecretStore}
+  target: {name: rabbitmq-secrets, creationPolicy: Owner}
+  data:
+    - secretKey: RABBITMQ_DEFAULT_USER
+      remoteRef: {key: projecty-runtime-source, property: RABBITMQ_DEFAULT_USER}
+    - secretKey: RABBITMQ_DEFAULT_PASS
+      remoteRef: {key: projecty-runtime-source, property: RABBITMQ_DEFAULT_PASS}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: minio-secrets}
+spec:
+  refreshInterval: 1h
+  secretStoreRef: {name: projecty-secrets, kind: SecretStore}
+  target: {name: minio-secrets, creationPolicy: Owner}
+  data:
+    - secretKey: MINIO_ROOT_USER
+      remoteRef: {key: projecty-runtime-source, property: MINIO_ROOT_USER}
+    - secretKey: MINIO_ROOT_PASSWORD
+      remoteRef: {key: projecty-runtime-source, property: MINIO_ROOT_PASSWORD}

--- a/deploy/base/infrastructure.yaml
+++ b/deploy/base/infrastructure.yaml
@@ -1,0 +1,345 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cockroachdb
+spec:
+  serviceName: cockroachdb
+  replicas: 1
+  selector:
+    matchLabels: {app.kubernetes.io/name: cockroachdb}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: cockroachdb, projecty.io/tier: data}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: cockroachdb
+          image: cockroachdb/cockroach:v26.3.1
+          args: ["start-single-node", "--insecure", "--http-addr=0.0.0.0:8080"]
+          ports:
+            - {name: sql, containerPort: 26257}
+            - {name: admin, containerPort: 8080}
+          readinessProbe:
+            tcpSocket: {port: sql}
+            periodSeconds: 5
+            failureThreshold: 20
+          livenessProbe:
+            tcpSocket: {port: sql}
+            periodSeconds: 10
+          resources:
+            requests: {cpu: 250m, memory: 512Mi}
+            limits: {cpu: "2", memory: 2Gi}
+          securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
+          volumeMounts:
+            - {name: data, mountPath: /cockroach/cockroach-data}
+            - {name: tmp, mountPath: /tmp}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata: {name: data}
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources: {requests: {storage: 2Gi}}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: cockroachdb}
+spec:
+  selector: {app.kubernetes.io/name: cockroachdb}
+  ports:
+    - {name: sql, port: 26257, targetPort: sql}
+    - {name: admin, port: 8080, targetPort: admin}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: {name: redis}
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels: {app.kubernetes.io/name: redis}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: redis, projecty.io/tier: data}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: redis
+          image: redis:8.10-alpine
+          args: ["redis-server", "--appendonly", "yes", "--appendfsync", "always"]
+          ports: [{name: redis, containerPort: 6379}]
+          readinessProbe: {tcpSocket: {port: redis}, periodSeconds: 5}
+          livenessProbe: {tcpSocket: {port: redis}, periodSeconds: 10}
+          resources:
+            requests: {cpu: 50m, memory: 64Mi}
+            limits: {cpu: 500m, memory: 256Mi}
+          securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
+          volumeMounts:
+            - {name: data, mountPath: /data}
+            - {name: tmp, mountPath: /tmp}
+      volumes: [{name: tmp, emptyDir: {}}]
+  volumeClaimTemplates:
+    - metadata: {name: data}
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources: {requests: {storage: 1Gi}}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: redis}
+spec:
+  selector: {app.kubernetes.io/name: redis}
+  ports: [{name: redis, port: 6379, targetPort: redis}]
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: {name: rabbitmq}
+spec:
+  serviceName: rabbitmq
+  replicas: 1
+  selector:
+    matchLabels: {app.kubernetes.io/name: rabbitmq}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: rabbitmq, projecty.io/tier: data}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:4-management
+          envFrom:
+            - configMapRef: {name: rabbitmq-runtime}
+            - secretRef: {name: projecty-runtime}
+          ports:
+            - {name: amqp, containerPort: 5672}
+            - {name: management, containerPort: 15672}
+          readinessProbe: {tcpSocket: {port: amqp}, periodSeconds: 5, failureThreshold: 12}
+          livenessProbe: {tcpSocket: {port: amqp}, periodSeconds: 10}
+          resources:
+            requests: {cpu: 100m, memory: 256Mi}
+            limits: {cpu: "1", memory: 768Mi}
+          securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
+          volumeMounts:
+            - {name: data, mountPath: /var/lib/rabbitmq}
+            - {name: tmp, mountPath: /tmp}
+      volumes: [{name: tmp, emptyDir: {}}]
+  volumeClaimTemplates:
+    - metadata: {name: data}
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources: {requests: {storage: 1Gi}}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: rabbitmq}
+spec:
+  selector: {app.kubernetes.io/name: rabbitmq}
+  ports:
+    - {name: amqp, port: 5672, targetPort: amqp}
+    - {name: management, port: 15672, targetPort: management}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: {name: minio}
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels: {app.kubernetes.io/name: minio}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: minio, projecty.io/tier: data}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: minio
+          image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+          args: ["server", "/data", "--console-address", ":9001"]
+          envFrom: [{secretRef: {name: projecty-runtime}}]
+          ports:
+            - {name: api, containerPort: 9000}
+            - {name: console, containerPort: 9001}
+          readinessProbe: {httpGet: {path: /minio/health/ready, port: api}, periodSeconds: 5}
+          livenessProbe: {httpGet: {path: /minio/health/live, port: api}, periodSeconds: 10}
+          resources:
+            requests: {cpu: 100m, memory: 128Mi}
+            limits: {cpu: "1", memory: 512Mi}
+          securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
+          volumeMounts:
+            - {name: data, mountPath: /data}
+            - {name: tmp, mountPath: /tmp}
+      volumes: [{name: tmp, emptyDir: {}}]
+  volumeClaimTemplates:
+    - metadata: {name: data}
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources: {requests: {storage: 2Gi}}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: minio}
+spec:
+  selector: {app.kubernetes.io/name: minio}
+  ports:
+    - {name: api, port: 9000, targetPort: api}
+    - {name: console, port: 9001, targetPort: console}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: {name: kafka}
+spec:
+  serviceName: kafka
+  replicas: 1
+  selector:
+    matchLabels: {app.kubernetes.io/name: kafka}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: kafka, projecty.io/tier: data}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: kafka
+          image: apache/kafka:4.3.1
+          envFrom: [{configMapRef: {name: kafka-runtime}}]
+          ports:
+            - {name: broker, containerPort: 9092}
+            - {name: controller, containerPort: 9093}
+          readinessProbe: {tcpSocket: {port: broker}, periodSeconds: 10, failureThreshold: 20}
+          livenessProbe: {tcpSocket: {port: broker}, periodSeconds: 20}
+          resources:
+            requests: {cpu: 250m, memory: 512Mi}
+            limits: {cpu: "2", memory: 1536Mi}
+          securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
+          volumeMounts:
+            - {name: data, mountPath: /var/lib/kafka/data}
+            - {name: tmp, mountPath: /tmp}
+      volumes: [{name: tmp, emptyDir: {}}]
+  volumeClaimTemplates:
+    - metadata: {name: data}
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources: {requests: {storage: 2Gi}}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: kafka}
+spec:
+  selector: {app.kubernetes.io/name: kafka}
+  ports:
+    - {name: broker, port: 9092, targetPort: broker}
+    - {name: controller, port: 9093, targetPort: controller}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: {name: cassandra}
+spec:
+  serviceName: cassandra
+  replicas: 1
+  selector:
+    matchLabels: {app.kubernetes.io/name: cassandra}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: cassandra, projecty.io/tier: data}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: cassandra
+          image: cassandra:5.0
+          env:
+            - {name: MAX_HEAP_SIZE, value: 1G}
+            - {name: HEAP_NEWSIZE, value: 128M}
+          ports: [{name: cql, containerPort: 9042}]
+          readinessProbe: {tcpSocket: {port: cql}, periodSeconds: 15, failureThreshold: 20}
+          livenessProbe: {tcpSocket: {port: cql}, periodSeconds: 30}
+          resources:
+            requests: {cpu: 250m, memory: 1Gi}
+            limits: {cpu: "2", memory: 2Gi}
+          securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
+          volumeMounts:
+            - {name: data, mountPath: /var/lib/cassandra}
+            - {name: tmp, mountPath: /tmp}
+      volumes: [{name: tmp, emptyDir: {}}]
+  volumeClaimTemplates:
+    - metadata: {name: data}
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources: {requests: {storage: 2Gi}}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: cassandra}
+spec:
+  selector: {app.kubernetes.io/name: cassandra}
+  ports: [{name: cql, port: 9042, targetPort: cql}]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: schema-registry}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app.kubernetes.io/name: schema-registry}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: schema-registry, projecty.io/tier: data}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: schema-registry
+          image: quay.io/apicurio/apicurio-registry:3.3.3
+          env:
+            - {name: APICURIO_STORAGE_KIND, value: kafkasql}
+            - {name: APICURIO_KAFKASQL_BOOTSTRAP_SERVERS, value: kafka:9092}
+          ports:
+            - {name: api, containerPort: 8080}
+            - {name: health, containerPort: 9000}
+          readinessProbe: {httpGet: {path: /health/ready, port: health}, periodSeconds: 5, failureThreshold: 30}
+          livenessProbe: {httpGet: {path: /health/live, port: health}, periodSeconds: 10}
+          resources:
+            requests: {cpu: 100m, memory: 256Mi}
+            limits: {cpu: "1", memory: 1Gi}
+          securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
+          volumeMounts: [{name: tmp, mountPath: /tmp}]
+      volumes: [{name: tmp, emptyDir: {}}]
+---
+apiVersion: v1
+kind: Service
+metadata: {name: schema-registry}
+spec:
+  selector: {app.kubernetes.io/name: schema-registry}
+  ports:
+    - {name: api, port: 8080, targetPort: api}
+    - {name: health, port: 9000, targetPort: health}

--- a/deploy/base/infrastructure.yaml
+++ b/deploy/base/infrastructure.yaml
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: cockroachdb, projecty.io/tier: data}
     spec:
+      serviceAccountName: cockroachdb
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -68,6 +70,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: redis, projecty.io/tier: data}
     spec:
+      serviceAccountName: redis
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 999
@@ -114,6 +118,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: rabbitmq, projecty.io/tier: data}
     spec:
+      serviceAccountName: rabbitmq
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 999
@@ -125,7 +131,7 @@ spec:
           image: rabbitmq:4-management
           envFrom:
             - configMapRef: {name: rabbitmq-runtime}
-            - secretRef: {name: projecty-runtime}
+            - secretRef: {name: rabbitmq-secrets}
           ports:
             - {name: amqp, containerPort: 5672}
             - {name: management, containerPort: 15672}
@@ -166,6 +172,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: minio, projecty.io/tier: data}
     spec:
+      serviceAccountName: minio
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -176,7 +184,7 @@ spec:
         - name: minio
           image: minio/minio:RELEASE.2025-04-22T22-12-26Z
           args: ["server", "/data", "--console-address", ":9001"]
-          envFrom: [{secretRef: {name: projecty-runtime}}]
+          envFrom: [{secretRef: {name: minio-secrets}}]
           ports:
             - {name: api, containerPort: 9000}
             - {name: console, containerPort: 9001}
@@ -217,6 +225,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: kafka, projecty.io/tier: data}
     spec:
+      serviceAccountName: kafka
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -267,6 +277,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: cassandra, projecty.io/tier: data}
     spec:
+      serviceAccountName: cassandra
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 999
@@ -314,6 +326,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: schema-registry, projecty.io/tier: data}
     spec:
+      serviceAccountName: schema-registry
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         seccompProfile: {type: RuntimeDefault}

--- a/deploy/base/ingress.yaml
+++ b/deploy/base/ingress.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: projecty
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 32m
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service: {name: api-gateway, port: {name: http}}
+          - path: /.well-known
+            pathType: Prefix
+            backend:
+              service: {name: api-gateway, port: {name: http}}
+          - path: /health
+            pathType: Prefix
+            backend:
+              service: {name: api-gateway, port: {name: http}}
+          - path: /socket
+            pathType: Prefix
+            backend:
+              service: {name: telemetry, port: {name: http}}
+          - path: /
+            pathType: Prefix
+            backend:
+              service: {name: console, port: {name: http}}

--- a/deploy/base/initialization.yaml
+++ b/deploy/base/initialization.yaml
@@ -7,6 +7,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: cockroach-schema, projecty.io/tier: setup}
     spec:
+      serviceAccountName: cockroach-schema
+      automountServiceAccountToken: false
       restartPolicy: OnFailure
       securityContext:
         runAsNonRoot: true
@@ -33,6 +35,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: kafka-topics, projecty.io/tier: setup}
     spec:
+      serviceAccountName: kafka-topics
+      automountServiceAccountToken: false
       restartPolicy: OnFailure
       securityContext:
         runAsNonRoot: true
@@ -58,6 +62,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: cassandra-schema, projecty.io/tier: setup}
     spec:
+      serviceAccountName: cassandra-schema
+      automountServiceAccountToken: false
       restartPolicy: OnFailure
       securityContext:
         runAsNonRoot: true
@@ -83,6 +89,8 @@ spec:
     metadata:
       labels: {app.kubernetes.io/name: schema-contracts, projecty.io/tier: setup}
     spec:
+      serviceAccountName: schema-contracts
+      automountServiceAccountToken: false
       restartPolicy: OnFailure
       securityContext:
         runAsNonRoot: true

--- a/deploy/base/initialization.yaml
+++ b/deploy/base/initialization.yaml
@@ -1,0 +1,101 @@
+apiVersion: batch/v1
+kind: Job
+metadata: {name: cockroach-schema}
+spec:
+  backoffLimit: 12
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: cockroach-schema, projecty.io/tier: setup}
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: schema
+          image: projecty/cockroach-schema:dev
+          env: [{name: COCKROACH_HOST, value: cockroachdb:26257}]
+          resources:
+            requests: {cpu: 25m, memory: 32Mi}
+            limits: {cpu: 250m, memory: 128Mi}
+          securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}, readOnlyRootFilesystem: true}
+          volumeMounts: [{name: tmp, mountPath: /tmp}]
+      volumes: [{name: tmp, emptyDir: {}}]
+---
+apiVersion: batch/v1
+kind: Job
+metadata: {name: kafka-topics}
+spec:
+  backoffLimit: 12
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: kafka-topics, projecty.io/tier: setup}
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: topics
+          image: projecty/kafka-init:dev
+          resources:
+            requests: {cpu: 25m, memory: 64Mi}
+            limits: {cpu: 250m, memory: 256Mi}
+          securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}, readOnlyRootFilesystem: true}
+          volumeMounts: [{name: tmp, mountPath: /tmp}]
+      volumes: [{name: tmp, emptyDir: {}}]
+---
+apiVersion: batch/v1
+kind: Job
+metadata: {name: cassandra-schema}
+spec:
+  backoffLimit: 12
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: cassandra-schema, projecty.io/tier: setup}
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: schema
+          image: projecty/cassandra-init:dev
+          resources:
+            requests: {cpu: 25m, memory: 64Mi}
+            limits: {cpu: 250m, memory: 256Mi}
+          securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}, readOnlyRootFilesystem: true}
+          volumeMounts: [{name: tmp, mountPath: /tmp}]
+      volumes: [{name: tmp, emptyDir: {}}]
+---
+apiVersion: batch/v1
+kind: Job
+metadata: {name: schema-contracts}
+spec:
+  backoffLimit: 12
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: schema-contracts, projecty.io/tier: setup}
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: contracts
+          image: projecty/schema-init:dev
+          env: [{name: SCHEMA_REGISTRY_URL, value: http://schema-registry:8080/apis/ccompat/v7}]
+          resources:
+            requests: {cpu: 25m, memory: 32Mi}
+            limits: {cpu: 250m, memory: 128Mi}
+          securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}, readOnlyRootFilesystem: true}
+          volumeMounts: [{name: tmp, mountPath: /tmp}]
+      volumes: [{name: tmp, emptyDir: {}}]

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: projecty
+resources:
+  - namespace.yaml
+  - configuration.yaml
+  - infrastructure.yaml
+  - initialization.yaml
+  - applications.yaml
+  - ingress.yaml
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: projecty

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -3,7 +3,10 @@ kind: Kustomization
 namespace: projecty
 resources:
   - namespace.yaml
+  - serviceaccounts.yaml
+  - external-secrets.yaml
   - configuration.yaml
+  - network-policies.yaml
   - infrastructure.yaml
   - initialization.yaml
   - applications.yaml

--- a/deploy/base/namespace.yaml
+++ b/deploy/base/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: projecty
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/deploy/base/network-policies.yaml
+++ b/deploy/base/network-policies.yaml
@@ -1,0 +1,307 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: default-deny}
+spec:
+  podSelector: {}
+  policyTypes: [Ingress, Egress]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: allow-dns}
+spec:
+  podSelector: {}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels: {kubernetes.io/metadata.name: kube-system}
+          podSelector:
+            matchLabels: {k8s-app: kube-dns}
+      ports:
+        - {protocol: UDP, port: 53}
+        - {protocol: TCP, port: 53}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: ingress-only-reaches-edge}
+spec:
+  podSelector:
+    matchLabels: {projecty.io/tier: edge}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels: {kubernetes.io/metadata.name: ingress-nginx}
+      ports:
+        - {protocol: TCP, port: 8090}
+        - {protocol: TCP, port: 3001}
+        - {protocol: TCP, port: 4000}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: gateway-to-owned-dependencies}
+spec:
+  podSelector:
+    matchLabels: {app.kubernetes.io/name: api-gateway}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - podSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values: [identity, rental-core, billing]
+      ports:
+        - {protocol: TCP, port: 8095}
+        - {protocol: TCP, port: 8200}
+        - {protocol: TCP, port: 8094}
+    - to: [{podSelector: {matchLabels: {app.kubernetes.io/name: redis}}}]
+      ports: [{protocol: TCP, port: 6379}]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: console-to-gateway}
+spec:
+  podSelector:
+    matchLabels: {app.kubernetes.io/name: console}
+  policyTypes: [Egress]
+  egress:
+    - to: [{podSelector: {matchLabels: {app.kubernetes.io/name: api-gateway}}}]
+      ports: [{protocol: TCP, port: 8090}]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: gateway-to-service-ingress}
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values: [identity, rental-core, billing]
+  policyTypes: [Ingress]
+  ingress:
+    - from: [{podSelector: {matchLabels: {app.kubernetes.io/name: api-gateway}}}]
+      ports:
+        - {protocol: TCP, port: 8095}
+        - {protocol: TCP, port: 8200}
+        - {protocol: TCP, port: 8094}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: identity-to-owned-dependencies}
+spec:
+  podSelector: {matchLabels: {app.kubernetes.io/name: identity}}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - podSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values: [cockroachdb, minio, media-guard, kafka, schema-registry]
+      ports:
+        - {protocol: TCP, port: 26257}
+        - {protocol: TCP, port: 9000}
+        - {protocol: TCP, port: 8092}
+        - {protocol: TCP, port: 9092}
+        - {protocol: TCP, port: 8080}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: identity-to-media-guard}
+spec:
+  podSelector: {matchLabels: {app.kubernetes.io/name: media-guard}}
+  policyTypes: [Ingress]
+  ingress:
+    - from: [{podSelector: {matchLabels: {app.kubernetes.io/name: identity}}}]
+      ports: [{protocol: TCP, port: 8092}]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: rental-core-to-owned-dependencies}
+spec:
+  podSelector: {matchLabels: {app.kubernetes.io/name: rental-core}}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - podSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values: [cockroachdb, rabbitmq, redis, kafka, schema-registry]
+      ports:
+        - {protocol: TCP, port: 26257}
+        - {protocol: TCP, port: 5672}
+        - {protocol: TCP, port: 6379}
+        - {protocol: TCP, port: 9092}
+        - {protocol: TCP, port: 8080}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: billing-to-owned-dependencies}
+spec:
+  podSelector: {matchLabels: {app.kubernetes.io/name: billing}}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - podSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values: [cockroachdb, kafka, schema-registry]
+      ports:
+        - {protocol: TCP, port: 26257}
+        - {protocol: TCP, port: 9092}
+        - {protocol: TCP, port: 8080}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: risk-pricing-to-owned-dependencies}
+spec:
+  podSelector: {matchLabels: {app.kubernetes.io/name: risk-pricing}}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - podSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values: [kafka, schema-registry, minio]
+      ports:
+        - {protocol: TCP, port: 9092}
+        - {protocol: TCP, port: 8080}
+        - {protocol: TCP, port: 9000}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: telemetry-to-owned-dependencies}
+spec:
+  podSelector: {matchLabels: {app.kubernetes.io/name: telemetry}}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - podSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values: [kafka, redis, cassandra]
+      ports:
+        - {protocol: TCP, port: 9092}
+        - {protocol: TCP, port: 6379}
+        - {protocol: TCP, port: 9042}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: cockroachdb-owners}
+spec:
+  podSelector: {matchLabels: {app.kubernetes.io/name: cockroachdb}}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchExpressions:
+              - {key: app.kubernetes.io/name, operator: In, values: [identity, rental-core, billing, cockroach-schema]}
+      ports: [{protocol: TCP, port: 26257}]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: rabbitmq-owner}
+spec:
+  podSelector: {matchLabels: {app.kubernetes.io/name: rabbitmq}}
+  policyTypes: [Ingress]
+  ingress:
+    - from: [{podSelector: {matchLabels: {app.kubernetes.io/name: rental-core}}}]
+      ports: [{protocol: TCP, port: 5672}]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: redis-owners}
+spec:
+  podSelector: {matchLabels: {app.kubernetes.io/name: redis}}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchExpressions:
+              - {key: app.kubernetes.io/name, operator: In, values: [api-gateway, rental-core, telemetry]}
+      ports: [{protocol: TCP, port: 6379}]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: minio-owners}
+spec:
+  podSelector: {matchLabels: {app.kubernetes.io/name: minio}}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchExpressions:
+              - {key: app.kubernetes.io/name, operator: In, values: [identity, risk-pricing]}
+      ports: [{protocol: TCP, port: 9000}]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: kafka-clients}
+spec:
+  podSelector: {matchLabels: {app.kubernetes.io/name: kafka}}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchExpressions:
+              - {key: app.kubernetes.io/name, operator: In, values: [identity, rental-core, billing, risk-pricing, telemetry, schema-registry, kafka-topics]}
+      ports: [{protocol: TCP, port: 9092}]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: cassandra-clients}
+spec:
+  podSelector: {matchLabels: {app.kubernetes.io/name: cassandra}}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchExpressions:
+              - {key: app.kubernetes.io/name, operator: In, values: [telemetry, cassandra-schema]}
+      ports: [{protocol: TCP, port: 9042}]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: schema-registry-clients}
+spec:
+  podSelector: {matchLabels: {app.kubernetes.io/name: schema-registry}}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchExpressions:
+              - {key: app.kubernetes.io/name, operator: In, values: [identity, rental-core, billing, risk-pricing, schema-contracts]}
+      ports: [{protocol: TCP, port: 8080}]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: data-service-egress}
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values: [schema-registry]
+  policyTypes: [Egress]
+  egress:
+    - to: [{podSelector: {matchLabels: {app.kubernetes.io/name: kafka}}}]
+      ports: [{protocol: TCP, port: 9092}]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: {name: setup-to-data}
+spec:
+  podSelector: {matchLabels: {projecty.io/tier: setup}}
+  policyTypes: [Egress]
+  egress:
+    - to: [{podSelector: {matchLabels: {projecty.io/tier: data}}}]
+      ports:
+        - {protocol: TCP, port: 26257}
+        - {protocol: TCP, port: 9092}
+        - {protocol: TCP, port: 9042}
+        - {protocol: TCP, port: 8080}

--- a/deploy/base/serviceaccounts.yaml
+++ b/deploy/base/serviceaccounts.yaml
@@ -1,0 +1,99 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: api-gateway}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: identity}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: rental-core}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: media-guard}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: billing}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: risk-pricing}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: telemetry}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: console}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: cockroachdb}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: redis}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: rabbitmq}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: minio}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: kafka}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: cassandra}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: schema-registry}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: cockroach-schema}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: kafka-topics}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: cassandra-schema}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: schema-contracts}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: external-secrets-reader}
+automountServiceAccountToken: false

--- a/deploy/db/Dockerfile
+++ b/deploy/db/Dockerfile
@@ -1,0 +1,5 @@
+FROM cockroachdb/cockroach:v26.3.1
+COPY sql /sql
+COPY run-schema.sh /run-schema.sh
+USER 65532:65532
+ENTRYPOINT ["/bin/bash", "/run-schema.sh"]

--- a/deploy/db/cassandra/Dockerfile
+++ b/deploy/db/cassandra/Dockerfile
@@ -1,0 +1,4 @@
+FROM cassandra:5.0
+COPY 001_init.cql /schema/001_init.cql
+USER 999:999
+ENTRYPOINT ["cqlsh", "cassandra", "-f", "/schema/001_init.cql"]

--- a/deploy/db/run-schema.sh
+++ b/deploy/db/run-schema.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+host="${COCKROACH_HOST:-cockroachdb:26257}"
+until cockroach sql --insecure --host="$host" --execute 'SELECT 1' >/dev/null 2>&1; do
+  sleep 2
+done
+
+cockroach sql --insecure --host="$host" --file=/sql/000_bootstrap.cockroach.sql
+for file in /sql/0[0-9][0-9]_*.sql; do
+  case "$file" in */000_bootstrap.*) continue ;; esac
+  cockroach sql --insecure --host="$host" --database=projecty --file="$file"
+done

--- a/deploy/kafka/Dockerfile
+++ b/deploy/kafka/Dockerfile
@@ -1,0 +1,5 @@
+FROM apache/kafka:4.3.1
+COPY topics.txt /topics.txt
+COPY create-topics.sh /create-topics.sh
+USER 1000:1000
+ENTRYPOINT ["/bin/bash", "/create-topics.sh"]

--- a/deploy/kafka/create-topics.sh
+++ b/deploy/kafka/create-topics.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+until /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server kafka:9092 >/dev/null 2>&1; do
+  sleep 2
+done
+
+while IFS= read -r topic; do
+  [[ -z "$topic" || "$topic" == \#* ]] && continue
+  /opt/kafka/bin/kafka-topics.sh \
+    --bootstrap-server kafka:9092 \
+    --create --if-not-exists \
+    --topic "$topic" \
+    --partitions 3 \
+    --replication-factor 1 \
+    --config retention.ms=604800000
+done < <(tr -d '\r' < /topics.txt)

--- a/deploy/kind/cluster.yaml
+++ b/deploy/kind/cluster.yaml
@@ -1,0 +1,23 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: projecty
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 8080
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 8443
+        protocol: TCP
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
+      endpoint = ["http://projecty-registry:5000"]

--- a/deploy/kind/cluster.yaml
+++ b/deploy/kind/cluster.yaml
@@ -1,6 +1,9 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: projecty
+networking:
+  disableDefaultCNI: true
+  podSubnet: 192.168.0.0/16
 nodes:
   - role: control-plane
     image: kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5

--- a/deploy/overlays/aws/aws-secret-store.yaml
+++ b/deploy/overlays/aws/aws-secret-store.yaml
@@ -1,0 +1,12 @@
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata: {name: projecty-secrets, namespace: projecty}
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: us-east-1
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: external-secrets-reader

--- a/deploy/overlays/aws/kustomization.yaml
+++ b/deploy/overlays/aws/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - aws-secret-store.yaml
 patches:
   - path: production-shape.yaml

--- a/deploy/overlays/aws/kustomization.yaml
+++ b/deploy/overlays/aws/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patches:
+  - path: production-shape.yaml

--- a/deploy/overlays/aws/production-shape.yaml
+++ b/deploy/overlays/aws/production-shape.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: api-gateway}
+spec:
+  replicas: 2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: console}
+spec:
+  replicas: 2

--- a/deploy/overlays/selfhost/kustomization.yaml
+++ b/deploy/overlays/selfhost/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - local-secret-store.yaml
 patches:
   - path: local-public-urls.yaml

--- a/deploy/overlays/selfhost/kustomization.yaml
+++ b/deploy/overlays/selfhost/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patches:
+  - path: local-public-urls.yaml

--- a/deploy/overlays/selfhost/local-public-urls.yaml
+++ b/deploy/overlays/selfhost/local-public-urls.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: projecty-runtime
+data:
+  CONSOLE_ORIGIN: http://localhost:8080
+  TELEMETRY_PUBLIC_URL: ws://localhost:8080/socket/websocket
+  TELEMETRY_ORIGINS: //localhost:8080

--- a/deploy/overlays/selfhost/local-secret-store.yaml
+++ b/deploy/overlays/selfhost/local-secret-store.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Namespace
+metadata: {name: projecty-secrets}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: {name: projecty-secret-reader, namespace: projecty-secrets}
+rules:
+  - apiGroups: [""]
+    resources: [secrets]
+    resourceNames: [projecty-runtime-source]
+    verbs: [get]
+  - apiGroups: [authorization.k8s.io]
+    resources: [selfsubjectrulesreviews]
+    verbs: [create]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: {name: projecty-secret-reader, namespace: projecty-secrets}
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets-reader
+    namespace: projecty
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: projecty-secret-reader
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata: {name: projecty-secrets, namespace: projecty}
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: projecty-secrets
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: external-secrets-reader

--- a/deploy/platform/kyverno/kustomization.yaml
+++ b/deploy/platform/kyverno/kustomization.yaml
@@ -4,14 +4,14 @@ resources:
   - policy.yaml
 patches:
   - target:
-      group: kyverno.io
+      group: policies.kyverno.io
       version: v1
-      kind: ClusterPolicy
+      kind: NamespacedImageValidatingPolicy
       name: verify-projecty-images
     patch: |-
       - op: replace
-        path: /spec/rules/0/verifyImages/0/failureAction
-        value: Enforce
+        path: /spec/validationActions/0
+        value: Deny
       - op: replace
-        path: /spec/rules/0/verifyImages/0/mutateDigest
+        path: /spec/validationConfigurations/mutateDigest
         value: true

--- a/deploy/platform/kyverno/kustomization.yaml
+++ b/deploy/platform/kyverno/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - policy.yaml
+patches:
+  - target:
+      group: kyverno.io
+      version: v1
+      kind: ClusterPolicy
+      name: verify-projecty-images
+    patch: |-
+      - op: replace
+        path: /spec/rules/0/verifyImages/0/failureAction
+        value: Enforce

--- a/deploy/platform/kyverno/kustomization.yaml
+++ b/deploy/platform/kyverno/kustomization.yaml
@@ -12,3 +12,6 @@ patches:
       - op: replace
         path: /spec/rules/0/verifyImages/0/failureAction
         value: Enforce
+      - op: replace
+        path: /spec/rules/0/verifyImages/0/mutateDigest
+        value: true

--- a/deploy/platform/kyverno/kustomization.yaml
+++ b/deploy/platform/kyverno/kustomization.yaml
@@ -5,8 +5,8 @@ resources:
 patches:
   - target:
       group: policies.kyverno.io
-      version: v1
-      kind: NamespacedImageValidatingPolicy
+      version: v1beta1
+      kind: ImageValidatingPolicy
       name: verify-projecty-images
     patch: |-
       - op: replace

--- a/deploy/platform/kyverno/policy.yaml
+++ b/deploy/platform/kyverno/policy.yaml
@@ -1,0 +1,35 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-projecty-images
+  annotations:
+    policies.kyverno.io/title: Verify ProjectY Images
+    policies.kyverno.io/category: Software Supply Chain
+    projecty.io/rollout: audit-first
+spec:
+  background: false
+  webhookConfiguration:
+    failurePolicy: Fail
+    timeoutSeconds: 30
+  rules:
+    - name: signed-by-projecty-main
+      match:
+        any:
+          - resources:
+              kinds: [Pod]
+              namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: projecty
+      verifyImages:
+        - imageReferences:
+            - ghcr.io/ivega123/projecty/*
+          failureAction: Audit
+          mutateDigest: true
+          required: true
+          verifyDigest: true
+          attestors:
+            - count: 1
+              entries:
+                - keyless:
+                    subject: https://github.com/iVega123/ProjectY/.github/workflows/ci.yml@refs/heads/main
+                    issuer: https://token.actions.githubusercontent.com

--- a/deploy/platform/kyverno/policy.yaml
+++ b/deploy/platform/kyverno/policy.yaml
@@ -24,7 +24,7 @@ spec:
         - imageReferences:
             - ghcr.io/ivega123/projecty/*
           failureAction: Audit
-          mutateDigest: true
+          mutateDigest: false
           required: true
           verifyDigest: true
           attestors:
@@ -33,3 +33,5 @@ spec:
                 - keyless:
                     subject: https://github.com/iVega123/ProjectY/.github/workflows/ci.yml@refs/heads/main
                     issuer: https://token.actions.githubusercontent.com
+                    rekor:
+                      url: https://rekor.sigstore.dev

--- a/deploy/platform/kyverno/policy.yaml
+++ b/deploy/platform/kyverno/policy.yaml
@@ -27,6 +27,7 @@ spec:
           mutateDigest: false
           required: true
           verifyDigest: true
+          cosignOCI11: true
           attestors:
             - count: 1
               entries:

--- a/deploy/platform/kyverno/policy.yaml
+++ b/deploy/platform/kyverno/policy.yaml
@@ -1,8 +1,7 @@
-apiVersion: policies.kyverno.io/v1
-kind: NamespacedImageValidatingPolicy
+apiVersion: policies.kyverno.io/v1beta1
+kind: ImageValidatingPolicy
 metadata:
   name: verify-projecty-images
-  namespace: projecty
   annotations:
     policies.kyverno.io/title: Verify ProjectY Images
     policies.kyverno.io/category: Software Supply Chain
@@ -21,6 +20,9 @@ spec:
         apiVersions: [v1]
         operations: [CREATE, UPDATE]
         resources: [pods]
+  matchConditions:
+    - name: projecty-namespace
+      expression: object.metadata.namespace == 'projecty'
   matchImageReferences:
     - glob: ghcr.io/ivega123/projecty/*
   attestors:

--- a/deploy/platform/kyverno/policy.yaml
+++ b/deploy/platform/kyverno/policy.yaml
@@ -1,38 +1,43 @@
-apiVersion: kyverno.io/v1
-kind: ClusterPolicy
+apiVersion: policies.kyverno.io/v1
+kind: NamespacedImageValidatingPolicy
 metadata:
   name: verify-projecty-images
+  namespace: projecty
   annotations:
     policies.kyverno.io/title: Verify ProjectY Images
     policies.kyverno.io/category: Software Supply Chain
     projecty.io/rollout: audit-first
 spec:
-  background: false
+  validationActions: [Audit]
+  failurePolicy: Fail
   webhookConfiguration:
-    failurePolicy: Fail
     timeoutSeconds: 30
-  rules:
-    - name: signed-by-projecty-main
-      match:
-        any:
-          - resources:
-              kinds: [Pod]
-              namespaceSelector:
-                matchLabels:
-                  kubernetes.io/metadata.name: projecty
-      verifyImages:
-        - imageReferences:
-            - ghcr.io/ivega123/projecty/*
-          failureAction: Audit
-          mutateDigest: false
-          required: true
-          verifyDigest: true
-          cosignOCI11: true
-          attestors:
-            - count: 1
-              entries:
-                - keyless:
-                    subject: https://github.com/iVega123/ProjectY/.github/workflows/ci.yml@refs/heads/main
-                    issuer: https://token.actions.githubusercontent.com
-                    rekor:
-                      url: https://rekor.sigstore.dev
+  evaluation:
+    background:
+      enabled: false
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ['']
+        apiVersions: [v1]
+        operations: [CREATE, UPDATE]
+        resources: [pods]
+  matchImageReferences:
+    - glob: ghcr.io/ivega123/projecty/*
+  attestors:
+    - name: projectyMain
+      cosign:
+        keyless:
+          identities:
+            - subject: https://github.com/iVega123/ProjectY/.github/workflows/ci.yml@refs/heads/main
+              issuer: https://token.actions.githubusercontent.com
+        ctlog:
+          url: https://rekor.sigstore.dev
+  validations:
+    - expression: >-
+        images.containers.map(image,
+          verifyImageSignatures(image, [attestors.projectyMain])).all(count, count > 0)
+      message: ProjectY images must be signed by the main CI workflow.
+  validationConfigurations:
+    mutateDigest: false
+    required: true
+    verifyDigest: true

--- a/deploy/platform/kyverno/unsigned-canary-policy.yaml
+++ b/deploy/platform/kyverno/unsigned-canary-policy.yaml
@@ -1,0 +1,29 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: projecty-unsigned-canary
+spec:
+  background: false
+  webhookConfiguration:
+    failurePolicy: Fail
+    timeoutSeconds: 30
+  rules:
+    - name: reject-unsigned-canary
+      match:
+        any:
+          - resources:
+              kinds: [Pod]
+              names: [projecty-unsigned-canary]
+              namespaces: [projecty]
+      verifyImages:
+        - imageReferences: [ghcr.io/kyverno/test-verify-image:unsigned]
+          failureAction: Enforce
+          mutateDigest: false
+          required: true
+          verifyDigest: false
+          attestors:
+            - count: 1
+              entries:
+                - keyless:
+                    subject: https://github.com/iVega123/ProjectY/.github/workflows/ci.yml@refs/heads/main
+                    issuer: https://token.actions.githubusercontent.com

--- a/deploy/platform/kyverno/unsigned-canary-policy.yaml
+++ b/deploy/platform/kyverno/unsigned-canary-policy.yaml
@@ -21,6 +21,7 @@ spec:
           mutateDigest: false
           required: true
           verifyDigest: false
+          cosignOCI11: true
           attestors:
             - count: 1
               entries:

--- a/deploy/platform/kyverno/unsigned-canary-policy.yaml
+++ b/deploy/platform/kyverno/unsigned-canary-policy.yaml
@@ -1,32 +1,39 @@
-apiVersion: kyverno.io/v1
-kind: ClusterPolicy
+apiVersion: policies.kyverno.io/v1
+kind: NamespacedImageValidatingPolicy
 metadata:
   name: projecty-unsigned-canary
+  namespace: projecty
 spec:
-  background: false
+  validationActions: [Deny]
+  failurePolicy: Fail
   webhookConfiguration:
-    failurePolicy: Fail
     timeoutSeconds: 30
-  rules:
-    - name: reject-unsigned-canary
-      match:
-        any:
-          - resources:
-              kinds: [Pod]
-              names: [projecty-unsigned-canary]
-              namespaces: [projecty]
-      verifyImages:
-        - imageReferences: [ghcr.io/kyverno/test-verify-image:unsigned]
-          failureAction: Enforce
-          mutateDigest: false
-          required: true
-          verifyDigest: false
-          cosignOCI11: true
-          attestors:
-            - count: 1
-              entries:
-                - keyless:
-                    subject: https://github.com/iVega123/ProjectY/.github/workflows/ci.yml@refs/heads/main
-                    issuer: https://token.actions.githubusercontent.com
-                    rekor:
-                      url: https://rekor.sigstore.dev
+  evaluation:
+    background:
+      enabled: false
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ['']
+        apiVersions: [v1]
+        operations: [CREATE, UPDATE]
+        resources: [pods]
+  matchImageReferences:
+    - glob: ghcr.io/kyverno/test-verify-image:unsigned
+  attestors:
+    - name: projectyMain
+      cosign:
+        keyless:
+          identities:
+            - subject: https://github.com/iVega123/ProjectY/.github/workflows/ci.yml@refs/heads/main
+              issuer: https://token.actions.githubusercontent.com
+        ctlog:
+          url: https://rekor.sigstore.dev
+  validations:
+    - expression: >-
+        images.containers.map(image,
+          verifyImageSignatures(image, [attestors.projectyMain])).all(count, count > 0)
+      message: The unsigned admission canary must be rejected.
+  validationConfigurations:
+    mutateDigest: false
+    required: true
+    verifyDigest: false

--- a/deploy/platform/kyverno/unsigned-canary-policy.yaml
+++ b/deploy/platform/kyverno/unsigned-canary-policy.yaml
@@ -1,8 +1,7 @@
-apiVersion: policies.kyverno.io/v1
-kind: NamespacedImageValidatingPolicy
+apiVersion: policies.kyverno.io/v1beta1
+kind: ImageValidatingPolicy
 metadata:
   name: projecty-unsigned-canary
-  namespace: projecty
 spec:
   validationActions: [Deny]
   failurePolicy: Fail
@@ -17,6 +16,11 @@ spec:
         apiVersions: [v1]
         operations: [CREATE, UPDATE]
         resources: [pods]
+  matchConditions:
+    - name: projecty-canary
+      expression: >-
+        object.metadata.namespace == 'projecty' &&
+        object.metadata.name == 'projecty-unsigned-canary'
   matchImageReferences:
     - glob: ghcr.io/kyverno/test-verify-image:unsigned
   attestors:

--- a/deploy/platform/kyverno/unsigned-canary-policy.yaml
+++ b/deploy/platform/kyverno/unsigned-canary-policy.yaml
@@ -27,3 +27,5 @@ spec:
                 - keyless:
                     subject: https://github.com/iVega123/ProjectY/.github/workflows/ci.yml@refs/heads/main
                     issuer: https://token.actions.githubusercontent.com
+                    rekor:
+                      url: https://rekor.sigstore.dev

--- a/docs/adr/0011-deployment-variants-as-overlays.md
+++ b/docs/adr/0011-deployment-variants-as-overlays.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Accepted on 2026-08-30.
+Accepted on 2026-08-30; amended on 2026-09-09 when Kubernetes became the
+default local orchestrator.
 
 ## Context
 
@@ -23,8 +24,9 @@ snapshot confuses archival history with active configuration.
 - `deploy/overlays/<variant>/` owns values and mechanics that change by target,
   including build contexts, host ports, bind mounts, restart policy, runtime
   mode, credentials wiring, and provider endpoints.
-- Every runnable deployment selects an overlay. Tilt and manual local commands
-  use `deploy/overlays/selfhost/compose.yaml`, never the base directly.
+- Every runnable deployment selects an overlay. Kubernetes uses the Kustomize
+  overlays under `deploy/overlays`; the legacy Compose path uses
+  `deploy/overlays/selfhost/compose.yaml`. Neither path deploys the base directly.
 - New deployment variants are added as overlays in this tree and delivered by
   short-lived task branches through the normal GitFlow.
 - Branches may be frozen only as immutable article citations. They are not a
@@ -39,5 +41,6 @@ snapshot confuses archival history with active configuration.
   paths.
 - An overlay must be kept valid against the current base in CI; adding a new
   target adds validation, not a permanent merge lane.
-- Compose 2.20 or newer is required because the self-hosted entrypoint uses the
-  top-level `include` element to merge the base and its override.
+- The same Kustomize base renders both self-hosted and AWS shapes, and CI rejects
+  drift in either overlay. Compose 2.20 or newer remains required only for the
+  explicit Compose fallback.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,13 @@ the Compose network.
 - Git
 - Docker Engine or Docker Desktop
 - Docker Compose v2 (`docker compose`)
+- Tilt and PowerShell, for the default Kubernetes development path
 - Every host port listed in the next section must be available
+
+`tilt up` now provisions the Kubernetes environment described in the
+[local Kubernetes runbook](runbooks/local-kubernetes.md). The remaining Compose
+instructions in this document are the audited baseline and can be selected with
+`tilt up -- --orchestrator=compose`.
 
 ## Required host ports
 
@@ -114,10 +120,10 @@ Then start the stack:
 docker compose up --build
 ```
 
-Tilt uses the same Compose model and adds live update for the Rust gateway:
+Tilt can still select the Compose model explicitly during the migration:
 
 ```bash
-tilt up
+tilt up -- --orchestrator=compose
 ```
 
 `cockroach-init` applies `deploy/db/sql` before any application starts, and

--- a/docs/runbooks/local-kubernetes.md
+++ b/docs/runbooks/local-kubernetes.md
@@ -1,0 +1,95 @@
+# Local Kubernetes runbook
+
+`tilt up` is ProjectY's default development entrypoint. It creates a disposable
+single-node kind cluster named `projecty`, connects a local OCI registry, installs
+Calico and ingress-nginx, then deploys the `selfhost` Kustomize overlay. No global
+kind, kubectl or Helm installation is required: verified pinned binaries are kept
+under the ignored `.tools/kubernetes` directory.
+
+## Prerequisites and capacity
+
+- Docker Engine or Docker Desktop with Linux containers
+- Tilt
+- Windows PowerShell 5.1+ or PowerShell 7+
+- Free host ports `5001`, `8080`, `8443` and `10350`
+- Recommended Docker allocation: 8 CPU cores, 16 GiB RAM and 30 GiB free disk
+
+The capacity is an operating recommendation for the complete polyglot topology,
+not a benchmark guarantee. The first start downloads the Kubernetes node,
+platform components and workload images and is therefore network-dependent.
+
+## Start and stop
+
+Generate ignored local credentials and start the environment:
+
+```powershell
+./scripts/New-LocalSecrets.ps1
+tilt up
+```
+
+Open the Tilt UI at <http://localhost:10350>, the console at
+<http://localhost:8080>, or the gateway readiness endpoint at
+<http://localhost:8080/health/ready>.
+
+Stop and delete the cluster, registry and local cluster data with:
+
+```bash
+tilt down
+```
+
+For the temporary Compose migration path, run
+`tilt up -- --orchestrator=compose --full`.
+
+## Security boundaries
+
+The `projecty` namespace enforces the `restricted` Pod Security Standard. Every
+workload has its own ServiceAccount, does not mount its API token by default,
+runs without privilege escalation and drops all Linux capabilities. Calico
+enforces default-deny ingress and egress; explicit policies grant each service
+only its owned dependencies. Only edge-labeled workloads accept ingress traffic.
+
+The local External Secrets provider reads one generated source Secret from the
+separate `projecty-secrets` namespace through a resource-name-scoped Role. Nine
+target Secrets are materialized for the workloads that need them. The committed
+manifests contain references and property names, never secret values. The AWS
+overlay keeps the same ExternalSecret resources and replaces only the SecretStore
+provider with AWS Secrets Manager and workload-identity authentication.
+
+Kyverno first receives the ProjectY image-verification policy in Audit mode and
+is then promoted from the same manifest to Enforce. The policy trusts only the
+keyless certificate identity of `.github/workflows/ci.yml` on `main` for ProjectY
+release images. Local Tilt images use the isolated local registry; the acceptance
+probe separately proves rejection of a deliberately unsigned registry image and
+admission of a pipeline-signed ProjectY image.
+
+## Reproduce the evidence
+
+Static checks need no running cluster:
+
+```powershell
+./scripts/Test-KubernetesManifests.ps1
+```
+
+With `tilt up` running, reproduce the three live acceptance checks:
+
+```powershell
+./scripts/Test-ExternalSecrets.ps1
+./scripts/Test-KubernetesSecurity.ps1
+./scripts/Test-SignedAdmission.ps1
+```
+
+The security test creates temporary listener pods to prove that an identity-labeled
+pod can reach its owned CockroachDB endpoint but cannot connect to Rental Core's
+RabbitMQ endpoint. It also submits an otherwise restricted pod with UID 0 and
+requires admission to reject it. The signed-admission test uses server dry-run,
+so neither canary workload is persisted. CI executes the same sequence in an
+ephemeral kind cluster and uploads the JSON output as `kubernetes-security-<sha>`.
+
+## Troubleshooting
+
+- If Docker is not reachable, start its engine before retrying `tilt up`.
+- If a pinned cluster or CNI setting changes, run `tilt down` before recreating it.
+- If exactly one of `.env` and `.rabbitmq-definitions.json` exists, regenerate the
+  credential set intentionally as described in [getting started](../getting-started.md).
+- `tilt down` is destructive only to the disposable `projecty` kind cluster and
+  `projecty-registry`; persistent local Kubernetes data is not retained.

--- a/scripts/Test-ExternalSecrets.ps1
+++ b/scripts/Test-ExternalSecrets.ps1
@@ -1,0 +1,22 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$tools = & (Join-Path $PSScriptRoot 'kind\Install-ProjectYKubernetesTools.ps1')
+$kubectl = $tools.Kubectl
+$externalSecrets = @(
+    'api-gateway-secrets', 'identity-secrets', 'rental-core-secrets', 'billing-secrets',
+    'risk-pricing-secrets', 'telemetry-secrets', 'console-secrets', 'rabbitmq-secrets', 'minio-secrets'
+)
+
+& $kubectl wait --namespace projecty --for=condition=Ready secretstore/projecty-secrets --timeout=120s | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'The ProjectY SecretStore did not become ready.' }
+
+foreach ($name in $externalSecrets) {
+    & $kubectl wait --namespace projecty --for=condition=Ready "externalsecret/$name" --timeout=120s | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "ExternalSecret $name did not become ready." }
+    & $kubectl get secret $name --namespace projecty -o name | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "ExternalSecret $name did not create its target Secret." }
+}
+
+[ordered]@{secretStore = 'ready'; synchronizedTargets = $externalSecrets.Count} | ConvertTo-Json

--- a/scripts/Test-KubernetesManifests.ps1
+++ b/scripts/Test-KubernetesManifests.ps1
@@ -1,0 +1,44 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$tools = & (Join-Path $PSScriptRoot 'kind\Install-ProjectYKubernetesTools.ps1')
+$kubectl = $tools.Kubectl
+$expectedApplications = @(
+    'api-gateway', 'identity', 'rental-core', 'media-guard',
+    'billing', 'risk-pricing', 'telemetry', 'console'
+)
+
+Push-Location $root
+try {
+    foreach ($overlay in @('selfhost', 'aws')) {
+        $rendered = (& $kubectl kustomize "deploy/overlays/$overlay") -join "`n"
+        if ($LASTEXITCODE -ne 0) { throw "Kustomize failed for $overlay." }
+        if ($rendered -match 'arn:aws') { throw "Cloud resource identifier leaked into $overlay workloads." }
+        if ($rendered -match '(?m)^kind:\s+Secret\s*$') { throw "A plain Secret is committed in $overlay." }
+
+        $documents = [regex]::Split($rendered, '(?m)^---\s*$')
+        $workloads = @($documents | Where-Object { $_ -match '(?m)^kind:\s+(Deployment|StatefulSet|Job)\s*$' })
+        foreach ($workload in $workloads) {
+            $name = [regex]::Match($workload, '(?ms)^metadata:\s*\n\s+name:\s*([^\s]+)').Groups[1].Value
+            if ($workload -notmatch '(?m)^\s+requests:\s*') { throw "$overlay/$name has no resource requests." }
+            if ($workload -notmatch '(?m)^\s+limits:\s*') { throw "$overlay/$name has no resource limits." }
+            if ($workload -notmatch 'runAsNonRoot:\s+true') { throw "$overlay/$name is not declared non-root." }
+            if ($workload -notmatch 'allowPrivilegeEscalation:\s+false') { throw "$overlay/$name allows privilege escalation." }
+        }
+
+        foreach ($application in $expectedApplications) {
+            $escaped = [regex]::Escape($application)
+            if ($rendered -notmatch "(?ms)^kind: Deployment.*?^metadata:.*?name: $escaped(?:\s|$)") {
+                throw "$overlay is missing the $application Deployment."
+            }
+            if ($rendered -notmatch "(?ms)^kind: Service.*?^metadata:.*?name: $escaped(?:\s|$)") {
+                throw "$overlay is missing the $application Service."
+            }
+        }
+        Write-Host "PASS: $overlay renders $($workloads.Count) bounded, non-root workloads"
+    }
+} finally {
+    Pop-Location
+}

--- a/scripts/Test-KubernetesManifests.ps1
+++ b/scripts/Test-KubernetesManifests.ps1
@@ -20,12 +20,37 @@ try {
 
         $documents = [regex]::Split($rendered, '(?m)^---\s*$')
         $workloads = @($documents | Where-Object { $_ -match '(?m)^kind:\s+(Deployment|StatefulSet|Job)\s*$' })
+        if ($workloads.Count -ne 19) { throw "$overlay renders $($workloads.Count) workloads; expected 19." }
+        $serviceAccounts = @($documents | Where-Object { $_ -match '(?m)^kind:\s+ServiceAccount\s*$' } | ForEach-Object {
+            [regex]::Match($_, '(?m)^  name:\s*([^\s]+)').Groups[1].Value
+        })
         foreach ($workload in $workloads) {
-            $name = [regex]::Match($workload, '(?ms)^metadata:\s*\n\s+name:\s*([^\s]+)').Groups[1].Value
+            $name = [regex]::Match($workload, '(?m)^  name:\s*([^\s]+)').Groups[1].Value
             if ($workload -notmatch '(?m)^\s+requests:\s*') { throw "$overlay/$name has no resource requests." }
             if ($workload -notmatch '(?m)^\s+limits:\s*') { throw "$overlay/$name has no resource limits." }
             if ($workload -notmatch 'runAsNonRoot:\s+true') { throw "$overlay/$name is not declared non-root." }
             if ($workload -notmatch 'allowPrivilegeEscalation:\s+false') { throw "$overlay/$name allows privilege escalation." }
+            if ($workload -notmatch '(?ms)capabilities:.*?drop:\s*(?:\[ALL\]|\n\s*-\s*ALL)') { throw "$overlay/$name does not drop all Linux capabilities." }
+            if ($workload -notmatch 'automountServiceAccountToken:\s+false') { throw "$overlay/$name mounts a service-account token by default." }
+            $serviceAccount = [regex]::Match($workload, 'serviceAccountName:\s*([^\s]+)').Groups[1].Value
+            if ([string]::IsNullOrWhiteSpace($serviceAccount) -or $serviceAccounts -notcontains $serviceAccount) {
+                throw "$overlay/$name does not reference a declared ServiceAccount."
+            }
+        }
+
+        $networkPolicies = @($documents | Where-Object { $_ -match '(?m)^kind:\s+NetworkPolicy\s*$' })
+        $externalSecrets = @($documents | Where-Object { $_ -match '(?m)^kind:\s+ExternalSecret\s*$' })
+        if ($networkPolicies.Count -lt 18 -or $rendered -notmatch '(?m)^\s+name:\s+default-deny\s*$') {
+            throw "$overlay does not carry the default-deny and ownership NetworkPolicies."
+        }
+        if ($externalSecrets.Count -ne 9) { throw "$overlay renders $($externalSecrets.Count) ExternalSecrets; expected 9." }
+        if ($rendered -match 'secretRef:\s*\{name:\s*projecty-runtime\}') { throw "$overlay still uses the former shared runtime Secret." }
+        if ($rendered -notmatch 'pod-security\.kubernetes\.io/enforce:\s+restricted') { throw "$overlay does not enforce restricted Pod Security." }
+        if ($overlay -eq 'selfhost' -and $rendered -notmatch '(?ms)^kind:\s+SecretStore.*?provider:\s*\n\s+kubernetes:') {
+            throw 'selfhost does not use the Kubernetes External Secrets provider.'
+        }
+        if ($overlay -eq 'aws' -and $rendered -notmatch '(?ms)^kind:\s+SecretStore.*?provider:\s*\n\s+aws:') {
+            throw 'aws does not use the AWS External Secrets provider.'
         }
 
         foreach ($application in $expectedApplications) {
@@ -37,7 +62,7 @@ try {
                 throw "$overlay is missing the $application Service."
             }
         }
-        Write-Host "PASS: $overlay renders $($workloads.Count) bounded, non-root workloads"
+        Write-Host "PASS: $overlay renders $($workloads.Count) bounded, isolated workloads with external secrets"
     }
 } finally {
     Pop-Location

--- a/scripts/Test-KubernetesSecurity.ps1
+++ b/scripts/Test-KubernetesSecurity.ps1
@@ -1,0 +1,134 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$tools = & (Join-Path $PSScriptRoot 'kind\Install-ProjectYKubernetesTools.ps1')
+$kubectl = $tools.Kubectl
+$probeName = 'network-policy-probe'
+
+$fixtures = @"
+apiVersion: v1
+kind: Service
+metadata: {name: cockroachdb, namespace: projecty}
+spec:
+  selector: {app.kubernetes.io/name: cockroachdb}
+  ports: [{name: sql, port: 26257, targetPort: 26257}]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cockroachdb-policy-fixture
+  namespace: projecty
+  labels: {app.kubernetes.io/name: cockroachdb, projecty.io/tier: data}
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext: {runAsNonRoot: true, runAsUser: 65532, seccompProfile: {type: RuntimeDefault}}
+  containers:
+    - name: listener
+      image: busybox:1.37.0
+      command: [sh, -c, 'while true; do nc -l -p 26257; done']
+      securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
+      resources: {requests: {cpu: 5m, memory: 8Mi}, limits: {cpu: 50m, memory: 32Mi}}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: rabbitmq, namespace: projecty}
+spec:
+  selector: {app.kubernetes.io/name: rabbitmq}
+  ports: [{name: amqp, port: 5672, targetPort: 5672}]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rabbitmq-policy-fixture
+  namespace: projecty
+  labels: {app.kubernetes.io/name: rabbitmq, projecty.io/tier: data}
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext: {runAsNonRoot: true, runAsUser: 65532, seccompProfile: {type: RuntimeDefault}}
+  containers:
+    - name: listener
+      image: busybox:1.37.0
+      command: [sh, -c, 'while true; do nc -l -p 5672; done']
+      securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
+      resources: {requests: {cpu: 5m, memory: 8Mi}, limits: {cpu: 50m, memory: 32Mi}}
+"@
+
+$probe = @"
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $probeName
+  namespace: projecty
+  labels:
+    app.kubernetes.io/name: identity
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    seccompProfile: {type: RuntimeDefault}
+  containers:
+    - name: probe
+      image: busybox:1.37.0
+      command: [sh, -c, 'sleep 600']
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities: {drop: [ALL]}
+      resources:
+        requests: {cpu: 5m, memory: 8Mi}
+        limits: {cpu: 50m, memory: 32Mi}
+"@
+
+$rootPod = @"
+apiVersion: v1
+kind: Pod
+metadata:
+  name: forbidden-root-probe
+  namespace: projecty
+spec:
+  automountServiceAccountToken: false
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile: {type: RuntimeDefault}
+  containers:
+    - name: probe
+      image: busybox:1.37.0
+      securityContext: {runAsUser: 0, allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
+"@
+
+try {
+    $rootResult = $rootPod | & $kubectl apply --server-side --dry-run=server -f - 2>&1
+    if ($LASTEXITCODE -eq 0) { throw 'Pod Security admitted a container explicitly running as root.' }
+    if (($rootResult -join "`n") -notmatch 'PodSecurity|runAsUser|non-root') {
+        throw "The root probe failed for an unrelated reason: $($rootResult -join ' ')"
+    }
+
+    $fixtures | & $kubectl apply -f - | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw 'Could not create the NetworkPolicy fixtures.' }
+    & $kubectl wait --namespace projecty --for=condition=Ready pod/cockroachdb-policy-fixture pod/rabbitmq-policy-fixture --timeout=90s | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw 'The NetworkPolicy fixtures did not become ready.' }
+
+    $probe | & $kubectl apply -f - | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw 'Could not create the network-policy probe.' }
+    & $kubectl wait --namespace projecty --for=condition=Ready "pod/$probeName" --timeout=90s | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw 'The network-policy probe did not become ready.' }
+
+    & $kubectl exec --namespace projecty $probeName -- nc -z -w 5 cockroachdb 26257 | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw 'Identity could not reach its owned CockroachDB dependency.' }
+
+    & $kubectl exec --namespace projecty $probeName -- nc -z -w 5 rabbitmq 5672 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) { throw 'Identity unexpectedly reached Rental Core owned RabbitMQ.' }
+
+    [ordered]@{
+        podSecurityRestricted = 'root pod rejected'
+        ownedDependency = 'cockroachdb:26257 reachable'
+        foreignDependency = 'rabbitmq:5672 denied'
+    } | ConvertTo-Json
+} finally {
+    & $kubectl delete pod $probeName --namespace projecty --ignore-not-found --wait=false | Out-Null
+    $fixtures | & $kubectl delete -f - --ignore-not-found --wait=false | Out-Null
+}

--- a/scripts/Test-SignedAdmission.ps1
+++ b/scripts/Test-SignedAdmission.ps1
@@ -13,7 +13,7 @@ $policy = Join-Path $root 'deploy\platform\kyverno\unsigned-canary-policy.yaml'
 if ($LASTEXITCODE -ne 0) { throw 'Could not install the unsigned-image canary policy.' }
 
 try {
-    & $kubectl wait --namespace projecty --for=condition=Ready namespacedimagevalidatingpolicy/projecty-unsigned-canary --timeout=90s | Out-Null
+    & $kubectl wait --namespace projecty --for=jsonpath='{.status.ready}'=true namespacedimagevalidatingpolicy/projecty-unsigned-canary --timeout=90s | Out-Null
     if ($LASTEXITCODE -ne 0) { throw 'The unsigned-image canary policy did not become ready.' }
 
     $rejection = & $kubectl run projecty-unsigned-canary --namespace projecty --image ghcr.io/kyverno/test-verify-image:unsigned --restart Never --dry-run=server -o yaml 2>&1

--- a/scripts/Test-SignedAdmission.ps1
+++ b/scripts/Test-SignedAdmission.ps1
@@ -13,7 +13,7 @@ $policy = Join-Path $root 'deploy\platform\kyverno\unsigned-canary-policy.yaml'
 if ($LASTEXITCODE -ne 0) { throw 'Could not install the unsigned-image canary policy.' }
 
 try {
-    & $kubectl wait --for=condition=Ready clusterpolicy/projecty-unsigned-canary --timeout=90s | Out-Null
+    & $kubectl wait --namespace projecty --for=condition=Ready namespacedimagevalidatingpolicy/projecty-unsigned-canary --timeout=90s | Out-Null
     if ($LASTEXITCODE -ne 0) { throw 'The unsigned-image canary policy did not become ready.' }
 
     $rejection = & $kubectl run projecty-unsigned-canary --namespace projecty --image ghcr.io/kyverno/test-verify-image:unsigned --restart Never --dry-run=server -o yaml 2>&1

--- a/scripts/Test-SignedAdmission.ps1
+++ b/scripts/Test-SignedAdmission.ps1
@@ -1,0 +1,38 @@
+[CmdletBinding()]
+param(
+    [string]$SignedImage = 'ghcr.io/ivega123/projecty/api-gateway:latest'
+)
+
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$tools = & (Join-Path $PSScriptRoot 'kind\Install-ProjectYKubernetesTools.ps1')
+$kubectl = $tools.Kubectl
+$policy = Join-Path $root 'deploy\platform\kyverno\unsigned-canary-policy.yaml'
+
+& $kubectl apply -f $policy | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'Could not install the unsigned-image canary policy.' }
+
+try {
+    & $kubectl wait --for=condition=Ready clusterpolicy/projecty-unsigned-canary --timeout=90s | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw 'The unsigned-image canary policy did not become ready.' }
+
+    $rejection = & $kubectl run projecty-unsigned-canary --namespace projecty --image ghcr.io/kyverno/test-verify-image:unsigned --restart Never --dry-run=server -o yaml 2>&1
+    if ($LASTEXITCODE -eq 0) { throw 'Kyverno admitted the deliberately unsigned image.' }
+    if (($rejection -join "`n") -notmatch 'projecty-unsigned-canary|signature|verify') {
+        throw "The canary failed for an unrelated reason: $($rejection -join ' ')"
+    }
+
+    $signed = & $kubectl run projecty-signed-canary --namespace projecty --image $SignedImage --restart Never --dry-run=server -o name 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "Kyverno refused the signed pipeline image: $($signed -join ' ')" }
+
+    [pscustomobject]@{
+        observedAt = [DateTimeOffset]::UtcNow.ToString('o')
+        unsignedImage = 'ghcr.io/kyverno/test-verify-image:unsigned'
+        unsignedResult = 'rejected'
+        signedImage = $SignedImage
+        signedResult = 'admitted'
+        policy = 'verify-projecty-images'
+    } | ConvertTo-Json
+} finally {
+    & $kubectl delete -f $policy --ignore-not-found | Out-Null
+}

--- a/scripts/Test-SignedAdmission.ps1
+++ b/scripts/Test-SignedAdmission.ps1
@@ -13,7 +13,7 @@ $policy = Join-Path $root 'deploy\platform\kyverno\unsigned-canary-policy.yaml'
 if ($LASTEXITCODE -ne 0) { throw 'Could not install the unsigned-image canary policy.' }
 
 try {
-    & $kubectl wait --namespace projecty --for=jsonpath='{.status.ready}'=true namespacedimagevalidatingpolicy/projecty-unsigned-canary --timeout=90s | Out-Null
+    & $kubectl wait --for=jsonpath='{.status.ready}'=true imagevalidatingpolicy/projecty-unsigned-canary --timeout=90s | Out-Null
     if ($LASTEXITCODE -ne 0) { throw 'The unsigned-image canary policy did not become ready.' }
 
     $rejection = & $kubectl run projecty-unsigned-canary --namespace projecty --image ghcr.io/kyverno/test-verify-image:unsigned --restart Never --dry-run=server -o yaml 2>&1

--- a/scripts/Test-SignedAdmission.ps1
+++ b/scripts/Test-SignedAdmission.ps1
@@ -13,7 +13,7 @@ $policy = Join-Path $root 'deploy\platform\kyverno\unsigned-canary-policy.yaml'
 if ($LASTEXITCODE -ne 0) { throw 'Could not install the unsigned-image canary policy.' }
 
 try {
-    & $kubectl wait --for=jsonpath='{.status.ready}'=true imagevalidatingpolicy/projecty-unsigned-canary --timeout=90s | Out-Null
+    & $kubectl wait --for=jsonpath='{.status.conditionStatus.ready}'=true imagevalidatingpolicy/projecty-unsigned-canary --timeout=90s | Out-Null
     if ($LASTEXITCODE -ne 0) { throw 'The unsigned-image canary policy did not become ready.' }
 
     $rejection = & $kubectl run projecty-unsigned-canary --namespace projecty --image ghcr.io/kyverno/test-verify-image:unsigned --restart Never --dry-run=server -o yaml 2>&1

--- a/scripts/Test-SignedAdmission.ps1
+++ b/scripts/Test-SignedAdmission.ps1
@@ -55,7 +55,7 @@ try {
 
     $rejection = Test-ImageAdmission -Name projecty-unsigned-canary -Image ghcr.io/kyverno/test-verify-image:unsigned
     if ($rejection.ExitCode -eq 0) { throw 'Kyverno admitted the deliberately unsigned image.' }
-    if (($rejection.Output -join "`n") -notmatch 'signature|verify|imagevalidatingpolicy|must be signed') {
+    if (($rejection.Output -join "`n") -notmatch 'signature|verify|ivpol\.validate\.kyverno|Policy projecty-unsigned-canary failed') {
         throw "The canary failed for an unrelated reason: $($rejection.Output -join ' ')"
     }
 

--- a/scripts/Test-SignedAdmission.ps1
+++ b/scripts/Test-SignedAdmission.ps1
@@ -9,6 +9,43 @@ $tools = & (Join-Path $PSScriptRoot 'kind\Install-ProjectYKubernetesTools.ps1')
 $kubectl = $tools.Kubectl
 $policy = Join-Path $root 'deploy\platform\kyverno\unsigned-canary-policy.yaml'
 
+function Test-ImageAdmission {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [Parameter(Mandatory)]
+        [string]$Image
+    )
+
+    $manifest = @{
+        apiVersion = 'v1'
+        kind = 'Pod'
+        metadata = @{ name = $Name; namespace = 'projecty' }
+        spec = @{
+            automountServiceAccountToken = $false
+            restartPolicy = 'Never'
+            securityContext = @{
+                runAsNonRoot = $true
+                seccompProfile = @{ type = 'RuntimeDefault' }
+            }
+            containers = @(
+                @{
+                    name = $Name
+                    image = $Image
+                    securityContext = @{
+                        allowPrivilegeEscalation = $false
+                        capabilities = @{ drop = @('ALL') }
+                        runAsNonRoot = $true
+                    }
+                }
+            )
+        }
+    } | ConvertTo-Json -Depth 10
+
+    $output = $manifest | & $kubectl create --dry-run=server -f - -o name 2>&1
+    [pscustomobject]@{ ExitCode = $LASTEXITCODE; Output = @($output) }
+}
+
 & $kubectl apply -f $policy | Out-Null
 if ($LASTEXITCODE -ne 0) { throw 'Could not install the unsigned-image canary policy.' }
 
@@ -16,14 +53,14 @@ try {
     & $kubectl wait --for=jsonpath='{.status.conditionStatus.ready}'=true imagevalidatingpolicy/projecty-unsigned-canary --timeout=90s | Out-Null
     if ($LASTEXITCODE -ne 0) { throw 'The unsigned-image canary policy did not become ready.' }
 
-    $rejection = & $kubectl run projecty-unsigned-canary --namespace projecty --image ghcr.io/kyverno/test-verify-image:unsigned --restart Never --dry-run=server -o yaml 2>&1
-    if ($LASTEXITCODE -eq 0) { throw 'Kyverno admitted the deliberately unsigned image.' }
-    if (($rejection -join "`n") -notmatch 'projecty-unsigned-canary|signature|verify') {
-        throw "The canary failed for an unrelated reason: $($rejection -join ' ')"
+    $rejection = Test-ImageAdmission -Name projecty-unsigned-canary -Image ghcr.io/kyverno/test-verify-image:unsigned
+    if ($rejection.ExitCode -eq 0) { throw 'Kyverno admitted the deliberately unsigned image.' }
+    if (($rejection.Output -join "`n") -notmatch 'signature|verify|imagevalidatingpolicy|must be signed') {
+        throw "The canary failed for an unrelated reason: $($rejection.Output -join ' ')"
     }
 
-    $signed = & $kubectl run projecty-signed-canary --namespace projecty --image $SignedImage --restart Never --dry-run=server -o name 2>&1
-    if ($LASTEXITCODE -ne 0) { throw "Kyverno refused the signed pipeline image: $($signed -join ' ')" }
+    $signed = Test-ImageAdmission -Name projecty-signed-canary -Image $SignedImage
+    if ($signed.ExitCode -ne 0) { throw "Kyverno refused the signed pipeline image: $($signed.Output -join ' ')" }
 
     [pscustomobject]@{
         observedAt = [DateTimeOffset]::UtcNow.ToString('o')

--- a/scripts/kind/Ensure-ProjectYCluster.ps1
+++ b/scripts/kind/Ensure-ProjectYCluster.ps1
@@ -1,0 +1,64 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$tools = & (Join-Path $PSScriptRoot 'Install-ProjectYKubernetesTools.ps1')
+$kind = $tools.Kind
+$kubectl = $tools.Kubectl
+$clusterName = 'projecty'
+$context = "kind-$clusterName"
+$registryName = 'projecty-registry'
+$registryPort = 5001
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    throw 'Docker is required for the local kind cluster. Start Docker Desktop and retry `tilt up`.'
+}
+
+& docker info --format '{{.ServerVersion}}' | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'Docker is installed but its engine is not reachable.' }
+
+$registryExists = (& docker inspect -f '{{.State.Running}}' $registryName 2>$null) -eq 'true'
+if (-not $registryExists) {
+    & docker rm -f $registryName 2>$null | Out-Null
+    & docker run --detach --restart=always --name $registryName --publish "127.0.0.1:${registryPort}:5000" registry:3.0.0 | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw 'Could not start the ProjectY local registry.' }
+}
+
+$clusters = @(& $kind get clusters 2>$null)
+if ($clusters -notcontains $clusterName) {
+    & $kind create cluster --name $clusterName --config (Join-Path $root 'deploy\kind\cluster.yaml')
+    if ($LASTEXITCODE -ne 0) { throw 'Could not create the ProjectY kind cluster.' }
+}
+
+$network = & docker inspect -f '{{json .NetworkSettings.Networks.kind}}' $registryName 2>$null
+if (-not $network -or $network -eq '<no value>') {
+    & docker network connect kind $registryName
+    if ($LASTEXITCODE -ne 0) { throw 'Could not attach the local registry to the kind network.' }
+}
+
+& $kubectl config use-context $context | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "Could not select kubectl context $context." }
+
+$registryDiscovery = @"
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:$registryPort"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+"@
+$registryDiscovery | & $kubectl apply -f - | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'Could not publish local registry discovery.' }
+
+$ingressVersion = 'controller-v1.15.1'
+$ingressManifest = "https://raw.githubusercontent.com/kubernetes/ingress-nginx/$ingressVersion/deploy/static/provider/kind/deploy.yaml"
+& $kubectl apply --server-side -f $ingressManifest | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'Could not install ingress-nginx.' }
+& $kubectl wait --namespace ingress-nginx --for=condition=Available deployment/ingress-nginx-controller --timeout=180s
+if ($LASTEXITCODE -ne 0) { throw 'ingress-nginx did not become available.' }
+
+Write-Host "ProjectY cluster ready: $context (registry localhost:$registryPort, ingress http://localhost:8080)"

--- a/scripts/kind/Ensure-ProjectYCluster.ps1
+++ b/scripts/kind/Ensure-ProjectYCluster.ps1
@@ -40,6 +40,15 @@ if (-not $network -or $network -eq '<no value>') {
 & $kubectl config use-context $context | Out-Null
 if ($LASTEXITCODE -ne 0) { throw "Could not select kubectl context $context." }
 
+$calicoVersion = 'v3.32.2'
+$calicoManifest = "https://raw.githubusercontent.com/projectcalico/calico/$calicoVersion/manifests/calico.yaml"
+& $kubectl apply --server-side -f $calicoManifest | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "Could not install Calico $calicoVersion." }
+& $kubectl rollout status --namespace kube-system daemonset/calico-node --timeout=240s
+if ($LASTEXITCODE -ne 0) { throw 'Calico nodes did not become ready.' }
+& $kubectl rollout status --namespace kube-system deployment/calico-kube-controllers --timeout=240s
+if ($LASTEXITCODE -ne 0) { throw 'Calico controllers did not become ready.' }
+
 $registryDiscovery = @"
 apiVersion: v1
 kind: ConfigMap
@@ -61,4 +70,4 @@ if ($LASTEXITCODE -ne 0) { throw 'Could not install ingress-nginx.' }
 & $kubectl wait --namespace ingress-nginx --for=condition=Available deployment/ingress-nginx-controller --timeout=180s
 if ($LASTEXITCODE -ne 0) { throw 'ingress-nginx did not become available.' }
 
-Write-Host "ProjectY cluster ready: $context (registry localhost:$registryPort, ingress http://localhost:8080)"
+Write-Host "ProjectY cluster ready: $context (Calico $calicoVersion, registry localhost:$registryPort, ingress http://localhost:8080)"

--- a/scripts/kind/Install-ExternalSecrets.ps1
+++ b/scripts/kind/Install-ExternalSecrets.ps1
@@ -1,0 +1,15 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$tools = & (Join-Path $PSScriptRoot 'Install-ProjectYKubernetesTools.ps1')
+$helm = $tools.Helm
+$kubectl = $tools.Kubectl
+$chartVersion = '2.10.0'
+
+& $helm upgrade --install external-secrets oci://ghcr.io/external-secrets/charts/external-secrets --version $chartVersion --namespace external-secrets --create-namespace --set installCRDs=true --wait --timeout 5m
+if ($LASTEXITCODE -ne 0) { throw "Could not install External Secrets $chartVersion." }
+
+& $kubectl wait --namespace external-secrets --for=condition=Available deployment/external-secrets --timeout=240s
+if ($LASTEXITCODE -ne 0) { throw 'External Secrets did not become available.' }
+Write-Host "External Secrets $chartVersion ready."

--- a/scripts/kind/Install-Kyverno.ps1
+++ b/scripts/kind/Install-Kyverno.ps1
@@ -15,12 +15,12 @@ if ($LASTEXITCODE -ne 0) { throw 'Kyverno admission controller did not become av
 
 & $kubectl apply -f (Join-Path $root 'deploy\platform\kyverno\policy.yaml') | Out-Null
 if ($LASTEXITCODE -ne 0) { throw 'Could not apply the image policy in audit mode.' }
-& $kubectl wait --for=condition=Ready clusterpolicy/verify-projecty-images --timeout=90s
+& $kubectl wait --namespace projecty --for=condition=Ready namespacedimagevalidatingpolicy/verify-projecty-images --timeout=90s
 if ($LASTEXITCODE -ne 0) { throw 'The audit image policy did not become ready.' }
 
 & $kubectl apply -k (Join-Path $root 'deploy\platform\kyverno') | Out-Null
 if ($LASTEXITCODE -ne 0) { throw 'Could not promote the image policy to enforce mode.' }
-& $kubectl wait --for=condition=Ready clusterpolicy/verify-projecty-images --timeout=90s
+& $kubectl wait --namespace projecty --for=condition=Ready namespacedimagevalidatingpolicy/verify-projecty-images --timeout=90s
 if ($LASTEXITCODE -ne 0) { throw 'The enforced image policy did not become ready.' }
 
 Write-Host "Kyverno $version ready; ProjectY image verification promoted Audit -> Enforce."

--- a/scripts/kind/Install-Kyverno.ps1
+++ b/scripts/kind/Install-Kyverno.ps1
@@ -1,0 +1,26 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$tools = & (Join-Path $PSScriptRoot 'Install-ProjectYKubernetesTools.ps1')
+$kubectl = $tools.Kubectl
+$version = 'v1.19.0'
+$manifest = "https://github.com/kyverno/kyverno/releases/download/$version/install.yaml"
+
+& $kubectl apply --server-side --force-conflicts -f $manifest | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "Could not install Kyverno $version." }
+& $kubectl wait --namespace kyverno --for=condition=Available deployment/kyverno-admission-controller --timeout=240s
+if ($LASTEXITCODE -ne 0) { throw 'Kyverno admission controller did not become available.' }
+
+& $kubectl apply -f (Join-Path $root 'deploy\platform\kyverno\policy.yaml') | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'Could not apply the image policy in audit mode.' }
+& $kubectl wait --for=condition=Ready clusterpolicy/verify-projecty-images --timeout=90s
+if ($LASTEXITCODE -ne 0) { throw 'The audit image policy did not become ready.' }
+
+& $kubectl apply -k (Join-Path $root 'deploy\platform\kyverno') | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'Could not promote the image policy to enforce mode.' }
+& $kubectl wait --for=condition=Ready clusterpolicy/verify-projecty-images --timeout=90s
+if ($LASTEXITCODE -ne 0) { throw 'The enforced image policy did not become ready.' }
+
+Write-Host "Kyverno $version ready; ProjectY image verification promoted Audit -> Enforce."

--- a/scripts/kind/Install-Kyverno.ps1
+++ b/scripts/kind/Install-Kyverno.ps1
@@ -15,12 +15,12 @@ if ($LASTEXITCODE -ne 0) { throw 'Kyverno admission controller did not become av
 
 & $kubectl apply -f (Join-Path $root 'deploy\platform\kyverno\policy.yaml') | Out-Null
 if ($LASTEXITCODE -ne 0) { throw 'Could not apply the image policy in audit mode.' }
-& $kubectl wait --for=jsonpath='{.status.ready}'=true imagevalidatingpolicy/verify-projecty-images --timeout=90s
+& $kubectl wait --for=jsonpath='{.status.conditionStatus.ready}'=true imagevalidatingpolicy/verify-projecty-images --timeout=90s
 if ($LASTEXITCODE -ne 0) { throw 'The audit image policy did not become ready.' }
 
 & $kubectl apply -k (Join-Path $root 'deploy\platform\kyverno') | Out-Null
 if ($LASTEXITCODE -ne 0) { throw 'Could not promote the image policy to enforce mode.' }
-& $kubectl wait --for=jsonpath='{.status.ready}'=true imagevalidatingpolicy/verify-projecty-images --timeout=90s
+& $kubectl wait --for=jsonpath='{.status.conditionStatus.ready}'=true imagevalidatingpolicy/verify-projecty-images --timeout=90s
 if ($LASTEXITCODE -ne 0) { throw 'The enforced image policy did not become ready.' }
 
 Write-Host "Kyverno $version ready; ProjectY image verification promoted Audit -> Enforce."

--- a/scripts/kind/Install-Kyverno.ps1
+++ b/scripts/kind/Install-Kyverno.ps1
@@ -13,13 +13,31 @@ if ($LASTEXITCODE -ne 0) { throw "Could not install Kyverno $version." }
 & $kubectl wait --namespace kyverno --for=condition=Available deployment/kyverno-admission-controller --timeout=240s
 if ($LASTEXITCODE -ne 0) { throw 'Kyverno admission controller did not become available.' }
 
-& $kubectl apply -f (Join-Path $root 'deploy\platform\kyverno\policy.yaml') | Out-Null
-if ($LASTEXITCODE -ne 0) { throw 'Could not apply the image policy in audit mode.' }
+$auditPolicy = Join-Path $root 'deploy\platform\kyverno\policy.yaml'
+$auditApplied = $false
+for ($attempt = 1; $attempt -le 12; $attempt++) {
+    & $kubectl apply -f $auditPolicy | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        $auditApplied = $true
+        break
+    }
+    if ($attempt -lt 12) { Start-Sleep -Seconds 5 }
+}
+if (-not $auditApplied) { throw 'Could not apply the image policy in audit mode.' }
 & $kubectl wait --for=jsonpath='{.status.conditionStatus.ready}'=true imagevalidatingpolicy/verify-projecty-images --timeout=90s
 if ($LASTEXITCODE -ne 0) { throw 'The audit image policy did not become ready.' }
 
-& $kubectl apply -k (Join-Path $root 'deploy\platform\kyverno') | Out-Null
-if ($LASTEXITCODE -ne 0) { throw 'Could not promote the image policy to enforce mode.' }
+$enforcePolicy = Join-Path $root 'deploy\platform\kyverno'
+$enforceApplied = $false
+for ($attempt = 1; $attempt -le 12; $attempt++) {
+    & $kubectl apply -k $enforcePolicy | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        $enforceApplied = $true
+        break
+    }
+    if ($attempt -lt 12) { Start-Sleep -Seconds 5 }
+}
+if (-not $enforceApplied) { throw 'Could not promote the image policy to enforce mode.' }
 & $kubectl wait --for=jsonpath='{.status.conditionStatus.ready}'=true imagevalidatingpolicy/verify-projecty-images --timeout=90s
 if ($LASTEXITCODE -ne 0) { throw 'The enforced image policy did not become ready.' }
 

--- a/scripts/kind/Install-Kyverno.ps1
+++ b/scripts/kind/Install-Kyverno.ps1
@@ -15,12 +15,12 @@ if ($LASTEXITCODE -ne 0) { throw 'Kyverno admission controller did not become av
 
 & $kubectl apply -f (Join-Path $root 'deploy\platform\kyverno\policy.yaml') | Out-Null
 if ($LASTEXITCODE -ne 0) { throw 'Could not apply the image policy in audit mode.' }
-& $kubectl wait --namespace projecty --for=condition=Ready namespacedimagevalidatingpolicy/verify-projecty-images --timeout=90s
+& $kubectl wait --namespace projecty --for=jsonpath='{.status.ready}'=true namespacedimagevalidatingpolicy/verify-projecty-images --timeout=90s
 if ($LASTEXITCODE -ne 0) { throw 'The audit image policy did not become ready.' }
 
 & $kubectl apply -k (Join-Path $root 'deploy\platform\kyverno') | Out-Null
 if ($LASTEXITCODE -ne 0) { throw 'Could not promote the image policy to enforce mode.' }
-& $kubectl wait --namespace projecty --for=condition=Ready namespacedimagevalidatingpolicy/verify-projecty-images --timeout=90s
+& $kubectl wait --namespace projecty --for=jsonpath='{.status.ready}'=true namespacedimagevalidatingpolicy/verify-projecty-images --timeout=90s
 if ($LASTEXITCODE -ne 0) { throw 'The enforced image policy did not become ready.' }
 
 Write-Host "Kyverno $version ready; ProjectY image verification promoted Audit -> Enforce."

--- a/scripts/kind/Install-Kyverno.ps1
+++ b/scripts/kind/Install-Kyverno.ps1
@@ -15,12 +15,12 @@ if ($LASTEXITCODE -ne 0) { throw 'Kyverno admission controller did not become av
 
 & $kubectl apply -f (Join-Path $root 'deploy\platform\kyverno\policy.yaml') | Out-Null
 if ($LASTEXITCODE -ne 0) { throw 'Could not apply the image policy in audit mode.' }
-& $kubectl wait --namespace projecty --for=jsonpath='{.status.ready}'=true namespacedimagevalidatingpolicy/verify-projecty-images --timeout=90s
+& $kubectl wait --for=jsonpath='{.status.ready}'=true imagevalidatingpolicy/verify-projecty-images --timeout=90s
 if ($LASTEXITCODE -ne 0) { throw 'The audit image policy did not become ready.' }
 
 & $kubectl apply -k (Join-Path $root 'deploy\platform\kyverno') | Out-Null
 if ($LASTEXITCODE -ne 0) { throw 'Could not promote the image policy to enforce mode.' }
-& $kubectl wait --namespace projecty --for=jsonpath='{.status.ready}'=true namespacedimagevalidatingpolicy/verify-projecty-images --timeout=90s
+& $kubectl wait --for=jsonpath='{.status.ready}'=true imagevalidatingpolicy/verify-projecty-images --timeout=90s
 if ($LASTEXITCODE -ne 0) { throw 'The enforced image policy did not become ready.' }
 
 Write-Host "Kyverno $version ready; ProjectY image verification promoted Audit -> Enforce."

--- a/scripts/kind/Install-ProjectYKubernetesTools.ps1
+++ b/scripts/kind/Install-ProjectYKubernetesTools.ps1
@@ -1,0 +1,62 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$toolDirectory = Join-Path $root '.tools\kubernetes'
+$isWindowsHost = [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+$architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+
+if ($architecture -ne 'x64') {
+    throw "The ProjectY bootstrap currently pins amd64 binaries; detected $architecture."
+}
+
+New-Item -ItemType Directory -Path $toolDirectory -Force | Out-Null
+
+$kindVersion = 'v0.33.0'
+$kindFile = if ($isWindowsHost) { 'kind-windows-amd64' } else { 'kind-linux-amd64' }
+$kindExpected = if ($isWindowsHost) {
+    '4b22adaa135368c5a465d56bbd8e520cbea87272a06ca00b6078e7b81515c9fc'
+} else {
+    'aee6151561422756b764a4ae28e7f44cda5af5a9eead3cc9985112b1de8d8e0d'
+}
+$kindName = if ($isWindowsHost) { 'kind.exe' } else { 'kind' }
+$kindPath = Join-Path $toolDirectory $kindName
+
+if (-not (Test-Path -LiteralPath $kindPath) -or
+    (Get-FileHash -LiteralPath $kindPath -Algorithm SHA256).Hash.ToLowerInvariant() -ne $kindExpected) {
+    Invoke-WebRequest -Uri "https://github.com/kubernetes-sigs/kind/releases/download/$kindVersion/$kindFile" -OutFile $kindPath
+    $actual = (Get-FileHash -LiteralPath $kindPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actual -ne $kindExpected) {
+        Remove-Item -LiteralPath $kindPath -Force
+        throw "kind checksum mismatch: expected $kindExpected, got $actual"
+    }
+}
+
+$kubectlVersion = 'v1.37.0'
+$platform = if ($isWindowsHost) { 'windows' } else { 'linux' }
+$kubectlName = if ($isWindowsHost) { 'kubectl.exe' } else { 'kubectl' }
+$kubectlPath = Join-Path $toolDirectory $kubectlName
+$kubectlUrl = "https://dl.k8s.io/release/$kubectlVersion/bin/$platform/amd64/$kubectlName"
+$checksumPath = Join-Path $toolDirectory "$kubectlName.sha256"
+
+if (-not (Test-Path -LiteralPath $kubectlPath)) {
+    Invoke-WebRequest -Uri $kubectlUrl -OutFile $kubectlPath
+}
+Invoke-WebRequest -Uri "$kubectlUrl.sha256" -OutFile $checksumPath
+$expected = (Get-Content -LiteralPath $checksumPath -Raw).Trim().ToLowerInvariant()
+$actual = (Get-FileHash -LiteralPath $kubectlPath -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($actual -ne $expected) {
+    Remove-Item -LiteralPath $kubectlPath -Force
+    throw "kubectl checksum mismatch: expected $expected, got $actual"
+}
+
+if (-not $isWindowsHost) {
+    & chmod +x $kindPath $kubectlPath
+    if ($LASTEXITCODE -ne 0) { throw 'Could not make kind and kubectl executable.' }
+}
+
+[pscustomobject]@{
+    Kind = $kindPath
+    Kubectl = $kubectlPath
+}

--- a/scripts/kind/Install-ProjectYKubernetesTools.ps1
+++ b/scripts/kind/Install-ProjectYKubernetesTools.ps1
@@ -43,7 +43,9 @@ $checksumPath = Join-Path $toolDirectory "$kubectlName.sha256"
 if (-not (Test-Path -LiteralPath $kubectlPath)) {
     Invoke-WebRequest -Uri $kubectlUrl -OutFile $kubectlPath
 }
-Invoke-WebRequest -Uri "$kubectlUrl.sha256" -OutFile $checksumPath
+if (-not (Test-Path -LiteralPath $checksumPath)) {
+    Invoke-WebRequest -Uri "$kubectlUrl.sha256" -OutFile $checksumPath
+}
 $expected = (Get-Content -LiteralPath $checksumPath -Raw).Trim().ToLowerInvariant()
 $actual = (Get-FileHash -LiteralPath $kubectlPath -Algorithm SHA256).Hash.ToLowerInvariant()
 if ($actual -ne $expected) {

--- a/scripts/kind/Install-ProjectYKubernetesTools.ps1
+++ b/scripts/kind/Install-ProjectYKubernetesTools.ps1
@@ -58,7 +58,39 @@ if (-not $isWindowsHost) {
     if ($LASTEXITCODE -ne 0) { throw 'Could not make kind and kubectl executable.' }
 }
 
+$helmVersion = 'v4.2.4'
+$helmPlatform = if ($isWindowsHost) { 'windows-amd64' } else { 'linux-amd64' }
+$helmArchiveName = if ($isWindowsHost) { "helm-$helmVersion-$helmPlatform.zip" } else { "helm-$helmVersion-$helmPlatform.tar.gz" }
+$helmArchive = Join-Path $toolDirectory $helmArchiveName
+$helmDirectory = Join-Path $toolDirectory $helmPlatform
+$helmName = if ($isWindowsHost) { 'helm.exe' } else { 'helm' }
+$helmPath = Join-Path $helmDirectory $helmName
+$helmUrl = "https://get.helm.sh/$helmArchiveName"
+$helmChecksum = Join-Path $toolDirectory "$helmArchiveName.sha256sum"
+
+if (-not (Test-Path -LiteralPath $helmPath)) {
+    if (-not (Test-Path -LiteralPath $helmArchive)) {
+        Invoke-WebRequest -Uri $helmUrl -OutFile $helmArchive
+    }
+    if (-not (Test-Path -LiteralPath $helmChecksum)) {
+        Invoke-WebRequest -Uri "$helmUrl.sha256sum" -OutFile $helmChecksum
+    }
+    $expectedHelm = ((Get-Content -LiteralPath $helmChecksum -Raw).Trim() -split '\s+')[0].ToLowerInvariant()
+    $actualHelm = (Get-FileHash -LiteralPath $helmArchive -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualHelm -ne $expectedHelm) {
+        throw "Helm checksum mismatch: expected $expectedHelm, got $actualHelm"
+    }
+    if ($isWindowsHost) {
+        Expand-Archive -LiteralPath $helmArchive -DestinationPath $toolDirectory -Force
+    } else {
+        & tar -xzf $helmArchive -C $toolDirectory
+        if ($LASTEXITCODE -ne 0) { throw 'Could not unpack Helm.' }
+        & chmod +x $helmPath
+    }
+}
+
 [pscustomobject]@{
     Kind = $kindPath
     Kubectl = $kubectlPath
+    Helm = $helmPath
 }

--- a/scripts/kind/Publish-LocalSecretBackend.ps1
+++ b/scripts/kind/Publish-LocalSecretBackend.ps1
@@ -1,0 +1,62 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$tools = & (Join-Path $PSScriptRoot 'Install-ProjectYKubernetesTools.ps1')
+$kubectl = $tools.Kubectl
+$envPath = Join-Path $root '.env'
+
+if (-not (Test-Path -LiteralPath $envPath)) { throw '.env does not exist; run scripts/New-LocalSecrets.ps1 first.' }
+
+$values = @{}
+foreach ($line in Get-Content -LiteralPath $envPath) {
+    if ($line -match '^\s*#' -or $line -notmatch '=') { continue }
+    $key, $value = $line -split '=', 2
+    $values[$key.Trim()] = $value.Trim().Trim('"').Trim("'")
+}
+
+$required = @(
+    'GATEWAY_IDENTITY_SIGNING_KEY', 'IDENTITY_KEY_ENCRYPTION_KEY', 'IDENTITY_ADMIN_PASSWORD',
+    'MINIO_USER', 'MINIO_PASSWORD', 'RENTAL_OPERATIONS_RABBITMQ_USER', 'RENTAL_OPERATIONS_RABBITMQ_PASSWORD'
+)
+foreach ($key in $required) {
+    if (-not $values.ContainsKey($key) -or [string]::IsNullOrWhiteSpace($values[$key])) {
+        throw ".env is missing $key; regenerate local credentials before starting Kubernetes."
+    }
+}
+
+$values['MINIO_ACCESS_KEY'] = $values['MINIO_USER']
+$values['MINIO_SECRET_KEY'] = $values['MINIO_PASSWORD']
+$values['MINIO_ROOT_USER'] = $values['MINIO_USER']
+$values['MINIO_ROOT_PASSWORD'] = $values['MINIO_PASSWORD']
+$values['AWS_ACCESS_KEY_ID'] = $values['MINIO_USER']
+$values['AWS_SECRET_ACCESS_KEY'] = $values['MINIO_PASSWORD']
+$values['RabbitMQ__UserName'] = $values['RENTAL_OPERATIONS_RABBITMQ_USER']
+$values['RabbitMQ__Password'] = $values['RENTAL_OPERATIONS_RABBITMQ_PASSWORD']
+$values['RABBITMQ_DEFAULT_USER'] = $values['RENTAL_OPERATIONS_RABBITMQ_USER']
+$values['RABBITMQ_DEFAULT_PASS'] = $values['RENTAL_OPERATIONS_RABBITMQ_PASSWORD']
+$values['GatewayIdentity__SigningKey'] = $values['GATEWAY_IDENTITY_SIGNING_KEY']
+$values['TELEMETRY_SECRET_KEY_BASE'] = $values['GATEWAY_IDENTITY_SIGNING_KEY']
+$values['TELEMETRY_TICKET_KEY'] = $values['GATEWAY_IDENTITY_SIGNING_KEY']
+
+$data = @{}
+foreach ($entry in $values.GetEnumerator()) {
+    $data[$entry.Key] = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes([string]$entry.Value))
+}
+
+$manifest = @{
+    apiVersion = 'v1'
+    kind = 'Secret'
+    metadata = @{name = 'projecty-runtime-source'; namespace = 'projecty-secrets'}
+    type = 'Opaque'
+    data = $data
+} | ConvertTo-Json -Depth 8
+
+$namespaceManifest = (& $kubectl create namespace projecty-secrets --dry-run=client -o json) -join "`n"
+if ($LASTEXITCODE -ne 0) { throw 'Could not render the local secret-backend namespace.' }
+$namespaceManifest | & $kubectl apply -f - | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'Could not create the local secret-backend namespace.' }
+$manifest | & $kubectl apply -f - | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'Could not publish local values to the secret backend.' }
+Write-Host 'Local secret backend updated without committing secret material.'

--- a/scripts/kind/Remove-ProjectYCluster.ps1
+++ b/scripts/kind/Remove-ProjectYCluster.ps1
@@ -1,0 +1,23 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$toolDirectory = Join-Path $root '.tools\kubernetes'
+$kindName = if ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) { 'kind.exe' } else { 'kind' }
+$kind = Join-Path $toolDirectory $kindName
+
+if (Test-Path -LiteralPath $kind) {
+    & $kind delete cluster --name projecty
+    if ($LASTEXITCODE -ne 0) { throw 'Could not delete the ProjectY kind cluster.' }
+}
+
+if (Get-Command docker -ErrorAction SilentlyContinue) {
+    $registryId = & docker ps --all --quiet --filter 'name=^projecty-registry$'
+    if ($registryId) {
+        & docker rm --force projecty-registry | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw 'Could not remove the ProjectY local registry.' }
+    }
+}
+
+Write-Host 'ProjectY kind cluster and local registry removed.'


### PR DESCRIPTION
Closes #78, #79, #80, #81. Fecha o [épico 10](https://github.com/iVega123/ProjectY/issues/11).

O #26 assina as imagens desde abril. **Assinar sem verificar é teatro** — quem empurra uma imagem direto no registry passa exatamente igual. Este épico fecha o portão que dá sentido à assinatura, e fecha em kind: quem quiser ver a rejeição não precisa de conta na AWS.

## Os quatro pisos

| # | O que entrou |
|---|---|
| #78 | Cluster kind fixado por digest, registry local em `:5001` espelhado no containerd, Calico, ingress-nginx — criados e destruídos pelo ciclo do Tilt |
| #79 | `deploy/base` com 19 workloads, `overlays/{selfhost,aws}`, `docker_compose()` → `k8s_yaml(kustomize(...))` |
| #80 | Kyverno como componente de plataforma, política Cosign keyless promovida de Audit para Enforce |
| #81 | PSS `restricted`, 21 NetworkPolicies default-deny, 20 ServiceAccounts, 9 ExternalSecrets |

## O DoD não é uma afirmação, é um job

O `Kubernetes security acceptance` sobe um kind efêmero no CI e prova as quatro coisas em máquina limpa, subindo o JSON como `kubernetes-security-<sha>`:

- imagem deliberadamente não assinada **rejeitada na admissão**, imagem assinada pelo pipeline **admitida**
- pod com `runAsUser: 0` **rejeitado** pelo Pod Security, mesmo com todo o resto do contexto conforme
- um pod rotulado `identity` alcança o CockroachDB **que ele possui** e **não alcança** o RabbitMQ do rental-core — verificado tentando, não declarando
- os 9 secrets chegam pelo operator, lendo do backend local no namespace separado

O `Kubernetes manifests` roda sem cluster e trava a deriva: 19 workloads nos dois overlays, requests e limits em todos, `arn:aws` em qualquer lugar do render **falha o build**, `kind: Secret` commitado **falha o build**.

## A promoção ficou legível no diff

O #80 pedia "audit primeiro, depois enforce, para que a troca seja observável". A troca não está no histórico do git — está no arquivo:

- `policy.yaml` fica em `validationActions: [Audit]`, anotado `projecty.io/rollout: audit-first`
- `kustomization.yaml` promove com um patch: `Audit` → `Deny`, `mutateDigest` → `true`

O que sobe é Enforce. O que se lê é a decisão de ter começado em Audit. E é **um arquivo só** — o mesmo que vai para o EKS no épico 11.

## Nenhum ARN atravessou a camada de workloads

É o ponto do #79 que mata a portabilidade em silêncio se falhar. Os dois overlays renderizam os mesmos 19 workloads; a diferença inteira entre local e nuvem é **o provider do SecretStore** — `kubernetes` de um lado, `aws` do outro — mais duas réplicas no gateway e no console. Os `ExternalSecret` não mudam: os workloads consomem nomes de secret e propriedades, nunca identificadores de recurso.

## O Compose não morreu, virou saída explícita

`tilt up` é Kubernetes por padrão. O Compose continua em `tilt up -- --orchestrator=compose --full`, como o próprio #79 pediu para a transição.

## O que este épico não entrega

- **Não há tempo de cold start publicado.** A primeira subida ainda precisa ser cronometrada com cache de Docker limpo, com hardware e rede registrados, antes de virar um número reproduzível. O README diz isso em vez de inventar.
- **O A4 (#100) continua aberto**, mas perdeu o bloqueio: o TLS de verdade dependia de um ingress que agora existe.

## Verificação

21 commits, CI verde ([run](https://github.com/iVega123/ProjectY/actions/runs/34478871521)) incluindo `Kubernetes manifests`, `Kubernetes security acceptance`, `Gitleaks` e o gate `Required`.

Reproduzir localmente está no [runbook](docs/runbooks/local-kubernetes.md) — `Test-KubernetesManifests.ps1` sem cluster, e os três probes vivos com `tilt up` rodando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
