### PR TITLE
feat(edge): terminate TLS at the ingress, and read the scheme instead of guessing it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,9 +194,11 @@ jobs:
               - 'deploy/overlays/aws/**'
               - 'deploy/overlays/selfhost/**'
               - 'deploy/platform/kyverno/**'
+              - 'deploy/platform/cert-manager/**'
               - 'scripts/kind/**'
               - 'scripts/Test-Kubernetes*.ps1'
               - 'scripts/Test-ExternalSecrets.ps1'
+              - 'scripts/Test-IngressTls.ps1'
               - 'Tiltfile'
               - '.github/workflows/ci.yml'
             polyglot:
@@ -745,6 +747,14 @@ jobs:
         run: |
           ./scripts/kind/Install-Kyverno.ps1
           ./scripts/Test-SignedAdmission.ps1 | Tee-Object artifacts/signed-admission.json
+
+      - name: Verify TLS at the ingress
+        shell: pwsh
+        run: |
+          $tools = ./scripts/kind/Install-ProjectYKubernetesTools.ps1
+          ./scripts/kind/Install-CertManager.ps1
+          & $tools.Kubectl apply --namespace projecty -f deploy/base/ingress.yaml
+          ./scripts/Test-IngressTls.ps1 -UseFixtureBackends | Tee-Object artifacts/ingress-tls.json
 
       - name: Upload reproducible acceptance evidence
         if: always()

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ State-changing API retries follow the shared
 ### Kubernetes development loop
 
 The root [`Tiltfile`](Tiltfile) now uses Kubernetes by default. It bootstraps a
-pinned kind cluster, a local registry, Calico, ingress-nginx, External Secrets
-and Kyverno before deploying the shared `deploy/base` topology through the
-`selfhost` Kustomize overlay. See the
+pinned kind cluster, a local registry, Calico, ingress-nginx, External Secrets,
+cert-manager and Kyverno before deploying the shared `deploy/base` topology
+through the `selfhost` Kustomize overlay. See the
 [local Kubernetes runbook](docs/runbooks/local-kubernetes.md) for prerequisites,
 resource sizing, security proofs and troubleshooting. Start everything with:
 
@@ -131,8 +131,13 @@ old credentials, and run
 `powershell -ExecutionPolicy Bypass -File scripts/New-LocalSecrets.ps1 -Force`.
 
 The Tilt UI is at <http://localhost:10350>; ingress serves the console and
-gateway at <http://localhost:8080>. `tilt down` removes the kind cluster and
-local registry, including their local data.
+gateway over TLS at <https://localhost:8443>, and redirects
+<http://localhost:8080> to it. The certificate is issued by a local authority
+cert-manager creates in the cluster, so it is not in your trust store and the
+first visit warns — that warning is the honest state of a certificate no public
+CA vouched for, and the runbook says how to verify the chain deliberately.
+`tilt down` removes the kind cluster and local registry, including their local
+data.
 
 Compose remains an explicit migration fallback:
 
@@ -143,7 +148,14 @@ tilt up -- --orchestrator=compose --full
 The release images built by CI use the Dockerfiles' final non-root stages. CI
 also renders both Kubernetes overlays and runs an ephemeral-cluster acceptance
 that captures unsigned-image rejection, Pod Security enforcement, datastore
-isolation and External Secrets synchronization as downloadable evidence.
+isolation, External Secrets synchronization and TLS at the ingress as
+downloadable evidence.
+
+TLS terminates at the ingress and nowhere else: between services the traffic is
+plain HTTP, confined by network policy and authenticated by the signed identity
+envelope rather than by mTLS. The reasoning, and the integrity gap that decision
+accepts, are in
+[ADR 0025](docs/adr/0025-tls-terminates-at-the-ingress.md).
 
 There is not yet an honest cold-start time to publish. The first successful
 start must still be timed on a clean Docker cache with the hardware and network

--- a/Tiltfile
+++ b/Tiltfile
@@ -92,6 +92,13 @@ if orchestrator == 'kubernetes':
             deps = ['deploy/platform/kyverno'],
             labels = ['platform'],
         )
+        local_resource(
+            'local-tls',
+            cmd = script_prefix + ['-File', 'scripts/kind/Install-CertManager.ps1'],
+            deps = ['deploy/platform/cert-manager', 'scripts/kind/Install-CertManager.ps1'],
+            resource_deps = ['projecty-platform'],
+            labels = ['platform'],
+        )
 
         workload_names = [
             'api-gateway', 'identity', 'rental-core', 'media-guard', 'billing', 'risk-pricing', 'telemetry', 'console',
@@ -151,14 +158,15 @@ if orchestrator == 'kubernetes':
         k8s_resource(
             new_name = 'projecty-edge',
             objects = ['projecty:ingress:projecty'],
-            resource_deps = ['api-gateway', 'console', 'telemetry'],
-            links = [link('http://localhost:8080', 'Console'), link('http://localhost:8080/health/ready', 'Gateway')],
+            resource_deps = ['api-gateway', 'console', 'telemetry', 'local-tls'],
+            links = [link('https://localhost:8443', 'Console'), link('https://localhost:8443/health/ready', 'Gateway')],
             labels = ['services'],
         )
 
         print('Tilt UI: http://localhost:10350')
-        print('Console: http://localhost:8080')
-        print('Gateway: http://localhost:8080/health/ready')
+        print('Console: https://localhost:8443')
+        print('Gateway: https://localhost:8443/health/ready')
+        print('The local authority is not in your trust store, so the first visit warns. Port 8080 redirects to 8443.')
 
 if orchestrator == 'compose':
     compose_files = ['docker-compose.yml', 'docker-compose.chaos.yml']

--- a/deploy/base/ingress.yaml
+++ b/deploy/base/ingress.yaml
@@ -4,8 +4,17 @@ metadata:
   name: projecty
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: 32m
+    # This is what replaced UseHttpsRedirection(), and it lives here because
+    # here is the only place that knows the request's original scheme. The
+    # services behind it never redirect; they read X-Forwarded-Proto. ADR 0025.
+    nginx.ingress.kubernetes.io/force-ssl-redirect: 'true'
 spec:
   ingressClassName: nginx
+  # No hosts: nginx serves this as the default certificate for every request
+  # that reaches it. The Secret is filled by the platform layer, never
+  # committed -- cert-manager locally, ACM in front of the load balancer on AWS.
+  tls:
+    - secretName: projecty-tls
   rules:
     - http:
         paths:

--- a/deploy/base/ingress.yaml
+++ b/deploy/base/ingress.yaml
@@ -10,11 +10,16 @@ metadata:
     nginx.ingress.kubernetes.io/force-ssl-redirect: 'true'
 spec:
   ingressClassName: nginx
-  # No hosts: nginx serves this as the default certificate for every request
-  # that reaches it. The Secret is filled by the platform layer, never
-  # committed -- cert-manager locally, ACM in front of the load balancer on AWS.
-  tls:
-    - secretName: projecty-tls
+  # There is deliberately no `tls` block and no host.
+  #
+  # A `tls` block needs `hosts` to mean anything -- ingress-nginx maps SNI to a
+  # Secret by hostname, and an entry without hosts is silently ignored, which is
+  # the A4 defect in miniature: a stated guarantee that does not hold. And the
+  # hostnames are not shareable, since this base also renders for AWS.
+  #
+  # So the certificate is named by the platform layer of each environment, not
+  # by this file: the controller's --default-ssl-certificate on kind, an ACM
+  # annotation in front of the load balancer on AWS. See ADR 0025.
   rules:
     - http:
         paths:

--- a/deploy/overlays/aws/ingress-acm.yaml
+++ b/deploy/overlays/aws/ingress-acm.yaml
@@ -1,0 +1,35 @@
+# On AWS the certificate never enters the cluster: TLS terminates at the load
+# balancer with an ACM certificate, so the `tls` block from the base -- which
+# names a Secret cert-manager fills in on kind -- is removed here.
+#
+# The ARN is a placeholder on purpose. The real one is an output of the
+# Terraform that provisions the certificate, and that Terraform belongs to
+# epic 11 (#83, #84). A literal ARN here would be a cloud resource identifier
+# for a cloud that has provisioned nothing yet.
+#
+# The class changes with it. The nginx annotations and the ALB ones are
+# different controllers, and an Ingress carrying both reads as if two were
+# expected. Epic 11 owns this choice and may reverse it -- ingress-nginx behind
+# an NLB is the other defensible answer, and it would move the certificate
+# annotation onto the controller's Service instead of onto this Ingress.
+- op: remove
+  path: /spec/tls
+- op: replace
+  path: /spec/ingressClassName
+  value: alb
+- op: remove
+  path: /metadata/annotations/nginx.ingress.kubernetes.io~1force-ssl-redirect
+- op: remove
+  path: /metadata/annotations/nginx.ingress.kubernetes.io~1proxy-body-size
+- op: add
+  path: /metadata/annotations/alb.ingress.kubernetes.io~1scheme
+  value: internet-facing
+- op: add
+  path: /metadata/annotations/alb.ingress.kubernetes.io~1certificate-arn
+  value: PLACEHOLDER_ACM_CERTIFICATE_ARN
+- op: add
+  path: /metadata/annotations/alb.ingress.kubernetes.io~1listen-ports
+  value: '[{"HTTP": 80}, {"HTTPS": 443}]'
+- op: add
+  path: /metadata/annotations/alb.ingress.kubernetes.io~1ssl-redirect
+  value: '443'

--- a/deploy/overlays/aws/ingress-acm.yaml
+++ b/deploy/overlays/aws/ingress-acm.yaml
@@ -1,6 +1,7 @@
 # On AWS the certificate never enters the cluster: TLS terminates at the load
-# balancer with an ACM certificate, so the `tls` block from the base -- which
-# names a Secret cert-manager fills in on kind -- is removed here.
+# balancer with an ACM certificate. The base names no certificate at all, so
+# there is nothing to remove here -- only the annotation that says which one the
+# load balancer presents.
 #
 # The ARN is a placeholder on purpose. The real one is an output of the
 # Terraform that provisions the certificate, and that Terraform belongs to
@@ -12,8 +13,6 @@
 # expected. Epic 11 owns this choice and may reverse it -- ingress-nginx behind
 # an NLB is the other defensible answer, and it would move the certificate
 # annotation onto the controller's Service instead of onto this Ingress.
-- op: remove
-  path: /spec/tls
 - op: replace
   path: /spec/ingressClassName
   value: alb

--- a/deploy/overlays/aws/kustomization.yaml
+++ b/deploy/overlays/aws/kustomization.yaml
@@ -5,3 +5,9 @@ resources:
   - aws-secret-store.yaml
 patches:
   - path: production-shape.yaml
+  - path: ingress-acm.yaml
+    target:
+      group: networking.k8s.io
+      version: v1
+      kind: Ingress
+      name: projecty

--- a/deploy/overlays/selfhost/local-public-urls.yaml
+++ b/deploy/overlays/selfhost/local-public-urls.yaml
@@ -3,6 +3,10 @@ kind: ConfigMap
 metadata:
   name: projecty-runtime
 data:
-  CONSOLE_ORIGIN: http://localhost:8080
-  TELEMETRY_PUBLIC_URL: ws://localhost:8080/socket/websocket
-  TELEMETRY_ORIGINS: //localhost:8080
+  # The ingress terminates TLS on 8443 and redirects 8080 to it, so these are
+  # https and wss. A client that follows the redirect and then opens a
+  # websocket against a ws:// URL would be told to upgrade a scheme the browser
+  # already refuses on a secure page.
+  CONSOLE_ORIGIN: https://localhost:8443
+  TELEMETRY_PUBLIC_URL: wss://localhost:8443/socket/websocket
+  TELEMETRY_ORIGINS: //localhost:8443

--- a/deploy/platform/cert-manager/kustomization.yaml
+++ b/deploy/platform/cert-manager/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - local-authority.yaml

--- a/deploy/platform/cert-manager/local-authority.yaml
+++ b/deploy/platform/cert-manager/local-authority.yaml
@@ -1,0 +1,58 @@
+# The local certificate authority for kind.
+#
+# On AWS, TLS terminates at the load balancer with an ACM certificate the
+# platform issues and rotates; nothing in the workloads layer knows the
+# certificate exists. This is the same shape locally: cert-manager issues,
+# rotates and republishes `projecty-tls`, and the Ingress in `deploy/base`
+# references it by name only. See ADR 0025.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: projecty-selfsigned
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: projecty-local-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: ProjectY Local Authority
+  secretName: projecty-local-ca
+  privateKey: {algorithm: ECDSA, size: 256}
+  duration: 8760h
+  renewBefore: 720h
+  issuerRef: {name: projecty-selfsigned, kind: ClusterIssuer, group: cert-manager.io}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: projecty-local-ca
+spec:
+  ca:
+    secretName: projecty-local-ca
+---
+# The Ingress carries no host, so nginx serves this as the default certificate.
+# `localhost` is what a visitor actually types; `projecty.localtest.me` resolves
+# to 127.0.0.1 without editing a hosts file, for anything that refuses to accept
+# a certificate for a bare `localhost`.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: projecty-tls
+  namespace: projecty
+spec:
+  secretName: projecty-tls
+  commonName: localhost
+  dnsNames:
+    - localhost
+    - projecty.localtest.me
+  ipAddresses:
+    - 127.0.0.1
+  privateKey: {algorithm: ECDSA, size: 256}
+  duration: 2160h
+  renewBefore: 360h
+  usages: [server auth]
+  issuerRef: {name: projecty-local-ca, kind: ClusterIssuer, group: cert-manager.io}

--- a/deploy/platform/cert-manager/local-authority.yaml
+++ b/deploy/platform/cert-manager/local-authority.yaml
@@ -3,8 +3,9 @@
 # On AWS, TLS terminates at the load balancer with an ACM certificate the
 # platform issues and rotates; nothing in the workloads layer knows the
 # certificate exists. This is the same shape locally: cert-manager issues,
-# rotates and republishes `projecty-tls`, and the Ingress in `deploy/base`
-# references it by name only. See ADR 0025.
+# rotates and republishes `projecty-tls`, and the deployment layer never names
+# it -- the controller is pointed at it with --default-ssl-certificate by
+# `scripts/kind/Install-CertManager.ps1`. See ADR 0025.
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -34,7 +35,6 @@ spec:
   ca:
     secretName: projecty-local-ca
 ---
-# The Ingress carries no host, so nginx serves this as the default certificate.
 # `localhost` is what a visitor actually types; `projecty.localtest.me` resolves
 # to 127.0.0.1 without editing a hosts file, for anything that refuses to accept
 # a certificate for a bare `localhost`.

--- a/docs/AUDITORIA-ARQUITETURA-SEGURANCA.md
+++ b/docs/AUDITORIA-ARQUITETURA-SEGURANCA.md
@@ -126,15 +126,23 @@ isolados com permissões específicas. Fechado pelo commit
   configurado, `ASPNETCORE_URLS` é só HTTP e `UseHttpsRedirection()` vira inofensivo sem
   porta HTTPS conhecida. As chamadas entre serviços são `http://` puro.
 
-  **Status: metade fechada.** A promessa saiu — a tabela de portas do
+  **Status: fechada.** A promessa saiu primeiro — a tabela de portas do
   `getting-started` diz HTTP e nomeia os serviços que existem, a porta 8201 (que
   o Compose publicava sem nada escutando) foi despublicada, e o
   `UseHttpsRedirection()` foi removido em vez de deixado como decoração. O
   [ADR 0025](adr/0025-tls-terminates-at-the-ingress.md) registra a decisão sobre
   o tráfego dentro do cluster antes de o cluster existir: TLS termina no
   ingress, e entre serviços é política de rede e não mTLS, porque o envelope do
-  ADR 0008 já autentica cada salto interno. **O que continua aberto é o TLS de
-  verdade**, que depende do ingress do épico 10 — #100.
+  ADR 0008 já autentica cada salto interno.
+
+  O TLS de verdade chegou com o ingress do épico 10: o cert-manager emite a
+  autoridade local e o certificado do `projecty-tls`, o ingress redireciona
+  8080 para 8443 com `force-ssl-redirect`, e o `rental-core` lê
+  `X-Forwarded-Proto` com `UseForwardedHeaders` em vez de redirecionar atrás de
+  um proxy. O `Test-IngressTls.ps1` verifica a cadeia contra a autoridade do
+  cluster e exige que um cliente sem ela seja recusado. **O que este achado não
+  cobre, e o ADR 0025 assume explicitamente, é a confidencialidade entre pods**
+  — segue em #191.
 - **A5 — Upload de CNH validado só por extensão, com `Content-Type` do cliente.** Nunca se
   verificam os bytes iniciais, e `contentType = file.ContentType` é gravado como metadado no
   MinIO e devolvido pela URL pré-assinada → XSS armazenado.

--- a/docs/adr/0025-tls-terminates-at-the-ingress.md
+++ b/docs/adr/0025-tls-terminates-at-the-ingress.md
@@ -118,6 +118,27 @@ service that is not ours running beside these.
   are load-bearing together. It does not carry integrity of the body, and this
   record says so where the decision rests on it, rather than in a footnote.
 
+## What implemented it
+
+Epic 10 landed, and with it this decision, in #100:
+
+- cert-manager issues a self-signed root, the `projecty-local-ca` authority from
+  it, and the `projecty-tls` serving certificate from that authority. The
+  `Ingress` in `deploy/base` names the Secret and nothing else; the `aws`
+  overlay drops the field, because ACM terminates in front of the load balancer.
+- `force-ssl-redirect` at the ingress is what replaced
+  `UseHttpsRedirection()` — the redirect now lives at the only hop that knows
+  the original scheme.
+- `UseForwardedHeaders` in `rental-core`, with a forward limit of two, since the
+  ingress and the gateway are both proxies in front of it. The known-proxy list
+  is empty, so the trust in that header rests on the default-deny
+  `NetworkPolicy` rather than on the middleware — noted where it is configured.
+- `scripts/Test-IngressTls.ps1` verifies the chain against the cluster's own
+  authority and requires a client without it to be refused.
+
+What did not change is the paragraph above it: between services the traffic is
+still plain HTTP, and the body-integrity gap is still open as #191.
+
 ## Follow-up
 
 - [Epic 10 — Local Kubernetes and signed admission](https://github.com/iVega123/ProjectY/issues/11)

--- a/docs/adr/0025-tls-terminates-at-the-ingress.md
+++ b/docs/adr/0025-tls-terminates-at-the-ingress.md
@@ -123,9 +123,14 @@ service that is not ours running beside these.
 Epic 10 landed, and with it this decision, in #100:
 
 - cert-manager issues a self-signed root, the `projecty-local-ca` authority from
-  it, and the `projecty-tls` serving certificate from that authority. The
-  `Ingress` in `deploy/base` names the Secret and nothing else; the `aws`
-  overlay drops the field, because ACM terminates in front of the load balancer.
+  it, and the `projecty-tls` serving certificate from that authority.
+- **The deployment layer names no certificate.** A `tls` block on the Ingress
+  needs `hosts` to do anything — ingress-nginx maps SNI to a Secret by hostname
+  and ignores an entry without them, which would have reproduced the A4 defect
+  itself: a stated guarantee that does not hold. And the hostnames are not
+  shareable, because the same base renders for AWS. So each environment names
+  its certificate in its own platform layer: `--default-ssl-certificate` on the
+  controller here, an ACM annotation in front of the load balancer there.
 - `force-ssl-redirect` at the ingress is what replaced
   `UseHttpsRedirection()` — the redirect now lives at the only hop that knows
   the original scheme.

--- a/docs/runbooks/local-kubernetes.md
+++ b/docs/runbooks/local-kubernetes.md
@@ -61,20 +61,25 @@ provider with AWS Secrets Manager and workload-identity authentication.
 TLS terminates at the ingress and nowhere else. cert-manager creates a
 self-signed root, issues the `projecty-local-ca` authority from it, and issues
 the `projecty-tls` serving certificate for `localhost`, `projecty.localtest.me`
-and `127.0.0.1` from that authority. The `Ingress` in `deploy/base` names the
-Secret and knows nothing else about it — on AWS the same field is dropped and
-ACM terminates in front of the load balancer.
+and `127.0.0.1` from that authority. The `Ingress` in `deploy/base` names no
+certificate at all: a `tls` block without hosts is ignored by ingress-nginx, and
+the hostnames could not be shared with the AWS overlay anyway. Each environment
+names its certificate in its own platform layer instead — the controller's
+`--default-ssl-certificate` here, an ACM annotation in front of the load
+balancer on AWS.
 
 The authority is local, so no public CA vouches for it and browsers warn on the
 first visit. To verify the chain deliberately instead of clicking through:
 
 ```powershell
-$tools = ./scripts/kind/Install-ProjectYKubernetesTools.ps1
-& $tools.Kubectl get secret projecty-local-ca --namespace cert-manager -o jsonpath='{.data.ca\.crt}' |
-  ForEach-Object { [System.Convert]::FromBase64String($_) } |
-  Set-Content projecty-local-ca.crt -AsByteStream
-curl --cacert projecty-local-ca.crt https://localhost:8443/health/ready
+./scripts/Test-IngressTls.ps1
 ```
+
+That script pins the chain to the cluster's own authority in .NET rather than
+shelling out to `curl --cacert`, which does not work here: the `curl` shipped
+with Windows is built against schannel, which can only trust what the machine
+already trusts and answers exit 60 for a certificate from an authority that is
+deliberately in no trust store.
 
 Between services the traffic is plain HTTP. That is a decision, not an
 omission: every internal hop is authenticated above the transport by the signed
@@ -108,6 +113,13 @@ With `tilt up` running, reproduce the three live acceptance checks:
 ./scripts/Test-SignedAdmission.ps1
 ./scripts/Test-IngressTls.ps1
 ```
+
+Every one of these runs on Windows PowerShell 5.1 as well as on PowerShell 7.
+That is worth stating because it did not use to: a probe that is *meant* to be
+rejected writes its rejection to stderr, and redirecting a native command's
+stderr under 5.1 wraps it in a `NativeCommandError` that terminates the script
+before the exit code is read. The expected rejection killed the run instead of
+satisfying it, and CI never noticed because CI runs pwsh 7 on Linux.
 
 The security test creates temporary listener pods to prove that an identity-labeled
 pod can reach its owned CockroachDB endpoint but cannot connect to Rental Core's

--- a/docs/runbooks/local-kubernetes.md
+++ b/docs/runbooks/local-kubernetes.md
@@ -2,9 +2,9 @@
 
 `tilt up` is ProjectY's default development entrypoint. It creates a disposable
 single-node kind cluster named `projecty`, connects a local OCI registry, installs
-Calico and ingress-nginx, then deploys the `selfhost` Kustomize overlay. No global
-kind, kubectl or Helm installation is required: verified pinned binaries are kept
-under the ignored `.tools/kubernetes` directory.
+Calico, ingress-nginx and cert-manager, then deploys the `selfhost` Kustomize
+overlay. No global kind, kubectl or Helm installation is required: verified pinned
+binaries are kept under the ignored `.tools/kubernetes` directory.
 
 ## Prerequisites and capacity
 
@@ -28,8 +28,9 @@ tilt up
 ```
 
 Open the Tilt UI at <http://localhost:10350>, the console at
-<http://localhost:8080>, or the gateway readiness endpoint at
-<http://localhost:8080/health/ready>.
+<https://localhost:8443>, or the gateway readiness endpoint at
+<https://localhost:8443/health/ready>. Port `8080` answers every request with a
+308 to `8443`.
 
 Stop and delete the cluster, registry and local cluster data with:
 
@@ -55,6 +56,35 @@ manifests contain references and property names, never secret values. The AWS
 overlay keeps the same ExternalSecret resources and replaces only the SecretStore
 provider with AWS Secrets Manager and workload-identity authentication.
 
+## TLS
+
+TLS terminates at the ingress and nowhere else. cert-manager creates a
+self-signed root, issues the `projecty-local-ca` authority from it, and issues
+the `projecty-tls` serving certificate for `localhost`, `projecty.localtest.me`
+and `127.0.0.1` from that authority. The `Ingress` in `deploy/base` names the
+Secret and knows nothing else about it — on AWS the same field is dropped and
+ACM terminates in front of the load balancer.
+
+The authority is local, so no public CA vouches for it and browsers warn on the
+first visit. To verify the chain deliberately instead of clicking through:
+
+```powershell
+$tools = ./scripts/kind/Install-ProjectYKubernetesTools.ps1
+& $tools.Kubectl get secret projecty-local-ca --namespace cert-manager -o jsonpath='{.data.ca\.crt}' |
+  ForEach-Object { [System.Convert]::FromBase64String($_) } |
+  Set-Content projecty-local-ca.crt -AsByteStream
+curl --cacert projecty-local-ca.crt https://localhost:8443/health/ready
+```
+
+Between services the traffic is plain HTTP. That is a decision, not an
+omission: every internal hop is authenticated above the transport by the signed
+identity envelope, and the integrity gap that leaves — same-route body
+substitution inside the 30 second window — is stated in
+[ADR 0025](../adr/0025-tls-terminates-at-the-ingress.md) and tracked as
+[#191](https://github.com/iVega123/ProjectY/issues/191). No service redirects to
+HTTPS; `rental-core` reads `X-Forwarded-Proto` through `UseForwardedHeaders`
+with a forward limit of two, because the ingress and the gateway are two hops.
+
 Kyverno first receives the ProjectY image-verification policy in Audit mode and
 is then promoted from the same manifest to Enforce. The policy trusts only the
 keyless certificate identity of `.github/workflows/ci.yml` on `main` for ProjectY
@@ -76,14 +106,25 @@ With `tilt up` running, reproduce the three live acceptance checks:
 ./scripts/Test-ExternalSecrets.ps1
 ./scripts/Test-KubernetesSecurity.ps1
 ./scripts/Test-SignedAdmission.ps1
+./scripts/Test-IngressTls.ps1
 ```
 
 The security test creates temporary listener pods to prove that an identity-labeled
 pod can reach its owned CockroachDB endpoint but cannot connect to Rental Core's
 RabbitMQ endpoint. It also submits an otherwise restricted pod with UID 0 and
 requires admission to reject it. The signed-admission test uses server dry-run,
-so neither canary workload is persisted. CI executes the same sequence in an
-ephemeral kind cluster and uploads the JSON output as `kubernetes-security-<sha>`.
+so neither canary workload is persisted. The TLS test verifies the served
+certificate against the cluster's own authority with no `--insecure`, and then
+requires an empty authority to be rejected — otherwise the first check would
+prove only that something answered on 8443.
+
+CI executes the same sequence in an ephemeral kind cluster and uploads the JSON
+output as `kubernetes-security-<sha>`. One difference is worth naming: CI has no
+application images in that cluster, so it runs the TLS test with
+`-UseFixtureBackends`, standing two busybox listeners in for the console and the
+gateway. CI therefore proves the edge — chain, SAN, redirect, refusal of an
+untrusted client — and the claim that the real console and gateway answer over
+TLS is what the switch-free run above verifies under `tilt up`.
 
 ## Troubleshooting
 

--- a/scripts/Test-IngressTls.ps1
+++ b/scripts/Test-IngressTls.ps1
@@ -1,7 +1,8 @@
 [CmdletBinding()]
 param(
-    [string]$HttpsBase = 'https://localhost:8443',
-    [string]$HttpBase = 'http://localhost:8080',
+    [string]$HttpsHost = 'localhost',
+    [int]$HttpsPort = 8443,
+    [int]$HttpPort = 8080,
     # CI has no application images in the cluster, so it stands two busybox
     # listeners in for the console and the gateway -- the same fixture pattern
     # the NetworkPolicy acceptance uses. What is proven is the edge: the chain,
@@ -13,10 +14,6 @@ param(
 $ErrorActionPreference = 'Stop'
 $tools = & (Join-Path $PSScriptRoot 'kind\Install-ProjectYKubernetesTools.ps1')
 $kubectl = $tools.Kubectl
-
-if (-not (Get-Command curl -ErrorAction SilentlyContinue) -and -not (Get-Command curl.exe -ErrorAction SilentlyContinue)) {
-    throw 'curl is required to verify the certificate chain against an explicit authority.'
-}
 
 $fixtures = @"
 apiVersion: v1
@@ -72,76 +69,160 @@ spec:
       resources: {requests: {cpu: 5m, memory: 8Mi}, limits: {cpu: 50m, memory: 32Mi}}
 "@
 
-function Invoke-Probe {
+# The chain is validated in .NET rather than by curl.
+#
+# curl on Windows is built against schannel, which ignores --cacert: it can only
+# trust what the machine already trusts, so it answers 60 for a certificate from
+# an authority that is deliberately in no trust store. Pinning the chain to our
+# own CA is the entire point of this test, so it is done here, the same way on
+# every platform the runbook names.
+function Invoke-TlsRequest {
     param(
-        [Parameter(Mandatory)] [string]$Url,
-        [string[]]$ExtraArguments = @()
+        [Parameter(Mandatory)] [string]$TargetHost,
+        [Parameter(Mandatory)] [int]$Port,
+        [Parameter(Mandatory)] [string]$Path,
+        # $null means "trust nothing extra", which must fail.
+        [System.Security.Cryptography.X509Certificates.X509Certificate2]$Authority
     )
 
-    $body = [System.IO.Path]::GetTempFileName()
+    $script:nameMatched = $false
+    $client = New-Object System.Net.Sockets.TcpClient
     try {
-        $arguments = @('--silent', '--show-error', '--max-time', '20', '--output', $body, '--write-out', '%{http_code}') + $ExtraArguments + @($Url)
-        $status = (& curl @arguments 2>&1 | Out-String).Trim()
-        [pscustomobject]@{ ExitCode = $LASTEXITCODE; Status = $status }
+        $client.ReceiveTimeout = 20000
+        $client.SendTimeout = 20000
+        $client.Connect($TargetHost, $Port)
+
+        $validation = [System.Net.Security.RemoteCertificateValidationCallback] {
+            param($senderObject, $certificate, $chain, $sslPolicyErrors)
+
+            # A hostname mismatch is a failure of the SAN, not of the chain, so
+            # it is recorded separately instead of folded into one bit.
+            $script:nameMatched = -not $sslPolicyErrors.HasFlag([System.Net.Security.SslPolicyErrors]::RemoteCertificateNameMismatch)
+
+            if (-not $Authority) { return $false }
+
+            $leaf = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 $certificate
+            $verifier = New-Object System.Security.Cryptography.X509Certificates.X509Chain
+            $verifier.ChainPolicy.RevocationMode = [System.Security.Cryptography.X509Certificates.X509RevocationMode]::NoCheck
+            # The authority is offered as an extra root, and the chain that gets
+            # built is then required to actually end at it. Allowing an unknown
+            # CA without checking where the chain landed would trust anything.
+            $verifier.ChainPolicy.VerificationFlags = [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::AllowUnknownCertificateAuthority
+            $verifier.ChainPolicy.ExtraStore.Add($Authority) | Out-Null
+            if (-not $verifier.Build($leaf)) { return $false }
+            $root = $verifier.ChainElements[$verifier.ChainElements.Count - 1].Certificate
+            return $root.Thumbprint -eq $Authority.Thumbprint
+        }
+
+        $ssl = New-Object System.Net.Security.SslStream $client.GetStream(), $false, $validation
+        try {
+            $ssl.AuthenticateAsClient($TargetHost, $null, [System.Security.Authentication.SslProtocols]::Tls12, $false)
+            $request = "GET $Path HTTP/1.1`r`nHost: ${TargetHost}:${Port}`r`nConnection: close`r`nAccept: */*`r`n`r`n"
+            $bytes = [System.Text.Encoding]::ASCII.GetBytes($request)
+            $ssl.Write($bytes, 0, $bytes.Length)
+            $ssl.Flush()
+            $reader = New-Object System.IO.StreamReader $ssl
+            $statusLine = $reader.ReadLine()
+            [pscustomobject]@{
+                Handshake = 'verified'
+                NameMatched = $script:nameMatched
+                Status = ($statusLine -split ' ')[1]
+            }
+        } finally {
+            $ssl.Dispose()
+        }
+    } catch {
+        [pscustomobject]@{
+            Handshake = 'refused'
+            NameMatched = $script:nameMatched
+            Status = $null
+            Reason = $_.Exception.Message
+        }
     } finally {
-        Remove-Item -LiteralPath $body -Force -ErrorAction SilentlyContinue
+        $client.Close()
     }
 }
 
 # The authority, not the leaf. Trusting the served certificate would prove only
-# that the ingress serves something; trusting the CA proves the leaf was issued
+# that the ingress serves something; pinning the CA proves the leaf was issued
 # from the authority this cluster created.
 $encodedCa = & $kubectl get secret projecty-local-ca --namespace cert-manager -o jsonpath='{.data.ca\.crt}'
 if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($encodedCa)) {
     throw 'Could not read the local certificate authority.'
 }
-$caFile = Join-Path ([System.IO.Path]::GetTempPath()) "projecty-local-ca-$PID.crt"
-[System.IO.File]::WriteAllBytes($caFile, [System.Convert]::FromBase64String($encodedCa))
-$emptyAuthority = Join-Path ([System.IO.Path]::GetTempPath()) "projecty-empty-authority-$PID.crt"
-Set-Content -LiteralPath $emptyAuthority -Value '' -NoNewline
+$authority = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 (, [System.Convert]::FromBase64String($encodedCa))
 
 try {
     if ($UseFixtureBackends) {
+        # A previous run tears the fixtures down without waiting, so a rerun can
+        # find a pod still terminating. `apply` then reports it unchanged and
+        # `wait` is satisfied by the dying pod, which serves nothing -- a 503
+        # that looks like a wiring bug. Delete and wait for it to be gone first.
+        $fixtures | & $kubectl delete -f - --ignore-not-found --wait --timeout=90s | Out-Null
+
         $fixtures | & $kubectl apply -f - | Out-Null
         if ($LASTEXITCODE -ne 0) { throw 'Could not create the TLS edge fixtures.' }
         & $kubectl wait --namespace projecty --for=condition=Ready pod/console-tls-fixture pod/api-gateway-tls-fixture --timeout=120s | Out-Null
         if ($LASTEXITCODE -ne 0) { throw 'The TLS edge fixtures did not become ready.' }
+
+        # A ready pod is not a reloaded ingress. The controller has to observe
+        # the new EndpointSlice and reload before it stops answering 503, and
+        # nothing in `kubectl wait` covers that -- so the edge is polled until
+        # it converges, and only then does the run start asserting.
+        $converged = $false
+        for ($attempt = 1; $attempt -le 30; $attempt++) {
+            $probe = Invoke-TlsRequest -TargetHost $HttpsHost -Port $HttpsPort -Path '/' -Authority $authority
+            if ($probe.Handshake -eq 'verified' -and $probe.Status -eq '200') {
+                $converged = $true
+                break
+            }
+            Start-Sleep -Seconds 2
+        }
+        if (-not $converged) { throw 'The ingress did not start serving the TLS edge fixtures.' }
     }
 
-    # No --insecure and no --resolve override: the SAN has to actually cover
-    # what a visitor types, and the chain has to reach the local authority.
-    $console = Invoke-Probe -Url "$HttpsBase/" -ExtraArguments @('--cacert', $caFile)
-    if ($console.ExitCode -ne 0) { throw "The console is not reachable over TLS: curl exited $($console.ExitCode)." }
+    $console = Invoke-TlsRequest -TargetHost $HttpsHost -Port $HttpsPort -Path '/' -Authority $authority
+    if ($console.Handshake -ne 'verified') { throw "The console certificate did not verify: $($console.Reason)" }
+    if (-not $console.NameMatched) { throw "The certificate does not cover $HttpsHost." }
     if ($console.Status -ne '200') { throw "The console answered $($console.Status) over TLS." }
 
-    $gateway = Invoke-Probe -Url "$HttpsBase/health/ready" -ExtraArguments @('--cacert', $caFile)
-    if ($gateway.ExitCode -ne 0) { throw "The gateway is not reachable over TLS: curl exited $($gateway.ExitCode)." }
+    $gateway = Invoke-TlsRequest -TargetHost $HttpsHost -Port $HttpsPort -Path '/health/ready' -Authority $authority
+    if ($gateway.Handshake -ne 'verified') { throw "The gateway certificate did not verify: $($gateway.Reason)" }
     if ($gateway.Status -ne '200') { throw "The gateway readiness endpoint answered $($gateway.Status) over TLS." }
 
-    # An untrusted client must fail. If it succeeded, the two probes above would
-    # have proven nothing about the chain.
-    $untrusted = Invoke-Probe -Url "$HttpsBase/" -ExtraArguments @('--cacert', $emptyAuthority)
-    if ($untrusted.ExitCode -eq 0) { throw 'The ingress certificate verified against an empty authority.' }
+    # A client trusting nothing extra must fail. If it succeeded, the two probes
+    # above would have proven nothing about the chain.
+    $untrusted = Invoke-TlsRequest -TargetHost $HttpsHost -Port $HttpsPort -Path '/' -Authority $null
+    if ($untrusted.Handshake -eq 'verified') { throw 'The ingress certificate verified with no authority at all.' }
 
     # The redirect is what replaced UseHttpsRedirection, so it is verified where
     # it now lives instead of being trusted to an annotation.
-    $redirect = Invoke-Probe -Url "$HttpBase/"
-    if ($redirect.Status -notin @('301', '308')) {
-        throw "Plain HTTP answered $($redirect.Status) instead of redirecting to TLS."
+    $plain = [System.Net.HttpWebRequest]::Create("http://${HttpsHost}:${HttpPort}/")
+    $plain.AllowAutoRedirect = $false
+    $plain.Timeout = 20000
+    try {
+        $response = $plain.GetResponse()
+        $redirectStatus = [int]$response.StatusCode
+        $response.Close()
+    } catch [System.Net.WebException] {
+        if (-not $_.Exception.Response) { throw }
+        $redirectStatus = [int]$_.Exception.Response.StatusCode
+    }
+    if ($redirectStatus -notin @(301, 308)) {
+        throw "Plain HTTP answered $redirectStatus instead of redirecting to TLS."
     }
 
     [ordered]@{
         observedAt = [DateTimeOffset]::UtcNow.ToString('o')
-        authority = 'cert-manager/projecty-local-ca'
+        authority = "cert-manager/projecty-local-ca $($authority.Thumbprint)"
         backends = if ($UseFixtureBackends) { 'busybox fixtures standing in for console and gateway' } else { 'the running console and gateway' }
-        console = "$HttpsBase/ verified against the local authority, 200"
-        gateway = "$HttpsBase/health/ready verified against the local authority, 200"
+        console = "https://${HttpsHost}:${HttpsPort}/ chained to the local authority, name matched, 200"
+        gateway = "https://${HttpsHost}:${HttpsPort}/health/ready chained to the local authority, 200"
         untrustedClient = 'rejected'
-        plainHttp = "$($redirect.Status) redirect to TLS"
+        plainHttp = "$redirectStatus redirect to TLS"
     } | ConvertTo-Json
 } finally {
     if ($UseFixtureBackends) {
         $fixtures | & $kubectl delete -f - --ignore-not-found --wait=false | Out-Null
     }
-    Remove-Item -LiteralPath $caFile, $emptyAuthority -Force -ErrorAction SilentlyContinue
 }

--- a/scripts/Test-IngressTls.ps1
+++ b/scripts/Test-IngressTls.ps1
@@ -166,19 +166,25 @@ try {
         if ($LASTEXITCODE -ne 0) { throw 'The TLS edge fixtures did not become ready.' }
 
         # A ready pod is not a reloaded ingress. The controller has to observe
-        # the new EndpointSlice and reload before it stops answering 503, and
+        # each new EndpointSlice and reload before it stops answering 503, and
         # nothing in `kubectl wait` covers that -- so the edge is polled until
         # it converges, and only then does the run start asserting.
-        $converged = $false
-        for ($attempt = 1; $attempt -le 30; $attempt++) {
-            $probe = Invoke-TlsRequest -TargetHost $HttpsHost -Port $HttpsPort -Path '/' -Authority $authority
-            if ($probe.Handshake -eq 'verified' -and $probe.Status -eq '200') {
-                $converged = $true
-                break
-            }
-            Start-Sleep -Seconds 2
+        #
+        # Both paths, not just the first: the two fixtures land in the
+        # controller's view independently, so waiting only on `/` left
+        # `/health/ready` still answering 503 when the assertions began.
+        $paths = @('/', '/health/ready')
+        $pending = $paths
+        for ($attempt = 1; $attempt -le 30 -and $pending.Count -gt 0; $attempt++) {
+            if ($attempt -gt 1) { Start-Sleep -Seconds 2 }
+            $pending = @($pending | Where-Object {
+                $probe = Invoke-TlsRequest -TargetHost $HttpsHost -Port $HttpsPort -Path $_ -Authority $authority
+                -not ($probe.Handshake -eq 'verified' -and $probe.Status -eq '200')
+            })
         }
-        if (-not $converged) { throw 'The ingress did not start serving the TLS edge fixtures.' }
+        if ($pending.Count -gt 0) {
+            throw "The ingress did not start serving the TLS edge fixtures at: $($pending -join ', ')"
+        }
     }
 
     $console = Invoke-TlsRequest -TargetHost $HttpsHost -Port $HttpsPort -Path '/' -Authority $authority

--- a/scripts/Test-IngressTls.ps1
+++ b/scripts/Test-IngressTls.ps1
@@ -1,0 +1,147 @@
+[CmdletBinding()]
+param(
+    [string]$HttpsBase = 'https://localhost:8443',
+    [string]$HttpBase = 'http://localhost:8080',
+    # CI has no application images in the cluster, so it stands two busybox
+    # listeners in for the console and the gateway -- the same fixture pattern
+    # the NetworkPolicy acceptance uses. What is proven is the edge: the chain,
+    # the SAN, the redirect and the refusal of an untrusted client. Run without
+    # this switch under `tilt up` to prove the real console and gateway answer.
+    [switch]$UseFixtureBackends
+)
+
+$ErrorActionPreference = 'Stop'
+$tools = & (Join-Path $PSScriptRoot 'kind\Install-ProjectYKubernetesTools.ps1')
+$kubectl = $tools.Kubectl
+
+if (-not (Get-Command curl -ErrorAction SilentlyContinue) -and -not (Get-Command curl.exe -ErrorAction SilentlyContinue)) {
+    throw 'curl is required to verify the certificate chain against an explicit authority.'
+}
+
+$fixtures = @"
+apiVersion: v1
+kind: Service
+metadata: {name: console, namespace: projecty}
+spec:
+  selector: {app.kubernetes.io/name: console}
+  ports: [{name: http, port: 3001, targetPort: 3001}]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: console-tls-fixture
+  namespace: projecty
+  labels: {app.kubernetes.io/name: console, projecty.io/tier: edge}
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext: {runAsNonRoot: true, runAsUser: 65532, seccompProfile: {type: RuntimeDefault}}
+  volumes: [{name: root, emptyDir: {}}]
+  containers:
+    - name: listener
+      image: busybox:1.37.0
+      command: [sh, -c, 'echo ok > /www/index.html && httpd -f -p 3001 -h /www']
+      volumeMounts: [{name: root, mountPath: /www}]
+      securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}, readOnlyRootFilesystem: true}
+      resources: {requests: {cpu: 5m, memory: 8Mi}, limits: {cpu: 50m, memory: 32Mi}}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: api-gateway, namespace: projecty}
+spec:
+  selector: {app.kubernetes.io/name: api-gateway}
+  ports: [{name: http, port: 8090, targetPort: 8090}]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: api-gateway-tls-fixture
+  namespace: projecty
+  labels: {app.kubernetes.io/name: api-gateway, projecty.io/tier: edge}
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext: {runAsNonRoot: true, runAsUser: 65532, seccompProfile: {type: RuntimeDefault}}
+  volumes: [{name: root, emptyDir: {}}]
+  containers:
+    - name: listener
+      image: busybox:1.37.0
+      command: [sh, -c, 'mkdir -p /www/health && echo ok > /www/health/ready && httpd -f -p 8090 -h /www']
+      volumeMounts: [{name: root, mountPath: /www}]
+      securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}, readOnlyRootFilesystem: true}
+      resources: {requests: {cpu: 5m, memory: 8Mi}, limits: {cpu: 50m, memory: 32Mi}}
+"@
+
+function Invoke-Probe {
+    param(
+        [Parameter(Mandatory)] [string]$Url,
+        [string[]]$ExtraArguments = @()
+    )
+
+    $body = [System.IO.Path]::GetTempFileName()
+    try {
+        $arguments = @('--silent', '--show-error', '--max-time', '20', '--output', $body, '--write-out', '%{http_code}') + $ExtraArguments + @($Url)
+        $status = (& curl @arguments 2>&1 | Out-String).Trim()
+        [pscustomobject]@{ ExitCode = $LASTEXITCODE; Status = $status }
+    } finally {
+        Remove-Item -LiteralPath $body -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# The authority, not the leaf. Trusting the served certificate would prove only
+# that the ingress serves something; trusting the CA proves the leaf was issued
+# from the authority this cluster created.
+$encodedCa = & $kubectl get secret projecty-local-ca --namespace cert-manager -o jsonpath='{.data.ca\.crt}'
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($encodedCa)) {
+    throw 'Could not read the local certificate authority.'
+}
+$caFile = Join-Path ([System.IO.Path]::GetTempPath()) "projecty-local-ca-$PID.crt"
+[System.IO.File]::WriteAllBytes($caFile, [System.Convert]::FromBase64String($encodedCa))
+$emptyAuthority = Join-Path ([System.IO.Path]::GetTempPath()) "projecty-empty-authority-$PID.crt"
+Set-Content -LiteralPath $emptyAuthority -Value '' -NoNewline
+
+try {
+    if ($UseFixtureBackends) {
+        $fixtures | & $kubectl apply -f - | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw 'Could not create the TLS edge fixtures.' }
+        & $kubectl wait --namespace projecty --for=condition=Ready pod/console-tls-fixture pod/api-gateway-tls-fixture --timeout=120s | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw 'The TLS edge fixtures did not become ready.' }
+    }
+
+    # No --insecure and no --resolve override: the SAN has to actually cover
+    # what a visitor types, and the chain has to reach the local authority.
+    $console = Invoke-Probe -Url "$HttpsBase/" -ExtraArguments @('--cacert', $caFile)
+    if ($console.ExitCode -ne 0) { throw "The console is not reachable over TLS: curl exited $($console.ExitCode)." }
+    if ($console.Status -ne '200') { throw "The console answered $($console.Status) over TLS." }
+
+    $gateway = Invoke-Probe -Url "$HttpsBase/health/ready" -ExtraArguments @('--cacert', $caFile)
+    if ($gateway.ExitCode -ne 0) { throw "The gateway is not reachable over TLS: curl exited $($gateway.ExitCode)." }
+    if ($gateway.Status -ne '200') { throw "The gateway readiness endpoint answered $($gateway.Status) over TLS." }
+
+    # An untrusted client must fail. If it succeeded, the two probes above would
+    # have proven nothing about the chain.
+    $untrusted = Invoke-Probe -Url "$HttpsBase/" -ExtraArguments @('--cacert', $emptyAuthority)
+    if ($untrusted.ExitCode -eq 0) { throw 'The ingress certificate verified against an empty authority.' }
+
+    # The redirect is what replaced UseHttpsRedirection, so it is verified where
+    # it now lives instead of being trusted to an annotation.
+    $redirect = Invoke-Probe -Url "$HttpBase/"
+    if ($redirect.Status -notin @('301', '308')) {
+        throw "Plain HTTP answered $($redirect.Status) instead of redirecting to TLS."
+    }
+
+    [ordered]@{
+        observedAt = [DateTimeOffset]::UtcNow.ToString('o')
+        authority = 'cert-manager/projecty-local-ca'
+        backends = if ($UseFixtureBackends) { 'busybox fixtures standing in for console and gateway' } else { 'the running console and gateway' }
+        console = "$HttpsBase/ verified against the local authority, 200"
+        gateway = "$HttpsBase/health/ready verified against the local authority, 200"
+        untrustedClient = 'rejected'
+        plainHttp = "$($redirect.Status) redirect to TLS"
+    } | ConvertTo-Json
+} finally {
+    if ($UseFixtureBackends) {
+        $fixtures | & $kubectl delete -f - --ignore-not-found --wait=false | Out-Null
+    }
+    Remove-Item -LiteralPath $caFile, $emptyAuthority -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/Test-KubernetesManifests.ps1
+++ b/scripts/Test-KubernetesManifests.ps1
@@ -46,6 +46,32 @@ try {
         if ($externalSecrets.Count -ne 9) { throw "$overlay renders $($externalSecrets.Count) ExternalSecrets; expected 9." }
         if ($rendered -match 'secretRef:\s*\{name:\s*projecty-runtime\}') { throw "$overlay still uses the former shared runtime Secret." }
         if ($rendered -notmatch 'pod-security\.kubernetes\.io/enforce:\s+restricted') { throw "$overlay does not enforce restricted Pod Security." }
+
+        # A4: the edge is the only place that terminates TLS, and each overlay
+        # has to terminate it in its own way -- cert-manager fills a Secret on
+        # kind, ACM sits in front of the load balancer on AWS. An overlay that
+        # carries neither is serving the stack in clear.
+        $ingress = @($documents | Where-Object { $_ -match '(?m)^kind:\s+Ingress\s*$' })
+        if ($ingress.Count -ne 1) { throw "$overlay renders $($ingress.Count) Ingress objects; expected 1." }
+        if ($overlay -eq 'selfhost') {
+            if ($ingress[0] -notmatch '(?ms)^\s+tls:\s*\n\s+-\s+secretName:\s+projecty-tls\s*$') {
+                throw 'selfhost does not terminate TLS with the cert-manager issued secret.'
+            }
+            if ($ingress[0] -notmatch 'nginx\.ingress\.kubernetes\.io/force-ssl-redirect:\s*"true"') {
+                throw 'selfhost does not redirect plain HTTP to TLS at the ingress.'
+            }
+        }
+        if ($overlay -eq 'aws') {
+            if ($ingress[0] -match '(?m)^\s+tls:\s*$') {
+                throw 'aws carries an in-cluster TLS secret; ACM terminates in front of the load balancer.'
+            }
+            if ($ingress[0] -notmatch 'alb\.ingress\.kubernetes\.io/certificate-arn:') {
+                throw 'aws does not name a certificate at the load balancer.'
+            }
+            if ($ingress[0] -match 'nginx\.ingress\.kubernetes\.io/') {
+                throw 'aws mixes nginx annotations into an ALB Ingress.'
+            }
+        }
         if ($overlay -eq 'selfhost' -and $rendered -notmatch '(?ms)^kind:\s+SecretStore.*?provider:\s*\n\s+kubernetes:') {
             throw 'selfhost does not use the Kubernetes External Secrets provider.'
         }

--- a/scripts/Test-KubernetesManifests.ps1
+++ b/scripts/Test-KubernetesManifests.ps1
@@ -53,18 +53,27 @@ try {
         # carries neither is serving the stack in clear.
         $ingress = @($documents | Where-Object { $_ -match '(?m)^kind:\s+Ingress\s*$' })
         if ($ingress.Count -ne 1) { throw "$overlay renders $($ingress.Count) Ingress objects; expected 1." }
+        # A `tls` block without hosts is ignored by ingress-nginx, and the
+        # hostnames cannot be shared between overlays -- so neither overlay is
+        # allowed to declare one. Each environment names its certificate in its
+        # own platform layer instead, and this asserts both halves.
+        if ($ingress[0] -match '(?m)^\s+tls:\s*$') {
+            throw "$overlay declares a tls block; a hostless one is ignored and a hosted one is not portable."
+        }
         if ($overlay -eq 'selfhost') {
-            if ($ingress[0] -notmatch '(?ms)^\s+tls:\s*\n\s+-\s+secretName:\s+projecty-tls\s*$') {
-                throw 'selfhost does not terminate TLS with the cert-manager issued secret.'
-            }
             if ($ingress[0] -notmatch 'nginx\.ingress\.kubernetes\.io/force-ssl-redirect:\s*"true"') {
                 throw 'selfhost does not redirect plain HTTP to TLS at the ingress.'
             }
+            $authority = (& $kubectl kustomize 'deploy/platform/cert-manager') -join "`n"
+            if ($LASTEXITCODE -ne 0) { throw 'Kustomize failed for the local certificate authority.' }
+            if ($authority -notmatch '(?m)^\s+secretName:\s+projecty-tls\s*$') {
+                throw 'The local authority does not issue the projecty-tls serving certificate.'
+            }
+            if ($authority -notmatch '(?m)^\s+isCA:\s+true\s*$') {
+                throw 'The local authority does not issue from a CA of its own.'
+            }
         }
         if ($overlay -eq 'aws') {
-            if ($ingress[0] -match '(?m)^\s+tls:\s*$') {
-                throw 'aws carries an in-cluster TLS secret; ACM terminates in front of the load balancer.'
-            }
             if ($ingress[0] -notmatch 'alb\.ingress\.kubernetes\.io/certificate-arn:') {
                 throw 'aws does not name a certificate at the load balancer.'
             }

--- a/scripts/Test-KubernetesSecurity.ps1
+++ b/scripts/Test-KubernetesSecurity.ps1
@@ -100,11 +100,34 @@ spec:
       securityContext: {runAsUser: 0, allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
 "@
 
+# These probes are meant to be rejected, and a rejection arrives on stderr.
+#
+# On Windows PowerShell 5.1, redirecting a native command's stderr wraps every
+# line in a NativeCommandError, and with $ErrorActionPreference = 'Stop' that
+# terminates the script before the exit code can be read -- so the expected
+# rejection killed the run instead of satisfying it. CI never saw this, because
+# CI runs pwsh 7 on Linux.
+function Invoke-Rejection {
+    param([Parameter(Mandatory)] [scriptblock]$Probe)
+
+    $previous = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $output = & $Probe 2>&1
+        [pscustomobject]@{
+            ExitCode = $LASTEXITCODE
+            Text = (@($output | ForEach-Object { $_.ToString() })) -join "`n"
+        }
+    } finally {
+        $ErrorActionPreference = $previous
+    }
+}
+
 try {
-    $rootResult = $rootPod | & $kubectl apply --server-side --dry-run=server -f - 2>&1
-    if ($LASTEXITCODE -eq 0) { throw 'Pod Security admitted a container explicitly running as root.' }
-    if (($rootResult -join "`n") -notmatch 'PodSecurity|runAsUser|non-root') {
-        throw "The root probe failed for an unrelated reason: $($rootResult -join ' ')"
+    $root = Invoke-Rejection -Probe { $rootPod | & $kubectl apply --server-side --dry-run=server -f - }
+    if ($root.ExitCode -eq 0) { throw 'Pod Security admitted a container explicitly running as root.' }
+    if ($root.Text -notmatch 'PodSecurity|runAsUser|non-root') {
+        throw "The root probe failed for an unrelated reason: $($root.Text)"
     }
 
     $fixtures | & $kubectl apply -f - | Out-Null
@@ -120,8 +143,8 @@ try {
     & $kubectl exec --namespace projecty $probeName -- nc -z -w 5 cockroachdb 26257 | Out-Null
     if ($LASTEXITCODE -ne 0) { throw 'Identity could not reach its owned CockroachDB dependency.' }
 
-    & $kubectl exec --namespace projecty $probeName -- nc -z -w 5 rabbitmq 5672 2>$null | Out-Null
-    if ($LASTEXITCODE -eq 0) { throw 'Identity unexpectedly reached Rental Core owned RabbitMQ.' }
+    $foreign = Invoke-Rejection -Probe { & $kubectl exec --namespace projecty $probeName -- nc -z -w 5 rabbitmq 5672 }
+    if ($foreign.ExitCode -eq 0) { throw 'Identity unexpectedly reached Rental Core owned RabbitMQ.' }
 
     [ordered]@{
         podSecurityRestricted = 'root pod rejected'

--- a/scripts/kind/Ensure-ProjectYCluster.ps1
+++ b/scripts/kind/Ensure-ProjectYCluster.ps1
@@ -11,6 +11,33 @@ $context = "kind-$clusterName"
 $registryName = 'projecty-registry'
 $registryPort = 5001
 
+# Probes that are allowed to fail cannot redirect a native command's stderr.
+#
+# On Windows PowerShell 5.1, `docker inspect ... 2>$null` wraps every stderr
+# line in a NativeCommandError, and with $ErrorActionPreference = 'Stop' that
+# terminates the script. So the first `tilt up` on a clean Windows machine --
+# the platform the runbook names first -- died on "no such object:
+# projecty-registry", which is the expected answer to "does the registry exist".
+# CI never saw it, because CI runs pwsh 7 on Linux.
+function Invoke-Probe {
+    param(
+        [Parameter(Mandatory)] [string]$FilePath,
+        [string[]]$Arguments = @()
+    )
+
+    $previous = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $output = & $FilePath @Arguments 2>&1
+    } finally {
+        $ErrorActionPreference = $previous
+    }
+    [pscustomobject]@{
+        ExitCode = $LASTEXITCODE
+        Lines = @($output | ForEach-Object { $_.ToString() })
+    }
+}
+
 if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
     throw 'Docker is required for the local kind cluster. Start Docker Desktop and retry `tilt up`.'
 }
@@ -18,21 +45,22 @@ if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
 & docker info --format '{{.ServerVersion}}' | Out-Null
 if ($LASTEXITCODE -ne 0) { throw 'Docker is installed but its engine is not reachable.' }
 
-$registryExists = (& docker inspect -f '{{.State.Running}}' $registryName 2>$null) -eq 'true'
-if (-not $registryExists) {
-    & docker rm -f $registryName 2>$null | Out-Null
+$registryState = Invoke-Probe -FilePath 'docker' -Arguments @('inspect', '-f', '{{.State.Running}}', $registryName)
+if ($registryState.ExitCode -ne 0 -or ($registryState.Lines -join '').Trim() -ne 'true') {
+    Invoke-Probe -FilePath 'docker' -Arguments @('rm', '-f', $registryName) | Out-Null
     & docker run --detach --restart=always --name $registryName --publish "127.0.0.1:${registryPort}:5000" registry:3.0.0 | Out-Null
     if ($LASTEXITCODE -ne 0) { throw 'Could not start the ProjectY local registry.' }
 }
 
-$clusters = @(& $kind get clusters 2>$null)
-if ($clusters -notcontains $clusterName) {
+$clusters = Invoke-Probe -FilePath $kind -Arguments @('get', 'clusters')
+if ($clusters.Lines -notcontains $clusterName) {
     & $kind create cluster --name $clusterName --config (Join-Path $root 'deploy\kind\cluster.yaml')
     if ($LASTEXITCODE -ne 0) { throw 'Could not create the ProjectY kind cluster.' }
 }
 
-$network = & docker inspect -f '{{json .NetworkSettings.Networks.kind}}' $registryName 2>$null
-if (-not $network -or $network -eq '<no value>') {
+$networkProbe = Invoke-Probe -FilePath 'docker' -Arguments @('inspect', '-f', '{{json .NetworkSettings.Networks.kind}}', $registryName)
+$network = ($networkProbe.Lines -join '').Trim()
+if ($networkProbe.ExitCode -ne 0 -or -not $network -or $network -eq '<no value>' -or $network -eq 'null') {
     & docker network connect kind $registryName
     if ($LASTEXITCODE -ne 0) { throw 'Could not attach the local registry to the kind network.' }
 }

--- a/scripts/kind/Install-CertManager.ps1
+++ b/scripts/kind/Install-CertManager.ps1
@@ -44,7 +44,9 @@ if ($LASTEXITCODE -ne 0) { throw 'The ingress serving certificate did not become
 $flag = '--default-ssl-certificate=projecty/projecty-tls'
 $current = & $kubectl get deployment ingress-nginx-controller --namespace ingress-nginx -o jsonpath='{.spec.template.spec.containers[0].args}'
 if ($LASTEXITCODE -ne 0) { throw 'Could not read the ingress controller arguments.' }
+$patched = $false
 if ($current -notlike "*default-ssl-certificate*") {
+    $patched = $true
     # Through a file, not through -p: a JSON patch on the command line loses its
     # quoting on the way to a native executable on Windows, and kubectl answers
     # with "the request is invalid" that names nothing.
@@ -65,11 +67,71 @@ if ($current -notlike "*default-ssl-certificate*") {
     }
 }
 
-# The Secret already exists at this point, so the restart comes up serving it
-# instead of the controller's own self-signed placeholder.
-& $kubectl rollout restart deployment/ingress-nginx-controller --namespace ingress-nginx | Out-Null
-if ($LASTEXITCODE -ne 0) { throw 'Could not restart the ingress controller.' }
+# Patching the args already rolls the Deployment, so a restart on top of it
+# would take the controller down twice. The explicit restart is only for the
+# already-patched case, where the Secret may have been reissued under a
+# controller that has been running since before it existed.
+if (-not $patched) {
+    & $kubectl rollout restart deployment/ingress-nginx-controller --namespace ingress-nginx | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw 'Could not restart the ingress controller.' }
+}
 & $kubectl rollout status deployment/ingress-nginx-controller --namespace ingress-nginx --timeout=240s
 if ($LASTEXITCODE -ne 0) { throw 'The ingress controller did not come back after the restart.' }
+
+# Rolling the controller takes its admission webhook down with it, and
+# `rollout status` returning is not permission to create an Ingress: the
+# readiness probe answers on /healthz:10254 while the webhook listens on 8443,
+# so there is a window where the pod is Ready and the webhook refuses the
+# connection. Whatever applied an Ingress next got "connection refused" from
+# validate.nginx.ingress.kubernetes.io and never created it.
+#
+# Pod readiness therefore cannot be the signal -- the only honest check is to
+# put a request through the webhook. A server-side dry run does exactly that
+# and persists nothing. Same shape as the Kyverno startup race already handled
+# in Install-Kyverno.ps1, and the wait lives with the component that caused the
+# outage instead of with every caller.
+# The canary needs a host and a path of its own. nginx rejects a second Ingress
+# that claims a host and path another one already has, so a canary on `/` is
+# admitted on a fresh cluster and denied on every later run -- the webhook
+# answering, read as the webhook being down.
+$canary = @"
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata: {name: projecty-admission-canary, namespace: ingress-nginx}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: projecty-admission-canary.invalid
+      http:
+        paths:
+          - path: /projecty-admission-canary
+            pathType: Prefix
+            backend:
+              service: {name: projecty-admission-canary, port: {number: 80}}
+"@
+
+$admits = $false
+for ($attempt = 1; $attempt -le 60; $attempt++) {
+    # The dry run is expected to fail while the webhook is down, and a native
+    # command's stderr terminates the script under Windows PowerShell 5.1, so
+    # the preference is relaxed around it.
+    $previous = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $answer = ($canary | & $kubectl apply --dry-run=server -f - 2>&1 | Out-String)
+        $exitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previous
+    }
+    # Any answer proves the webhook is serving, including a denial. Only a
+    # failure to reach it is worth another attempt -- that is the distinction
+    # the first version of this wait did not make.
+    if ($exitCode -eq 0 -or $answer -notmatch 'failed calling webhook|connection refused|no endpoints available') {
+        $admits = $true
+        break
+    }
+    Start-Sleep -Seconds 2
+}
+if (-not $admits) { throw 'The ingress admission webhook did not start answering.' }
 
 Write-Host "cert-manager $chartVersion ready; the ingress serves projecty-tls from the local authority."

--- a/scripts/kind/Install-CertManager.ps1
+++ b/scripts/kind/Install-CertManager.ps1
@@ -36,4 +36,40 @@ if ($LASTEXITCODE -ne 0) { throw 'The local certificate authority did not become
 & $kubectl wait --namespace projecty --for=condition=Ready certificate/projecty-tls --timeout=180s
 if ($LASTEXITCODE -ne 0) { throw 'The ingress serving certificate did not become ready.' }
 
-Write-Host "cert-manager $chartVersion ready; projecty-tls issued by the local authority."
+# The Ingress carries no `tls` block, because one without hosts is ignored and
+# the hostnames are not shareable with the AWS overlay. So the certificate is
+# named here, on the controller: --default-ssl-certificate makes projecty-tls
+# the certificate served for every request that reaches this cluster's edge.
+# It is the local counterpart of the ACM annotation. See ADR 0025.
+$flag = '--default-ssl-certificate=projecty/projecty-tls'
+$current = & $kubectl get deployment ingress-nginx-controller --namespace ingress-nginx -o jsonpath='{.spec.template.spec.containers[0].args}'
+if ($LASTEXITCODE -ne 0) { throw 'Could not read the ingress controller arguments.' }
+if ($current -notlike "*default-ssl-certificate*") {
+    # Through a file, not through -p: a JSON patch on the command line loses its
+    # quoting on the way to a native executable on Windows, and kubectl answers
+    # with "the request is invalid" that names nothing.
+    $patchFile = Join-Path ([System.IO.Path]::GetTempPath()) "projecty-ingress-patch-$PID.json"
+    $patch = @(
+        [ordered]@{
+            op = 'add'
+            path = '/spec/template/spec/containers/0/args/-'
+            value = $flag
+        }
+    )
+    try {
+        Set-Content -LiteralPath $patchFile -Value (ConvertTo-Json -InputObject $patch -Depth 5) -Encoding utf8
+        & $kubectl patch deployment ingress-nginx-controller --namespace ingress-nginx --type=json --patch-file $patchFile | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw 'Could not point the ingress controller at the local certificate.' }
+    } finally {
+        Remove-Item -LiteralPath $patchFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# The Secret already exists at this point, so the restart comes up serving it
+# instead of the controller's own self-signed placeholder.
+& $kubectl rollout restart deployment/ingress-nginx-controller --namespace ingress-nginx | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'Could not restart the ingress controller.' }
+& $kubectl rollout status deployment/ingress-nginx-controller --namespace ingress-nginx --timeout=240s
+if ($LASTEXITCODE -ne 0) { throw 'The ingress controller did not come back after the restart.' }
+
+Write-Host "cert-manager $chartVersion ready; the ingress serves projecty-tls from the local authority."

--- a/scripts/kind/Install-CertManager.ps1
+++ b/scripts/kind/Install-CertManager.ps1
@@ -1,0 +1,39 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$tools = & (Join-Path $PSScriptRoot 'Install-ProjectYKubernetesTools.ps1')
+$helm = $tools.Helm
+$kubectl = $tools.Kubectl
+$chartVersion = 'v1.21.1'
+
+& $helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager --version $chartVersion --namespace cert-manager --create-namespace --set crds.enabled=true --wait --timeout 5m
+if ($LASTEXITCODE -ne 0) { throw "Could not install cert-manager $chartVersion." }
+
+foreach ($deployment in @('cert-manager', 'cert-manager-webhook', 'cert-manager-cainjector')) {
+    & $kubectl wait --namespace cert-manager --for=condition=Available "deployment/$deployment" --timeout=240s
+    if ($LASTEXITCODE -ne 0) { throw "$deployment did not become available." }
+}
+
+# The webhook reports Available before it serves; applying an Issuer against a
+# webhook that is not yet answering fails with a connection refused that says
+# nothing about the manifest. Retry instead of failing the first start.
+$authority = Join-Path $root 'deploy\platform\cert-manager'
+$applied = $false
+for ($attempt = 1; $attempt -le 12; $attempt++) {
+    & $kubectl apply -k $authority | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        $applied = $true
+        break
+    }
+    if ($attempt -lt 12) { Start-Sleep -Seconds 5 }
+}
+if (-not $applied) { throw 'Could not apply the ProjectY local certificate authority.' }
+
+& $kubectl wait --namespace cert-manager --for=condition=Ready certificate/projecty-local-ca --timeout=180s
+if ($LASTEXITCODE -ne 0) { throw 'The local certificate authority did not become ready.' }
+& $kubectl wait --namespace projecty --for=condition=Ready certificate/projecty-tls --timeout=180s
+if ($LASTEXITCODE -ne 0) { throw 'The ingress serving certificate did not become ready.' }
+
+Write-Host "cert-manager $chartVersion ready; projecty-tls issued by the local authority."

--- a/services/rental-core/RentalCore/Program.cs
+++ b/services/rental-core/RentalCore/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 using MotoHub.Data;
@@ -76,6 +77,27 @@ builder.Services.AddSingleton(NpgsqlDataSource.Create(connectionString));
 // paths now, so a token minted for either half is accepted by the merged service.
 builder.Services.AddGatewayIdentityAuthentication(builder.Configuration, "projecty.rental-core");
 
+// O esquema original chega em X-Forwarded-Proto, não na requisição.
+//
+// São dois saltos até aqui: o ingress termina TLS e reescreve o cabeçalho, e o
+// gateway repassa os cabeçalhos do cliente que não são hop-by-hop -- inclusive
+// este. Daí ForwardLimit = 2. Com o limite padrão de 1, o valor lido seria o
+// que o gateway viu, e não o que o cliente enviou.
+//
+// KnownNetworks e KnownProxies ficam vazios porque o IP do pod do ingress é
+// dinâmico e não há faixa estável para nomear. Isso significa confiar no
+// cabeçalho de quem alcançar esta porta -- e o que sustenta essa confiança não
+// é o middleware, é a NetworkPolicy: rental-core só aceita ingresso do gateway,
+// e o gateway só aceita do ingress. Se aquela política cair, esta linha passa a
+// aceitar o esquema que o chamador inventar. Ver ADR 0025.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedFor;
+    options.ForwardLimit = 2;
+    options.KnownIPNetworks.Clear();
+    options.KnownProxies.Clear();
+});
+
 builder.Services.AddProblemDetails();
 builder.Services.AddExceptionHandler<RentalCore.Errors.ProblemDetailsExceptionHandler>();
 builder.Services.AddControllers();
@@ -127,20 +149,28 @@ builder.Services.AddScoped<IRentalService, RentalService>();
 
 var app = builder.Build();
 
+// UseHttpsRedirection saiu no #100, e o que entrou no lugar é isto.
+//
+// Sem porta HTTPS conhecida ele não redirecionava nada: registrava um aviso na
+// subida e deixava a requisição passar. Ficava como decoração que se lia como
+// garantia -- e é a metade pior do achado A4, porque uma garantia declarada e
+// não cumprida engana mais do que uma ausente.
+//
+// Quem redireciona agora é o ingress, com force-ssl-redirect, porque é o único
+// ponto que conhece o esquema original. Aqui só se lê o esquema, nunca se
+// redireciona: redirecionar atrás de um proxy que já terminou TLS é como se
+// produzem laços de redirecionamento. Ver ADR 0025.
+//
+// Primeiro middleware da cadeia, de propósito: tudo o que vem depois -- a
+// autenticação, o idempotency, os logs -- deve ver o esquema e o IP do cliente,
+// não os do último salto.
+app.UseForwardedHeaders();
+
 if (SwaggerPolicy.IsEnabled(app.Environment, app.Configuration))
 {
     app.UseSwagger();
     app.UseSwaggerUI();
 }
-
-// UseHttpsRedirection saiu no #100.
-//
-// Sem porta HTTPS conhecida ele não redireciona nada: registra um aviso na
-// subida e deixa a requisição passar. Ficava como decoração que se lia como
-// garantia -- e é a metade pior do achado A4, porque uma garantia declarada e
-// não cumprida engana mais do que uma ausente. Quando o ingress do épico 10
-// terminar TLS, o que entra no lugar é ForwardedHeaders, para o aplicativo ver
-// o esquema original em vez de adivinhá-lo. Ver ADR 0025.
 
 app.UseAuthentication();
 app.UseAuthorization();


### PR DESCRIPTION
Closes #100. A metade do **A4** que precisava de cluster — a outra saiu na #190, e o ingress que ela esperava chegou com o [épico 10](https://github.com/iVega123/ProjectY/issues/11).

## Nenhuma camada de deployment nomeia certificado

O cert-manager emite um root self-signed, a autoridade `projecty-local-ca` a partir dele, e o certificado `projecty-tls` a partir da autoridade.

O `Ingress` do `deploy/base` **não nomeia certificado nenhum** — e essa foi a lição da primeira tentativa deste PR. Eu tinha posto um bloco `tls:` sem `hosts:`, e o ingress-nginx **mapeia SNI para Secret por hostname e ignora em silêncio uma entrada sem host**. O nginx serviu o self-signed dele, a aceitação falhou, e o manifesto continuava se lendo como se TLS estivesse configurado: **o defeito do A4 reproduzido dentro da correção do A4**. E os hostnames não são compartilháveis, porque a mesma base renderiza para a AWS.

Então cada ambiente nomeia o certificado na sua própria camada de plataforma: `--default-ssl-certificate` no controller aqui, anotação do ACM na frente do load balancer lá. O ARN é placeholder de propósito — o valor real é output do Terraform do épico 11 (#83, #84).

A classe muda junto: as anotações do nginx e as do ALB são controllers diferentes, e um Ingress com as duas se lê como se dois fossem esperados. **Essa escolha é do épico 11 e pode ser revertida** — ingress-nginx atrás de um NLB é a outra resposta defensável, e moveria a anotação para o Service do controller.

## O redirecionamento mudou de lugar, não de existência

`force-ssl-redirect` no ingress é o que entra no lugar do `UseHttpsRedirection()` removido na #190 — porque o ingress é o único salto que conhece o esquema original.

Atrás dele, o `rental-core` **lê** `X-Forwarded-Proto` com `UseForwardedHeaders` e nunca redireciona: redirecionar atrás de um proxy que já terminou TLS é como se produzem laços. `ForwardLimit = 2`, porque são dois proxies na frente — o ingress reescreve o cabeçalho, e o gateway repassa os do cliente que não são hop-by-hop, inclusive este.

**O que sustenta a confiança nesse cabeçalho não é o middleware.** `KnownIPNetworks` e `KnownProxies` ficam vazios porque o IP do pod do ingress é dinâmico e não há faixa estável para nomear — então quem alcançar aquela porta tem o esquema aceito. Quem impede isso é a `NetworkPolicy`. Se ela cair, esta linha passa a aceitar o esquema que o chamador inventar. Está escrito no arquivo onde ela é configurada, não em nota de rodapé.

## A verificação não pode passar por acidente

O `Test-IngressTls.ps1` fixa a cadeia na autoridade do próprio cluster: constrói o `X509Chain` com a CA como root extra e **exige que a cadeia termine nela** — permitir CA desconhecida sem checar onde a cadeia caiu confiaria em qualquer coisa. Incompatibilidade de hostname é registrada em separado, para SAN e cadeia falharem por motivos distinguíveis. E depois **exige que um cliente sem autoridade nenhuma seja recusado**: sem esse passo, o primeiro provaria apenas que algo respondeu na 8443.

A validação é em .NET e não via `curl --cacert` — o `curl` do Windows é compilado contra schannel, que só confia no que a máquina já confia e responde 60 para uma autoridade que está deliberadamente fora de qualquer trust store. O runbook mandava usar `curl --cacert`; isso estava errado e saiu.

O `Kubernetes manifests` ganhou guardas por overlay: **nenhum** dos dois pode declarar bloco `tls` (um sem host é ignorado, um com host não é portável), o `selfhost` tem que redirecionar e a autoridade tem que renderizar com `isCA`, e o `aws` tem que nomear certificado no load balancer sem misturar anotação de nginx. O guard `arn:aws` que já existia ficou intacto.

## Três defeitos que só apareceram contra um cluster de verdade

Subi um kind local e rodei a sequência do CI. Além do `tls` sem host, saíram dois defeitos de PowerShell 5.1 — **e um deles é anterior a este PR**:

**`tilt up` não subia numa máquina Windows limpa.** `docker inspect ... 2>$null` empacota o stderr em `NativeCommandError`, que sob `$ErrorActionPreference = 'Stop'` termina o script — ou seja, a resposta *esperada* para "o registry existe?" matava o bootstrap. O mesmo defeito estava nos probes de Pod Security e de NetworkPolicy, **cuja função é justamente serem rejeitados**: o `Test-KubernetesSecurity.ps1` nunca funcionou em Windows PowerShell 5.1, que é a plataforma que o runbook nomeia primeiro. O CI nunca viu porque roda pwsh 7 no Linux.

E um terceiro, meu: `wait --for=condition=Ready` prova o pod, **não o reload do nginx**. O controller precisa observar o EndpointSlice novo antes de parar de responder 503, então o teste agora converge com poll limitado antes de começar a afirmar — no CI isso falharia sempre.

## O que ficou verificado, e onde

Contra um cluster kind real, **em Windows PowerShell 5.1**:

```
authority        : cert-manager/projecty-local-ca 87712C41...
console          : chained to the local authority, name matched, 200
gateway          : /health/ready chained to the local authority, 200
untrustedClient  : rejected
plainHttp        : 308 redirect to TLS
```

E o `Test-KubernetesSecurity.ps1` passa junto: root rejeitado, CockroachDB próprio alcançável, RabbitMQ alheio negado.

**Duas ressalvas honestas:**

1. **O CI prova a borda, não o console de verdade.** O cluster efêmero não tem as imagens da aplicação, então o teste roda com `-UseFixtureBackends` e dois busybox fazem o papel do console e do gateway — mesmo padrão de fixture da aceitação de NetworkPolicy. A afirmação de que o console e o gateway **reais** respondem sob TLS é a execução sem o switch, sob `tilt up`.
2. **O `UseForwardedHeaders` não ganhou teste próprio.** Os testes de integração do serviço dependem de Testcontainers, e escrever um teste que eu não executo seria pior do que dizer que ele não existe.

Uma observação de ambiente, não deste PR: nesta máquina a porta **8080 está ocupada** por outro container seu, e o `deploy/kind/cluster.yaml` fixa 8080/8443. Validei em 18080/18443 e restaurei o arquivo. Se isso incomodar no dia a dia, as portas do ingress virarem configuráveis é um issue próprio.

## Fica registrado

O [ADR 0025](docs/adr/0025-tls-terminates-at-the-ingress.md) ganhou uma seção dizendo o que o implementou — incluindo por que a camada de deployment não nomeia certificado. A decisão em si não foi reescrita. O `AUDITORIA-ARQUITETURA-SEGURANCA.md` passou o A4 de "metade fechada" para fechada, nomeando o que o achado **não** cobre: a confidencialidade entre pods, que segue no #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
